### PR TITLE
feat(hook_manager): add non-blocking try_with_*_hook accessors and reentrancy guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    name: Build (MinGW)
+  env-setup:
+    name: Setup Environment
     runs-on: windows-latest
 
     steps:
@@ -19,10 +19,71 @@ jobs:
         run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: powershell
 
-      - name: Install Ninja and gcovr
-        run: |
-          choco install ninja --yes --force --no-progress
-          pip install gcovr
+      - name: Cache Chocolatey packages
+        uses: actions/cache@v4
+        with:
+          path: C:\ProgramData\chocolatey\lib
+          key: choco-${{ runner.os }}-v2-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            choco-${{ runner.os }}-v2-
+            choco-${{ runner.os }}-
+
+      - name: Install Ninja
+        run: choco install ninja --yes --force --no-progress
+        shell: powershell
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: pip-${{ runner.os }}-v2
+          restore-keys: |
+            pip-${{ runner.os }}-v2-
+            pip-${{ runner.os }}-
+
+      - name: Install gcovr
+        run: pip install gcovr
+        shell: powershell
+
+  build:
+    name: Build (MinGW)
+    runs-on: windows-latest
+    needs: env-setup
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Add pre-installed MinGW to PATH
+        run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: powershell
+
+      - name: Cache Chocolatey packages
+        uses: actions/cache@v4
+        with:
+          path: C:\ProgramData\chocolatey\lib
+          key: choco-${{ runner.os }}-v2-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: |
+            choco-${{ runner.os }}-v2-
+            choco-${{ runner.os }}-
+
+      - name: Install Ninja
+        run: choco install ninja --yes --force --no-progress
+        shell: powershell
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: pip-${{ runner.os }}-v2
+          restore-keys: |
+            pip-${{ runner.os }}-v2-
+            pip-${{ runner.os }}-
+
+      - name: Install gcovr
+        run: pip install gcovr
         shell: powershell
 
       - name: Verify Tools
@@ -88,9 +149,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~\AppData\Local\pip\Cache
-          key: pip-gcovr-${{ runner.os }}-v1
+          key: pip-${{ runner.os }}-v2
           restore-keys: |
-            pip-gcovr-${{ runner.os }}-
+            pip-${{ runner.os }}-v2-
+            pip-${{ runner.os }}-
 
       - name: Install gcovr
         run: pip install gcovr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,50 +5,9 @@ on:
     branches: [main]
 
 jobs:
-  env-setup:
-    name: Setup Environment
+  build-and-test:
+    name: Build, Test & Coverage (MinGW)
     runs-on: windows-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-
-      - name: Add pre-installed MinGW to PATH
-        run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: powershell
-
-      - name: Cache Chocolatey packages
-        uses: actions/cache@v4
-        with:
-          path: C:\ProgramData\chocolatey\lib
-          key: choco-${{ runner.os }}-v2-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: |
-            choco-${{ runner.os }}-v2-
-            choco-${{ runner.os }}-
-
-      - name: Install Ninja
-        run: choco install ninja --yes --force --no-progress
-        shell: powershell
-
-      - name: Cache pip packages
-        uses: actions/cache@v4
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: pip-${{ runner.os }}-v2
-          restore-keys: |
-            pip-${{ runner.os }}-v2-
-            pip-${{ runner.os }}-
-
-      - name: Install gcovr
-        run: pip install gcovr
-        shell: powershell
-
-  build:
-    name: Build (MinGW)
-    runs-on: windows-latest
-    needs: env-setup
 
     steps:
       - name: Checkout code
@@ -102,70 +61,9 @@ jobs:
         run: cmake --build --preset mingw-debug --parallel
         shell: bash
 
-  test:
-    name: Tests (MinGW)
-    runs-on: windows-latest
-    needs: build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-
-      - name: Add pre-installed MinGW to PATH
-        run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: powershell
-
-      - name: Cache CMake build
-        uses: actions/cache@v4
-        with:
-          path: build/mingw-debug
-          key: cmake-build-${{ runner.os }}-v1-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'src/**', 'include/**') }}
-          restore-keys: |
-            cmake-build-${{ runner.os }}-v1-
-            cmake-build-${{ runner.os }}-
-
       - name: Run Tests
         run: ctest --preset mingw-debug
         shell: bash
-
-  coverage:
-    name: Coverage Report (MinGW)
-    runs-on: windows-latest
-    needs: test
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-
-      - name: Add pre-installed MinGW to PATH
-        run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: powershell
-
-      - name: Cache pip packages
-        uses: actions/cache@v4
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: pip-${{ runner.os }}-v2
-          restore-keys: |
-            pip-${{ runner.os }}-v2-
-            pip-${{ runner.os }}-
-
-      - name: Install gcovr
-        run: pip install gcovr
-        shell: powershell
-
-      - name: Cache CMake build
-        uses: actions/cache@v4
-        with:
-          path: build/mingw-debug
-          key: cmake-build-${{ runner.os }}-v1-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'src/**', 'include/**') }}
-          restore-keys: |
-            cmake-build-${{ runner.os }}-v1-
-            cmake-build-${{ runner.os }}-
 
       - name: Generate Coverage Report
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     branches: [main]
 
+  workflow_dispatch:
+
 jobs:
-  build-and-test:
-    name: Build, Test & Coverage (MinGW)
+  build-os:
+    name: Setup MinGW (Build OS)
     runs-on: windows-latest
+    outputs:
+      cache_hit: ${{ steps.cache-mingw.outputs.cache-hit }}
 
     steps:
       - name: Checkout code
@@ -15,21 +19,39 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Add pre-installed MinGW to PATH
-        run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        shell: powershell
-
-      - name: Cache Chocolatey packages
+      - name: Cache MinGW
+        id: cache-mingw
         uses: actions/cache@v4
         with:
-          path: C:\ProgramData\chocolatey\lib
-          key: choco-${{ runner.os }}-v2-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: |
-            choco-${{ runner.os }}-v2-
-            choco-${{ runner.os }}-
+          path: C:\ProgramData\chocolatey\lib\mingw
+          key: ${{ runner.os }}-mingw-13.2.0-v2
+
+      - name: Install MinGW (if not cached)
+        if: steps.cache-mingw.outputs.cache-hit != 'true'
+        run: choco install mingw --version=13.2.0 --yes --force --no-progress
+        shell: powershell
+
+      - name: Add MinGW to PATH
+        run: echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: powershell
 
       - name: Install Ninja
         run: choco install ninja --yes --force --no-progress
+        shell: powershell
+
+  build-test:
+    name: Build, Test & Coverage
+    runs-on: windows-latest
+    needs: build-os
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Add MinGW to PATH
+        run: echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: powershell
 
       - name: Cache pip packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 jobs:
-  test-and-coverage:
-    name: Tests & Coverage (MinGW)
+  build:
+    name: Build (MinGW)
     runs-on: windows-latest
 
     steps:
@@ -27,12 +27,6 @@ jobs:
           restore-keys: |
             choco-ninja-${{ runner.os }}-
 
-      - name: Install Ninja and gcovr
-        run: |
-          choco install ninja --yes --force --no-progress
-          pip install gcovr
-        shell: powershell
-
       - name: Cache pip packages
         uses: actions/cache@v4
         with:
@@ -41,11 +35,17 @@ jobs:
           restore-keys: |
             pip-gcovr-${{ runner.os }}-
 
+      - name: Install Ninja and gcovr
+        run: |
+          choco install ninja --yes --force --no-progress
+          pip install gcovr
+        shell: powershell
+
       - name: Cache CMake build
         uses: actions/cache@v4
         with:
           path: build/mingw-debug
-          key: cmake-build-${{ runner.os }}-v1-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'src/**', 'include/**') }}
+          key: cmake-build-${{ runner.os }}-v1-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'src/**', 'include/**') }}
           restore-keys: |
             cmake-build-${{ runner.os }}-v1-
             cmake-build-${{ runner.os }}-
@@ -66,9 +66,69 @@ jobs:
         run: cmake --build --preset mingw-debug --parallel
         shell: bash
 
+  test:
+    name: Tests (MinGW)
+    runs-on: windows-latest
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Add pre-installed MinGW to PATH
+        run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: powershell
+
+      - name: Cache CMake build
+        uses: actions/cache@v4
+        with:
+          path: build/mingw-debug
+          key: cmake-build-${{ runner.os }}-v1-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'src/**', 'include/**') }}
+          restore-keys: |
+            cmake-build-${{ runner.os }}-v1-
+            cmake-build-${{ runner.os }}-
+
       - name: Run Tests
         run: ctest --preset mingw-debug
         shell: bash
+
+  coverage:
+    name: Coverage Report (MinGW)
+    runs-on: windows-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Add pre-installed MinGW to PATH
+        run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: powershell
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: pip-gcovr-${{ runner.os }}-v1
+          restore-keys: |
+            pip-gcovr-${{ runner.os }}-
+
+      - name: Install gcovr
+        run: pip install gcovr
+        shell: powershell
+
+      - name: Cache CMake build
+        uses: actions/cache@v4
+        with:
+          path: build/mingw-debug
+          key: cmake-build-${{ runner.os }}-v1-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'src/**', 'include/**') }}
+          restore-keys: |
+            cmake-build-${{ runner.os }}-v1-
+            cmake-build-${{ runner.os }}-
 
       - name: Generate Coverage Report
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,36 @@ jobs:
         run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: powershell
 
+      - name: Cache Chocolatey packages
+        uses: actions/cache@v4
+        with:
+          path: C:\ProgramData\chocolatey\lib
+          key: choco-ninja-${{ runner.os }}-v1
+          restore-keys: |
+            choco-ninja-${{ runner.os }}-
+
       - name: Install Ninja and gcovr
         run: |
           choco install ninja --yes --force --no-progress
           pip install gcovr
         shell: powershell
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: pip-gcovr-${{ runner.os }}-v1
+          restore-keys: |
+            pip-gcovr-${{ runner.os }}-
+
+      - name: Cache CMake build
+        uses: actions/cache@v4
+        with:
+          path: build/mingw-debug
+          key: cmake-build-${{ runner.os }}-v1-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'src/**', 'include/**') }}
+          restore-keys: |
+            cmake-build-${{ runner.os }}-v1-
+            cmake-build-${{ runner.os }}-
 
       - name: Verify Tools
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,36 +19,11 @@ jobs:
         run: echo "C:\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         shell: powershell
 
-      - name: Cache Chocolatey packages
-        uses: actions/cache@v4
-        with:
-          path: C:\ProgramData\chocolatey\lib
-          key: choco-ninja-${{ runner.os }}-v1
-          restore-keys: |
-            choco-ninja-${{ runner.os }}-
-
-      - name: Cache pip packages
-        uses: actions/cache@v4
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: pip-gcovr-${{ runner.os }}-v1
-          restore-keys: |
-            pip-gcovr-${{ runner.os }}-
-
       - name: Install Ninja and gcovr
         run: |
           choco install ninja --yes --force --no-progress
           pip install gcovr
         shell: powershell
-
-      - name: Cache CMake build
-        uses: actions/cache@v4
-        with:
-          path: build/mingw-debug
-          key: cmake-build-${{ runner.os }}-v1-${{ hashFiles('CMakeLists.txt', 'CMakePresets.json', 'cmake/**', 'src/**', 'include/**') }}
-          restore-keys: |
-            cmake-build-${{ runner.os }}-v1-
-            cmake-build-${{ runner.os }}-
 
       - name: Verify Tools
         run: |

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -436,14 +436,13 @@ namespace DetourModKit
         [[nodiscard]] auto with_inline_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
-            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_inline_hook() callback. Use try_with_inline_hook() instead.");
+            assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_inline_hook() callback. Use try_with_inline_hook() instead.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-            ++m_callback_reentrancy_guard;
+            ++t_callback_reentrancy_guard;
             struct Guard
             {
-                HookManager *mgr;
-                ~Guard() noexcept { --mgr->m_callback_reentrancy_guard; }
-            } guard{this};
+                ~Guard() noexcept { --t_callback_reentrancy_guard; }
+            } guard{};
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
@@ -455,9 +454,13 @@ namespace DetourModKit
         /**
          * @brief Try-safe access to an InlineHook by its ID using a non-blocking lock.
          * @details Provides a non-blocking alternative to with_inline_hook(). The callback
-         *          is invoked only if the lock is immediately acquired. This prevents
-         *          deadlocks when the callback must call HookManager methods that require
-         *          a unique_lock.
+         *          is invoked only if the lock is immediately acquired via std::try_to_lock.
+         *          Note: try_to_lock only avoids blocking on initial acquisition - it does NOT
+         *          make callbacks safe to re-enter HookManager methods that also acquire the
+         *          same non-recursive mutex (e.g., enable_hook, disable_hook). If a callback
+         *          needs to call those methods, it must release the lock first or perform those
+         *          calls asynchronously to avoid deadlock. See with_inline_hook for the blocking
+         *          analogue.
          * @param hook_id The name of the inline hook.
          * @param fn The callback to invoke with the hook reference.
          * @return std::optional<R> The callback's return value. Returns std::nullopt if either
@@ -467,18 +470,17 @@ namespace DetourModKit
         [[nodiscard]] auto try_with_inline_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
-            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_inline_hook() callback.");
+            assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_inline_hook() callback.");
             std::unique_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
             if (!lock.owns_lock())
             {
                 return std::nullopt;
             }
-            ++m_callback_reentrancy_guard;
+            ++t_callback_reentrancy_guard;
             struct Guard
             {
-                HookManager *mgr;
-                ~Guard() noexcept { --mgr->m_callback_reentrancy_guard; }
-            } guard{this};
+                ~Guard() noexcept { --t_callback_reentrancy_guard; }
+            } guard{};
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
@@ -504,14 +506,13 @@ namespace DetourModKit
         [[nodiscard]] auto with_mid_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
-            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_mid_hook() callback. Use try_with_mid_hook() instead.");
+            assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_mid_hook() callback. Use try_with_mid_hook() instead.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-            ++m_callback_reentrancy_guard;
+            ++t_callback_reentrancy_guard;
             struct Guard
             {
-                HookManager *mgr;
-                ~Guard() noexcept { --mgr->m_callback_reentrancy_guard; }
-            } guard{this};
+                ~Guard() noexcept { --t_callback_reentrancy_guard; }
+            } guard{};
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
@@ -523,9 +524,13 @@ namespace DetourModKit
         /**
          * @brief Try-safe access to a MidHook by its ID using a non-blocking lock.
          * @details Provides a non-blocking alternative to with_mid_hook(). The callback
-         *          is invoked only if the lock is immediately acquired. This prevents
-         *          deadlocks when the callback must call HookManager methods that require
-         *          a unique_lock.
+         *          is invoked only if the lock is immediately acquired via std::try_to_lock.
+         *          Note: try_to_lock only avoids blocking on initial acquisition - it does NOT
+         *          make callbacks safe to re-enter HookManager methods that also acquire the
+         *          same non-recursive mutex (e.g., enable_hook, disable_hook). If a callback
+         *          needs to call those methods, it must release the lock first or perform those
+         *          calls asynchronously to avoid deadlock. See with_mid_hook for the blocking
+         *          analogue.
          * @param hook_id The name of the mid hook.
          * @param fn The callback to invoke with the hook reference.
          * @return std::optional<R> The callback's return value. Returns std::nullopt if either
@@ -535,18 +540,17 @@ namespace DetourModKit
         [[nodiscard]] auto try_with_mid_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
-            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_mid_hook() callback.");
+            assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_mid_hook() callback.");
             std::unique_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
             if (!lock.owns_lock())
             {
                 return std::nullopt;
             }
-            ++m_callback_reentrancy_guard;
+            ++t_callback_reentrancy_guard;
             struct Guard
             {
-                HookManager *mgr;
-                ~Guard() noexcept { --mgr->m_callback_reentrancy_guard; }
-            } guard{this};
+                ~Guard() noexcept { --t_callback_reentrancy_guard; }
+            } guard{};
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
@@ -561,7 +565,7 @@ namespace DetourModKit
         Logger &m_logger;
         std::shared_ptr<safetyhook::Allocator> m_allocator;
         std::atomic<bool> m_shutdown_called{false};
-        std::atomic<int> m_callback_reentrancy_guard{0};
+        thread_local inline static int t_callback_reentrancy_guard{0};
 
         std::string error_to_string(const safetyhook::InlineHook::Error &err) const;
         std::string error_to_string(const safetyhook::MidHook::Error &err) const;

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -11,6 +11,7 @@
 #include <expected>
 #include <string_view>
 #include <type_traits>
+#include <cassert>
 
 #include "safetyhook.hpp"
 #include "DetourModKit/logger.hpp"
@@ -388,14 +389,14 @@ namespace DetourModKit
          * @param hook_id The name of the hook to enable.
          * @return true if the hook was found and successfully enabled, false otherwise.
          */
-        bool enable_hook(const std::string &hook_id);
+        [[nodiscard]] bool enable_hook(const std::string &hook_id);
 
         /**
          * @brief Disables an active hook temporarily without removing it.
          * @param hook_id The name of the hook to disable.
          * @return true if the hook was found and successfully disabled, false otherwise.
          */
-        bool disable_hook(const std::string &hook_id);
+        [[nodiscard]] bool disable_hook(const std::string &hook_id);
 
         /**
          * @brief Retrieves the current status of a hook.
@@ -420,49 +421,137 @@ namespace DetourModKit
         /**
          * @brief Safely accesses an InlineHook by its ID while holding the internal lock.
          * @details The callback is invoked with a reference to the InlineHook while the
-         *          shared_mutex is held, preventing concurrent removal.
-         * @warning Do not call HookManager methods that acquire a unique_lock from
-         *          within the callback — this will deadlock.
+         *          shared_mutex is held as a reader, preventing concurrent removal.
+         * @warning DANGER: Calling any HookManager method that acquires a unique_lock
+         *          (e.g., remove_hook, enable_hook, disable_hook, create_*_hook) from
+         *          within the callback WILL DEADLOCK. If you need to call such methods,
+         *          use try_with_inline_hook() instead.
          * @tparam F Callable type accepting (InlineHook&) and returning a value.
          * @param hook_id The name of the inline hook.
          * @param fn The callback to invoke with the hook reference.
          * @return std::optional<R> The callback's return value, or std::nullopt if hook not found.
          */
         template <typename F>
-        auto with_inline_hook(const std::string &hook_id, F &&fn)
+        [[nodiscard]] auto with_inline_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
+            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_inline_hook() callback. Use try_with_inline_hook() instead.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-            auto it = m_hooks.find(hook_id);
-            if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
+            ++m_callback_reentrancy_guard;
+            auto result = [this, &hook_id, &fn]() -> std::optional<std::invoke_result_t<F, InlineHook &>>
             {
-                return fn(static_cast<InlineHook &>(*it->second));
+                auto it = m_hooks.find(hook_id);
+                if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
+                {
+                    return fn(static_cast<InlineHook &>(*it->second));
+                }
+                return std::nullopt;
+            }();
+            --m_callback_reentrancy_guard;
+            return result;
+        }
+
+        /**
+         * @brief Try-safe access to an InlineHook by its ID using a non-blocking lock.
+         * @details Provides a non-blocking alternative to with_inline_hook(). The callback
+         *          is invoked only if the lock is immediately acquired. This prevents
+         *          deadlocks when the callback must call HookManager methods that require
+         *          a unique_lock.
+         * @param hook_id The name of the inline hook.
+         * @param fn The callback to invoke with the hook reference.
+         * @return std::optional<R> The callback's return value, std::nullopt if hook not
+         *         found, or std::nullopt with error tag if lock could not be acquired.
+         */
+        template <typename F>
+        [[nodiscard]] auto try_with_inline_hook(const std::string &hook_id, F &&fn)
+            -> std::optional<std::invoke_result_t<F, InlineHook &>>
+        {
+            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_inline_hook() callback.");
+            std::unique_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
+            if (!lock.owns_lock())
+            {
+                return std::nullopt;
             }
-            return std::nullopt;
+            ++m_callback_reentrancy_guard;
+            auto result = [this, &hook_id, &fn]() -> std::optional<std::invoke_result_t<F, InlineHook &>>
+            {
+                auto it = m_hooks.find(hook_id);
+                if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
+                {
+                    return fn(static_cast<InlineHook &>(*it->second));
+                }
+                return std::nullopt;
+            }();
+            --m_callback_reentrancy_guard;
+            return result;
         }
 
         /**
          * @brief Safely accesses a MidHook by its ID while holding the internal lock.
          * @details The callback is invoked with a reference to the MidHook while the
-         *          shared_mutex is held, preventing concurrent removal.
-         * @warning Do not call HookManager methods that acquire a unique_lock from
-         *          within the callback — this will deadlock.
+         *          shared_mutex is held as a reader, preventing concurrent removal.
+         * @warning DANGER: Calling any HookManager method that acquires a unique_lock
+         *          (e.g., remove_hook, enable_hook, disable_hook, create_*_hook) from
+         *          within the callback WILL DEADLOCK. If you need to call such methods,
+         *          use try_with_mid_hook() instead.
          * @tparam F Callable type accepting (MidHook&) and returning a value.
          * @param hook_id The name of the mid hook.
          * @param fn The callback to invoke with the hook reference.
          * @return std::optional<R> The callback's return value, or std::nullopt if hook not found.
          */
         template <typename F>
-        auto with_mid_hook(const std::string &hook_id, F &&fn)
+        [[nodiscard]] auto with_mid_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
+            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_mid_hook() callback. Use try_with_mid_hook() instead.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-            auto it = m_hooks.find(hook_id);
-            if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
+            ++m_callback_reentrancy_guard;
+            auto result = [this, &hook_id, &fn]() -> std::optional<std::invoke_result_t<F, MidHook &>>
             {
-                return fn(static_cast<MidHook &>(*it->second));
+                auto it = m_hooks.find(hook_id);
+                if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
+                {
+                    return fn(static_cast<MidHook &>(*it->second));
+                }
+                return std::nullopt;
+            }();
+            --m_callback_reentrancy_guard;
+            return result;
+        }
+
+        /**
+         * @brief Try-safe access to a MidHook by its ID using a non-blocking lock.
+         * @details Provides a non-blocking alternative to with_mid_hook(). The callback
+         *          is invoked only if the lock is immediately acquired. This prevents
+         *          deadlocks when the callback must call HookManager methods that require
+         *          a unique_lock.
+         * @param hook_id The name of the mid hook.
+         * @param fn The callback to invoke with the hook reference.
+         * @return std::optional<R> The callback's return value, std::nullopt if hook not
+         *         found, or std::nullopt with error tag if lock could not be acquired.
+         */
+        template <typename F>
+        [[nodiscard]] auto try_with_mid_hook(const std::string &hook_id, F &&fn)
+            -> std::optional<std::invoke_result_t<F, MidHook &>>
+        {
+            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_mid_hook() callback.");
+            std::unique_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
+            if (!lock.owns_lock())
+            {
+                return std::nullopt;
             }
-            return std::nullopt;
+            ++m_callback_reentrancy_guard;
+            auto result = [this, &hook_id, &fn]() -> std::optional<std::invoke_result_t<F, MidHook &>>
+            {
+                auto it = m_hooks.find(hook_id);
+                if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
+                {
+                    return fn(static_cast<MidHook &>(*it->second));
+                }
+                return std::nullopt;
+            }();
+            --m_callback_reentrancy_guard;
+            return result;
         }
 
     private:
@@ -471,6 +560,7 @@ namespace DetourModKit
         Logger &m_logger;
         std::shared_ptr<safetyhook::Allocator> m_allocator;
         std::atomic<bool> m_shutdown_called{false};
+        std::atomic<int> m_callback_reentrancy_guard{0};
 
         std::string error_to_string(const safetyhook::InlineHook::Error &err) const;
         std::string error_to_string(const safetyhook::MidHook::Error &err) const;

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -423,10 +423,10 @@ namespace DetourModKit
          * @brief Safely accesses an InlineHook by its ID while holding the internal lock.
          * @details The callback is invoked with a reference to the InlineHook while the
          *          shared_mutex is held as a reader, preventing concurrent removal.
-         * @warning DANGER: Calling any HookManager method that acquires a unique_lock
-         *          (e.g., remove_hook, enable_hook, disable_hook, create_*_hook) from
-         *          within the callback WILL DEADLOCK. If you need to call such methods,
-         *          use try_with_inline_hook() instead.
+         * @warning DANGER: Any callback holding m_hooks_mutex must NOT call methods that
+         *          acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook)
+         *          because those calls will deadlock. Perform such mutations outside the callback
+         *          or use an asynchronous/posted operation that does not hold m_hooks_mutex.
          * @tparam F Callable type accepting (InlineHook&) and returning a value.
          * @param hook_id The name of the inline hook.
          * @param fn The callback to invoke with the hook reference.
@@ -436,13 +436,14 @@ namespace DetourModKit
         [[nodiscard]] auto with_inline_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
-            assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_inline_hook() callback. Use try_with_inline_hook() instead.");
+            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-            ++t_callback_reentrancy_guard;
+            ++m_callback_reentrancy_guard;
             struct Guard
             {
-                ~Guard() noexcept { --t_callback_reentrancy_guard; }
-            } guard{};
+                int &counter;
+                ~Guard() noexcept { --counter; }
+            } guard{m_callback_reentrancy_guard};
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
@@ -470,17 +471,18 @@ namespace DetourModKit
         [[nodiscard]] auto try_with_inline_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
-            assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_inline_hook() callback.");
+            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
             if (!lock.owns_lock())
             {
                 return std::nullopt;
             }
-            ++t_callback_reentrancy_guard;
+            ++m_callback_reentrancy_guard;
             struct Guard
             {
-                ~Guard() noexcept { --t_callback_reentrancy_guard; }
-            } guard{};
+                int &counter;
+                ~Guard() noexcept { --counter; }
+            } guard{m_callback_reentrancy_guard};
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
@@ -493,10 +495,10 @@ namespace DetourModKit
          * @brief Safely accesses a MidHook by its ID while holding the internal lock.
          * @details The callback is invoked with a reference to the MidHook while the
          *          shared_mutex is held as a reader, preventing concurrent removal.
-         * @warning DANGER: Calling any HookManager method that acquires a unique_lock
-         *          (e.g., remove_hook, enable_hook, disable_hook, create_*_hook) from
-         *          within the callback WILL DEADLOCK. If you need to call such methods,
-         *          use try_with_mid_hook() instead.
+         * @warning DANGER: Any callback holding m_hooks_mutex must NOT call methods that
+         *          acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook)
+         *          because those calls will deadlock. Perform such mutations outside the callback
+         *          or use an asynchronous/posted operation that does not hold m_hooks_mutex.
          * @tparam F Callable type accepting (MidHook&) and returning a value.
          * @param hook_id The name of the mid hook.
          * @param fn The callback to invoke with the hook reference.
@@ -506,13 +508,14 @@ namespace DetourModKit
         [[nodiscard]] auto with_mid_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
-            assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_mid_hook() callback. Use try_with_mid_hook() instead.");
+            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-            ++t_callback_reentrancy_guard;
+            ++m_callback_reentrancy_guard;
             struct Guard
             {
-                ~Guard() noexcept { --t_callback_reentrancy_guard; }
-            } guard{};
+                int &counter;
+                ~Guard() noexcept { --counter; }
+            } guard{m_callback_reentrancy_guard};
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
@@ -540,17 +543,18 @@ namespace DetourModKit
         [[nodiscard]] auto try_with_mid_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
-            assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_mid_hook() callback.");
+            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
             if (!lock.owns_lock())
             {
                 return std::nullopt;
             }
-            ++t_callback_reentrancy_guard;
+            ++m_callback_reentrancy_guard;
             struct Guard
             {
-                ~Guard() noexcept { --t_callback_reentrancy_guard; }
-            } guard{};
+                int &counter;
+                ~Guard() noexcept { --counter; }
+            } guard{m_callback_reentrancy_guard};
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
@@ -565,7 +569,7 @@ namespace DetourModKit
         Logger &m_logger;
         std::shared_ptr<safetyhook::Allocator> m_allocator;
         std::atomic<bool> m_shutdown_called{false};
-        thread_local inline static int t_callback_reentrancy_guard{0};
+        int m_callback_reentrancy_guard{0};
 
         std::string error_to_string(const safetyhook::InlineHook::Error &err) const;
         std::string error_to_string(const safetyhook::MidHook::Error &err) const;

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -471,7 +471,7 @@ namespace DetourModKit
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
             assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_inline_hook() callback.");
-            std::unique_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
+            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
             if (!lock.owns_lock())
             {
                 return std::nullopt;
@@ -541,7 +541,7 @@ namespace DetourModKit
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
             assert(!t_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within try_with_mid_hook() callback.");
-            std::unique_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
+            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
             if (!lock.owns_lock())
             {
                 return std::nullopt;

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -12,6 +12,7 @@
 #include <string_view>
 #include <type_traits>
 #include <cassert>
+#include <utility>
 
 #include "safetyhook.hpp"
 #include "DetourModKit/logger.hpp"
@@ -438,17 +439,17 @@ namespace DetourModKit
             assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_inline_hook() callback. Use try_with_inline_hook() instead.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
             ++m_callback_reentrancy_guard;
-            auto result = [this, &hook_id, &fn]() -> std::optional<std::invoke_result_t<F, InlineHook &>>
+            struct Guard
             {
-                auto it = m_hooks.find(hook_id);
-                if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
-                {
-                    return fn(static_cast<InlineHook &>(*it->second));
-                }
-                return std::nullopt;
-            }();
-            --m_callback_reentrancy_guard;
-            return result;
+                HookManager *mgr;
+                ~Guard() noexcept { --mgr->m_callback_reentrancy_guard; }
+            } guard{this};
+            auto it = m_hooks.find(hook_id);
+            if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
+            {
+                return fn(static_cast<InlineHook &>(*it->second));
+            }
+            return std::nullopt;
         }
 
         /**
@@ -459,8 +460,8 @@ namespace DetourModKit
          *          a unique_lock.
          * @param hook_id The name of the inline hook.
          * @param fn The callback to invoke with the hook reference.
-         * @return std::optional<R> The callback's return value, std::nullopt if hook not
-         *         found, or std::nullopt with error tag if lock could not be acquired.
+         * @return std::optional<R> The callback's return value. Returns std::nullopt if either
+         *         the lock could not be acquired or the hook was not found.
          */
         template <typename F>
         [[nodiscard]] auto try_with_inline_hook(const std::string &hook_id, F &&fn)
@@ -473,17 +474,17 @@ namespace DetourModKit
                 return std::nullopt;
             }
             ++m_callback_reentrancy_guard;
-            auto result = [this, &hook_id, &fn]() -> std::optional<std::invoke_result_t<F, InlineHook &>>
+            struct Guard
             {
-                auto it = m_hooks.find(hook_id);
-                if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
-                {
-                    return fn(static_cast<InlineHook &>(*it->second));
-                }
-                return std::nullopt;
-            }();
-            --m_callback_reentrancy_guard;
-            return result;
+                HookManager *mgr;
+                ~Guard() noexcept { --mgr->m_callback_reentrancy_guard; }
+            } guard{this};
+            auto it = m_hooks.find(hook_id);
+            if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
+            {
+                return fn(static_cast<InlineHook &>(*it->second));
+            }
+            return std::nullopt;
         }
 
         /**
@@ -506,17 +507,17 @@ namespace DetourModKit
             assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Cannot call HookManager methods from within with_mid_hook() callback. Use try_with_mid_hook() instead.");
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
             ++m_callback_reentrancy_guard;
-            auto result = [this, &hook_id, &fn]() -> std::optional<std::invoke_result_t<F, MidHook &>>
+            struct Guard
             {
-                auto it = m_hooks.find(hook_id);
-                if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
-                {
-                    return fn(static_cast<MidHook &>(*it->second));
-                }
-                return std::nullopt;
-            }();
-            --m_callback_reentrancy_guard;
-            return result;
+                HookManager *mgr;
+                ~Guard() noexcept { --mgr->m_callback_reentrancy_guard; }
+            } guard{this};
+            auto it = m_hooks.find(hook_id);
+            if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
+            {
+                return fn(static_cast<MidHook &>(*it->second));
+            }
+            return std::nullopt;
         }
 
         /**
@@ -527,8 +528,8 @@ namespace DetourModKit
          *          a unique_lock.
          * @param hook_id The name of the mid hook.
          * @param fn The callback to invoke with the hook reference.
-         * @return std::optional<R> The callback's return value, std::nullopt if hook not
-         *         found, or std::nullopt with error tag if lock could not be acquired.
+         * @return std::optional<R> The callback's return value. Returns std::nullopt if either
+         *         the lock could not be acquired or the hook was not found.
          */
         template <typename F>
         [[nodiscard]] auto try_with_mid_hook(const std::string &hook_id, F &&fn)
@@ -541,17 +542,17 @@ namespace DetourModKit
                 return std::nullopt;
             }
             ++m_callback_reentrancy_guard;
-            auto result = [this, &hook_id, &fn]() -> std::optional<std::invoke_result_t<F, MidHook &>>
+            struct Guard
             {
-                auto it = m_hooks.find(hook_id);
-                if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
-                {
-                    return fn(static_cast<MidHook &>(*it->second));
-                }
-                return std::nullopt;
-            }();
-            --m_callback_reentrancy_guard;
-            return result;
+                HookManager *mgr;
+                ~Guard() noexcept { --mgr->m_callback_reentrancy_guard; }
+            } guard{this};
+            auto it = m_hooks.find(hook_id);
+            if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
+            {
+                return fn(static_cast<MidHook &>(*it->second));
+            }
+            return std::nullopt;
         }
 
     private:

--- a/src/hook_manager.cpp
+++ b/src/hook_manager.cpp
@@ -395,7 +395,6 @@ bool HookManager::remove_hook(const std::string &hook_id)
 
 void HookManager::remove_all_hooks()
 {
-    m_shutdown_called.store(false, std::memory_order_release);
     std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
     if (!m_hooks.empty())
     {
@@ -520,4 +519,3 @@ std::vector<std::string> HookManager::get_hook_ids(std::optional<HookStatus> sta
     }
     return ids;
 }
-

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -267,11 +267,11 @@ TEST_F(HookManagerTest, ThreadSafety)
                              {
             for (int j = 0; j < 10; ++j)
             {
-                hook_manager_->get_hook_status("Thread" + std::to_string(i) + "_" + std::to_string(j));
-                hook_manager_->get_hook_counts();
-                hook_manager_->get_hook_ids();
-                hook_manager_->enable_hook("nonexistent_" + std::to_string(i));
-                hook_manager_->disable_hook("nonexistent_" + std::to_string(i));
+                (void)hook_manager_->get_hook_status("Thread" + std::to_string(i) + "_" + std::to_string(j));
+                (void)hook_manager_->get_hook_counts();
+                (void)hook_manager_->get_hook_ids();
+                (void)hook_manager_->enable_hook("nonexistent_" + std::to_string(i));
+                (void)hook_manager_->disable_hook("nonexistent_" + std::to_string(i));
             } });
     }
 
@@ -955,6 +955,68 @@ TEST_F(HookManagerTest, WithMidHook_SuccessCallback)
     EXPECT_EQ(*name_opt, "WithMidCB");
 
     hook_manager_->remove_hook("WithMidCB");
+}
+
+TEST_F(HookManagerTest, TryWithInlineHook_Success)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "TryInlineCB",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    auto name_opt = hook_manager_->try_with_inline_hook(
+        "TryInlineCB",
+        [](InlineHook &hook) -> std::string
+        {
+            return std::string(hook.get_name());
+        });
+    ASSERT_TRUE(name_opt.has_value());
+    EXPECT_EQ(*name_opt, "TryInlineCB");
+
+    hook_manager_->remove_hook("TryInlineCB");
+}
+
+TEST_F(HookManagerTest, TryWithInlineHook_NotFound)
+{
+    auto result = hook_manager_->try_with_inline_hook(
+        "NonExistentTryHook",
+        [](InlineHook &) -> bool
+        { return true; });
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(HookManagerTest, TryWithMidHook_Success)
+{
+    auto detour_fn = [](safetyhook::Context &) {};
+
+    auto result = hook_manager_->create_mid_hook(
+        "TryMidCB",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        detour_fn);
+    ASSERT_TRUE(result.has_value());
+
+    auto name_opt = hook_manager_->try_with_mid_hook(
+        "TryMidCB",
+        [](MidHook &hook) -> std::string
+        {
+            return std::string(hook.get_name());
+        });
+    ASSERT_TRUE(name_opt.has_value());
+    EXPECT_EQ(*name_opt, "TryMidCB");
+
+    hook_manager_->remove_hook("TryMidCB");
+}
+
+TEST_F(HookManagerTest, TryWithMidHook_NotFound)
+{
+    auto result = hook_manager_->try_with_mid_hook(
+        "NonExistentTryMidHook",
+        [](MidHook &) -> bool
+        { return true; });
+    EXPECT_FALSE(result.has_value());
 }
 
 TEST_F(HookManagerTest, RealMidHook_CreateDisabledAutoEnable)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-blocking "try" access paths for safer concurrent hook use.

* **API Improvements**
  * Several hook-related calls now require handling of return values (warn on ignored results).

* **Bug Fixes**
  * Added callback reentrancy tracking and updated docs to warn about potential deadlocks; bulk hook removal no longer resets the shutdown flag.

* **Tests**
  * New tests for try-access paths and updated tests to explicitly handle return values.

* **CI**
  * Windows CI split into separate build/test jobs with improved caching and coverage steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->