### PR TITLE
perf: lock-free hook status transitions and reduced lock contention

### DIFF
--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -11,6 +11,8 @@
 #include <expected>
 #include <string_view>
 #include <type_traits>
+#include <concepts>
+#include <atomic>
 #include <cassert>
 #include <utility>
 
@@ -84,53 +86,53 @@ namespace DetourModKit
         const std::string &get_name() const noexcept { return m_name; }
         HookType get_type() const noexcept { return m_type; }
         uintptr_t get_target_address() const noexcept { return m_target_address; }
-        HookStatus get_status() const noexcept { return m_status; }
+        HookStatus get_status() const noexcept { return m_status.load(std::memory_order_acquire); }
 
         /**
          * @brief Enables the hook.
-         * @return true if the hook was successfully enabled, false otherwise.
-         * @note This is a Template Method; derived classes implement do_enable().
+         * @return true if the hook was successfully enabled or already active, false otherwise.
+         * @note Uses atomic CAS for lock-free status transitions. Thread-safe without
+         *       requiring external synchronization.
          */
         bool enable()
         {
             if (!is_impl_valid())
                 return false;
-            if (m_status == HookStatus::Active)
-                return true;
-            if (m_status != HookStatus::Disabled)
-                return false;
+
+            auto expected = HookStatus::Disabled;
+            if (!m_status.compare_exchange_strong(expected, HookStatus::Active, std::memory_order_acq_rel))
+                return expected == HookStatus::Active;
 
             if (do_enable())
-            {
-                m_status = HookStatus::Active;
                 return true;
-            }
+
+            m_status.store(HookStatus::Disabled, std::memory_order_release);
             return false;
         }
 
         /**
          * @brief Disables the hook.
-         * @return true if the hook was successfully disabled, false otherwise.
-         * @note This is a Template Method; derived classes implement do_disable().
+         * @return true if the hook was successfully disabled or already disabled, false otherwise.
+         * @note Uses atomic CAS for lock-free status transitions. Thread-safe without
+         *       requiring external synchronization.
          */
         bool disable()
         {
             if (!is_impl_valid())
                 return false;
-            if (m_status == HookStatus::Disabled)
-                return true;
-            if (m_status != HookStatus::Active)
-                return false;
+
+            auto expected = HookStatus::Active;
+            if (!m_status.compare_exchange_strong(expected, HookStatus::Disabled, std::memory_order_acq_rel))
+                return expected == HookStatus::Disabled;
 
             if (do_disable())
-            {
-                m_status = HookStatus::Disabled;
                 return true;
-            }
+
+            m_status.store(HookStatus::Active, std::memory_order_release);
             return false;
         }
 
-        bool is_enabled() const noexcept { return m_status == HookStatus::Active; }
+        bool is_enabled() const noexcept { return m_status.load(std::memory_order_acquire) == HookStatus::Active; }
 
         static std::string_view status_to_string(HookStatus status)
         {
@@ -176,7 +178,7 @@ namespace DetourModKit
         std::string m_name;
         HookType m_type;
         uintptr_t m_target_address;
-        HookStatus m_status;
+        std::atomic<HookStatus> m_status;
 
         Hook(std::string name, HookType type, uintptr_t target_address, HookStatus initial_status)
             : m_name(std::move(name)), m_type(type), m_target_address(target_address), m_status(initial_status) {}
@@ -208,7 +210,7 @@ namespace DetourModKit
          * @return A function pointer of type T to the original function's trampoline.
          */
         template <typename T>
-        T get_original() const
+        T get_original() const noexcept
         {
             return m_safetyhook_impl ? m_safetyhook_impl->original<T>() : nullptr;
         }
@@ -247,7 +249,7 @@ namespace DetourModKit
          * @brief Gets the destination function of this mid-hook.
          * @return safetyhook::MidHookFn The function pointer to the detour.
          */
-        safetyhook::MidHookFn get_destination() const
+        safetyhook::MidHookFn get_destination() const noexcept
         {
             return m_safetyhook_impl ? m_safetyhook_impl->destination() : nullptr;
         }
@@ -284,7 +286,6 @@ namespace DetourModKit
          */
         static HookManager &get_instance();
 
-        explicit HookManager(Logger &logger = Logger::get_instance());
         ~HookManager();
 
         /**
@@ -378,7 +379,7 @@ namespace DetourModKit
          * @param hook_id The name of the hook to remove.
          * @return true if the hook was found and successfully removed, false otherwise.
          */
-        bool remove_hook(const std::string &hook_id);
+        [[nodiscard]] bool remove_hook(const std::string &hook_id);
 
         /**
          * @brief Removes all hooks currently managed by this HookManager instance.
@@ -404,7 +405,7 @@ namespace DetourModKit
          * @param hook_id The name of the hook.
          * @return std::optional<HookStatus> The current status, or std::nullopt if not found.
          */
-        std::optional<HookStatus> get_hook_status(const std::string &hook_id) const;
+        [[nodiscard]] std::optional<HookStatus> get_hook_status(const std::string &hook_id) const;
 
         /**
          * @brief Gets a summary of hook counts categorized by their status.
@@ -433,17 +434,17 @@ namespace DetourModKit
          * @return std::optional<R> The callback's return value, or std::nullopt if hook not found.
          */
         template <typename F>
+            requires std::invocable<F, InlineHook &>
         [[nodiscard]] auto with_inline_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
-            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.");
-            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-            ++m_callback_reentrancy_guard;
-            struct Guard
+            if (get_reentrancy_guard() > 0)
             {
-                int &counter;
-                ~Guard() noexcept { --counter; }
-            } guard{m_callback_reentrancy_guard};
+                m_logger.error("HookManager: Reentrant callback detected in with_inline_hook('{}')! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.", hook_id);
+                return std::nullopt;
+            }
+            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
+            ReentrancyGuard guard(get_reentrancy_guard());
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
@@ -468,21 +469,21 @@ namespace DetourModKit
          *         the lock could not be acquired or the hook was not found.
          */
         template <typename F>
+            requires std::invocable<F, InlineHook &>
         [[nodiscard]] auto try_with_inline_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
-            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.");
+            if (get_reentrancy_guard() > 0)
+            {
+                m_logger.error("HookManager: Reentrant callback detected in try_with_inline_hook('{}')! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.", hook_id);
+                return std::nullopt;
+            }
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
             if (!lock.owns_lock())
             {
                 return std::nullopt;
             }
-            ++m_callback_reentrancy_guard;
-            struct Guard
-            {
-                int &counter;
-                ~Guard() noexcept { --counter; }
-            } guard{m_callback_reentrancy_guard};
+            ReentrancyGuard guard(get_reentrancy_guard());
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
@@ -505,17 +506,17 @@ namespace DetourModKit
          * @return std::optional<R> The callback's return value, or std::nullopt if hook not found.
          */
         template <typename F>
+            requires std::invocable<F, MidHook &>
         [[nodiscard]] auto with_mid_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
-            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.");
-            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-            ++m_callback_reentrancy_guard;
-            struct Guard
+            if (get_reentrancy_guard() > 0)
             {
-                int &counter;
-                ~Guard() noexcept { --counter; }
-            } guard{m_callback_reentrancy_guard};
+                m_logger.error("HookManager: Reentrant callback detected in with_mid_hook('{}')! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.", hook_id);
+                return std::nullopt;
+            }
+            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
+            ReentrancyGuard guard(get_reentrancy_guard());
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
@@ -540,21 +541,21 @@ namespace DetourModKit
          *         the lock could not be acquired or the hook was not found.
          */
         template <typename F>
+            requires std::invocable<F, MidHook &>
         [[nodiscard]] auto try_with_mid_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
-            assert(!m_callback_reentrancy_guard && "HookManager: Reentrant callback detected! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.");
+            if (get_reentrancy_guard() > 0)
+            {
+                m_logger.error("HookManager: Reentrant callback detected in try_with_mid_hook('{}')! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.", hook_id);
+                return std::nullopt;
+            }
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex, std::try_to_lock);
             if (!lock.owns_lock())
             {
                 return std::nullopt;
             }
-            ++m_callback_reentrancy_guard;
-            struct Guard
-            {
-                int &counter;
-                ~Guard() noexcept { --counter; }
-            } guard{m_callback_reentrancy_guard};
+            ReentrancyGuard guard(get_reentrancy_guard());
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
@@ -564,19 +565,36 @@ namespace DetourModKit
         }
 
     private:
+        explicit HookManager(Logger &logger = Logger::get_instance());
+
         mutable std::shared_mutex m_hooks_mutex;
         std::unordered_map<std::string, std::unique_ptr<Hook>> m_hooks;
         Logger &m_logger;
         std::shared_ptr<safetyhook::Allocator> m_allocator;
         std::atomic<bool> m_shutdown_called{false};
-        int m_callback_reentrancy_guard{0};
+
+        [[nodiscard]] int &get_reentrancy_guard() noexcept
+        {
+            thread_local int reentrancy_counter{0};
+            return reentrancy_counter;
+        }
+
+        struct ReentrancyGuard
+        {
+            int &counter;
+            explicit ReentrancyGuard(int &cnt) noexcept : counter(cnt) { ++counter; }
+            ~ReentrancyGuard() noexcept { --counter; }
+            ReentrancyGuard(const ReentrancyGuard &) = delete;
+            ReentrancyGuard &operator=(const ReentrancyGuard &) = delete;
+            ReentrancyGuard(ReentrancyGuard &&) = delete;
+            ReentrancyGuard &operator=(ReentrancyGuard &&) = delete;
+        };
 
         std::string error_to_string(const safetyhook::InlineHook::Error &err) const;
         std::string error_to_string(const safetyhook::MidHook::Error &err) const;
 
-        // Non-locking variants - caller must already hold m_hooks_mutex
+        // Non-locking variant - caller must already hold m_hooks_mutex
         bool hook_id_exists_locked(const std::string &hook_id) const;
-        Hook *get_hook_raw_ptr_locked(const std::string &hook_id);
     };
 } // namespace DetourModKit
 

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -41,6 +41,8 @@ namespace DetourModKit
     {
         Active,
         Disabled,
+        Enabling,
+        Disabling,
         Failed,
         Removed
     };
@@ -92,19 +94,24 @@ namespace DetourModKit
          * @brief Enables the hook.
          * @return true if the hook was successfully enabled or already active, false otherwise.
          * @note Uses atomic CAS for lock-free status transitions. Thread-safe without
-         *       requiring external synchronization.
+         *       requiring external synchronization. Uses an intermediate Enabling state
+         *       to prevent other threads from observing a speculative terminal state
+         *       while the SafetyHook enable call is in progress.
          */
         bool enable()
         {
             if (!is_impl_valid())
                 return false;
 
-            auto expected = HookStatus::Disabled;
-            if (!m_status.compare_exchange_strong(expected, HookStatus::Active, std::memory_order_acq_rel))
+            HookStatus expected = HookStatus::Disabled;
+            if (!m_status.compare_exchange_strong(expected, HookStatus::Enabling, std::memory_order_acq_rel))
                 return expected == HookStatus::Active;
 
             if (do_enable())
+            {
+                m_status.store(HookStatus::Active, std::memory_order_release);
                 return true;
+            }
 
             m_status.store(HookStatus::Disabled, std::memory_order_release);
             return false;
@@ -114,19 +121,24 @@ namespace DetourModKit
          * @brief Disables the hook.
          * @return true if the hook was successfully disabled or already disabled, false otherwise.
          * @note Uses atomic CAS for lock-free status transitions. Thread-safe without
-         *       requiring external synchronization.
+         *       requiring external synchronization. Uses an intermediate Disabling state
+         *       to prevent other threads from observing a speculative terminal state
+         *       while the SafetyHook disable call is in progress.
          */
         bool disable()
         {
             if (!is_impl_valid())
                 return false;
 
-            auto expected = HookStatus::Active;
-            if (!m_status.compare_exchange_strong(expected, HookStatus::Disabled, std::memory_order_acq_rel))
+            HookStatus expected = HookStatus::Active;
+            if (!m_status.compare_exchange_strong(expected, HookStatus::Disabling, std::memory_order_acq_rel))
                 return expected == HookStatus::Disabled;
 
             if (do_disable())
+            {
+                m_status.store(HookStatus::Disabled, std::memory_order_release);
                 return true;
+            }
 
             m_status.store(HookStatus::Active, std::memory_order_release);
             return false;
@@ -142,6 +154,10 @@ namespace DetourModKit
                 return "Active";
             case HookStatus::Disabled:
                 return "Disabled";
+            case HookStatus::Enabling:
+                return "Enabling";
+            case HookStatus::Disabling:
+                return "Disabling";
             case HookStatus::Failed:
                 return "Failed";
             case HookStatus::Removed:
@@ -434,7 +450,9 @@ namespace DetourModKit
          * @return std::optional<R> The callback's return value, or std::nullopt if hook not found.
          */
         template <typename F>
-            requires std::invocable<F, InlineHook &>
+            requires std::invocable<F, InlineHook &> &&
+                     (!std::is_void_v<std::invoke_result_t<F, InlineHook &>>) &&
+                     (!std::is_reference_v<std::invoke_result_t<F, InlineHook &>>)
         [[nodiscard]] auto with_inline_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
@@ -448,7 +466,7 @@ namespace DetourModKit
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
-                return fn(static_cast<InlineHook &>(*it->second));
+                return std::invoke(std::forward<F>(fn), static_cast<InlineHook &>(*it->second));
             }
             return std::nullopt;
         }
@@ -469,7 +487,9 @@ namespace DetourModKit
          *         the lock could not be acquired or the hook was not found.
          */
         template <typename F>
-            requires std::invocable<F, InlineHook &>
+            requires std::invocable<F, InlineHook &> &&
+                     (!std::is_void_v<std::invoke_result_t<F, InlineHook &>>) &&
+                     (!std::is_reference_v<std::invoke_result_t<F, InlineHook &>>)
         [[nodiscard]] auto try_with_inline_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
@@ -487,7 +507,7 @@ namespace DetourModKit
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
-                return fn(static_cast<InlineHook &>(*it->second));
+                return std::invoke(std::forward<F>(fn), static_cast<InlineHook &>(*it->second));
             }
             return std::nullopt;
         }
@@ -506,7 +526,9 @@ namespace DetourModKit
          * @return std::optional<R> The callback's return value, or std::nullopt if hook not found.
          */
         template <typename F>
-            requires std::invocable<F, MidHook &>
+            requires std::invocable<F, MidHook &> &&
+                     (!std::is_void_v<std::invoke_result_t<F, MidHook &>>) &&
+                     (!std::is_reference_v<std::invoke_result_t<F, MidHook &>>)
         [[nodiscard]] auto with_mid_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
@@ -520,7 +542,7 @@ namespace DetourModKit
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
-                return fn(static_cast<MidHook &>(*it->second));
+                return std::invoke(std::forward<F>(fn), static_cast<MidHook &>(*it->second));
             }
             return std::nullopt;
         }
@@ -541,7 +563,9 @@ namespace DetourModKit
          *         the lock could not be acquired or the hook was not found.
          */
         template <typename F>
-            requires std::invocable<F, MidHook &>
+            requires std::invocable<F, MidHook &> &&
+                     (!std::is_void_v<std::invoke_result_t<F, MidHook &>>) &&
+                     (!std::is_reference_v<std::invoke_result_t<F, MidHook &>>)
         [[nodiscard]] auto try_with_mid_hook(const std::string &hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
@@ -559,7 +583,7 @@ namespace DetourModKit
             auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
-                return fn(static_cast<MidHook &>(*it->second));
+                return std::invoke(std::forward<F>(fn), static_cast<MidHook &>(*it->second));
             }
             return std::nullopt;
         }

--- a/src/hook_manager.cpp
+++ b/src/hook_manager.cpp
@@ -113,12 +113,6 @@ bool HookManager::hook_id_exists_locked(const std::string &hook_id) const
     return m_hooks.find(hook_id) != m_hooks.end();
 }
 
-Hook *HookManager::get_hook_raw_ptr_locked(const std::string &hook_id)
-{
-    auto it = m_hooks.find(hook_id);
-    return (it != m_hooks.end()) ? it->second.get() : nullptr;
-}
-
 std::expected<std::string, HookError> HookManager::create_inline_hook(
     const std::string &name,
     uintptr_t target_address,
@@ -411,71 +405,71 @@ void HookManager::remove_all_hooks()
 
 bool HookManager::enable_hook(const std::string &hook_id)
 {
-    std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+    std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
     auto it = m_hooks.find(hook_id);
-    if (it != m_hooks.end())
+    if (it == m_hooks.end())
     {
-        Hook *hook = it->second.get();
-        if (hook->get_status() == HookStatus::Disabled)
-        {
-            if (hook->enable())
-            {
-                m_logger.info("HookManager: Hook '{}' successfully enabled.", hook_id);
-                return true;
-            }
-            else
-            {
-                m_logger.error("HookManager: Failed to enable hook '{}'. Underlying SafetyHook call may have failed.", hook_id);
-                return false;
-            }
-        }
-        else if (hook->get_status() == HookStatus::Active)
-        {
-            m_logger.debug("HookManager: Hook '{}' is already active. Enable request ignored.", hook_id);
-            return true;
-        }
-        else
-        {
-            m_logger.warning("HookManager: Hook '{}' cannot be enabled. Current status: {}", hook_id, Hook::status_to_string(hook->get_status()));
-            return false;
-        }
+        m_logger.warning("HookManager: Hook ID '{}' not found for enable operation.", hook_id);
+        return false;
     }
-    m_logger.warning("HookManager: Hook ID '{}' not found for enable operation.", hook_id);
+
+    Hook *hook = it->second.get();
+    if (hook->enable())
+    {
+        m_logger.info("HookManager: Hook '{}' successfully enabled.", hook_id);
+        return true;
+    }
+
+    const auto status = hook->get_status();
+    if (status == HookStatus::Active)
+    {
+        m_logger.debug("HookManager: Hook '{}' is already active. Enable request ignored.", hook_id);
+        return true;
+    }
+
+    if (status == HookStatus::Disabled)
+    {
+        m_logger.error("HookManager: Failed to enable hook '{}'. Underlying SafetyHook call may have failed.", hook_id);
+    }
+    else
+    {
+        m_logger.warning("HookManager: Hook '{}' cannot be enabled. Current status: {}", hook_id, Hook::status_to_string(status));
+    }
     return false;
 }
 
 bool HookManager::disable_hook(const std::string &hook_id)
 {
-    std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+    std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
     auto it = m_hooks.find(hook_id);
-    if (it != m_hooks.end())
+    if (it == m_hooks.end())
     {
-        Hook *hook = it->second.get();
-        if (hook->get_status() == HookStatus::Active)
-        {
-            if (hook->disable())
-            {
-                m_logger.info("HookManager: Hook '{}' successfully disabled.", hook_id);
-                return true;
-            }
-            else
-            {
-                m_logger.error("HookManager: Failed to disable hook '{}'. Underlying SafetyHook call may have failed.", hook_id);
-                return false;
-            }
-        }
-        else if (hook->get_status() == HookStatus::Disabled)
-        {
-            m_logger.debug("HookManager: Hook '{}' is already disabled. Disable request ignored.", hook_id);
-            return true;
-        }
-        else
-        {
-            m_logger.warning("HookManager: Hook '{}' cannot be disabled. Current status: {}", hook_id, Hook::status_to_string(hook->get_status()));
-            return false;
-        }
+        m_logger.warning("HookManager: Hook ID '{}' not found for disable operation.", hook_id);
+        return false;
     }
-    m_logger.warning("HookManager: Hook ID '{}' not found for disable operation.", hook_id);
+
+    Hook *hook = it->second.get();
+    if (hook->disable())
+    {
+        m_logger.info("HookManager: Hook '{}' successfully disabled.", hook_id);
+        return true;
+    }
+
+    const auto status = hook->get_status();
+    if (status == HookStatus::Disabled)
+    {
+        m_logger.debug("HookManager: Hook '{}' is already disabled. Disable request ignored.", hook_id);
+        return true;
+    }
+
+    if (status == HookStatus::Active)
+    {
+        m_logger.error("HookManager: Failed to disable hook '{}'. Underlying SafetyHook call may have failed.", hook_id);
+    }
+    else
+    {
+        m_logger.warning("HookManager: Hook '{}' cannot be disabled. Current status: {}", hook_id, Hook::status_to_string(status));
+    }
     return false;
 }
 

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -1066,10 +1066,12 @@ TEST_F(HookManagerTest, ConcurrentEnableDisable)
     constexpr int iterations = 50;
     std::vector<std::thread> threads;
     std::latch start_latch(num_threads);
+    std::atomic<bool> saw_active{false};
+    std::atomic<bool> saw_disabled{false};
 
     for (int i = 0; i < num_threads; ++i)
     {
-        threads.emplace_back([this, i, &start_latch]()
+        threads.emplace_back([this, i, &start_latch, &saw_active, &saw_disabled]()
                              {
             start_latch.arrive_and_wait();
             for (int j = 0; j < iterations; ++j)
@@ -1082,6 +1084,14 @@ TEST_F(HookManagerTest, ConcurrentEnableDisable)
                 {
                     (void)hook_manager_->disable_hook("ConcurrentHook");
                 }
+                auto s = hook_manager_->get_hook_status("ConcurrentHook");
+                if (s.has_value())
+                {
+                    if (*s == HookStatus::Active)
+                        saw_active.store(true, std::memory_order_relaxed);
+                    else if (*s == HookStatus::Disabled)
+                        saw_disabled.store(true, std::memory_order_relaxed);
+                }
             } });
     }
 
@@ -1090,9 +1100,8 @@ TEST_F(HookManagerTest, ConcurrentEnableDisable)
         t.join();
     }
 
-    auto status = hook_manager_->get_hook_status("ConcurrentHook");
-    ASSERT_TRUE(status.has_value());
-    EXPECT_TRUE(*status == HookStatus::Active || *status == HookStatus::Disabled);
+    EXPECT_TRUE(saw_active.load()) << "Expected Active to be observed during concurrent toggling";
+    EXPECT_TRUE(saw_disabled.load()) << "Expected Disabled to be observed during concurrent toggling";
 
     EXPECT_TRUE(hook_manager_->disable_hook("ConcurrentHook"));
     EXPECT_EQ(*hook_manager_->get_hook_status("ConcurrentHook"), HookStatus::Disabled);

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -883,7 +883,7 @@ TEST_F(HookManagerTest, CreateInlineHookAOB_Success)
     if (result.has_value())
     {
         EXPECT_NE(tramp, nullptr);
-        hook_manager_->remove_hook("AOBSuccessHook");
+        EXPECT_TRUE(hook_manager_->remove_hook("AOBSuccessHook"));
     }
 }
 
@@ -911,7 +911,7 @@ TEST_F(HookManagerTest, CreateMidHookAOB_Success)
 
     if (result.has_value())
     {
-        hook_manager_->remove_hook("MidAOBSuccess");
+        EXPECT_TRUE(hook_manager_->remove_hook("MidAOBSuccess"));
     }
 }
 
@@ -933,7 +933,7 @@ TEST_F(HookManagerTest, WithInlineHook_SuccessCallback)
     ASSERT_TRUE(name_opt.has_value());
     EXPECT_EQ(*name_opt, "WithInlineCB");
 
-    hook_manager_->remove_hook("WithInlineCB");
+    EXPECT_TRUE(hook_manager_->remove_hook("WithInlineCB"));
 }
 
 TEST_F(HookManagerTest, WithMidHook_SuccessCallback)
@@ -954,7 +954,7 @@ TEST_F(HookManagerTest, WithMidHook_SuccessCallback)
     ASSERT_TRUE(name_opt.has_value());
     EXPECT_EQ(*name_opt, "WithMidCB");
 
-    hook_manager_->remove_hook("WithMidCB");
+    EXPECT_TRUE(hook_manager_->remove_hook("WithMidCB"));
 }
 
 TEST_F(HookManagerTest, TryWithInlineHook_Success)
@@ -976,7 +976,7 @@ TEST_F(HookManagerTest, TryWithInlineHook_Success)
     ASSERT_TRUE(name_opt.has_value());
     EXPECT_EQ(*name_opt, "TryInlineCB");
 
-    hook_manager_->remove_hook("TryInlineCB");
+    EXPECT_TRUE(hook_manager_->remove_hook("TryInlineCB"));
 }
 
 TEST_F(HookManagerTest, TryWithInlineHook_NotFound)
@@ -1007,7 +1007,7 @@ TEST_F(HookManagerTest, TryWithMidHook_Success)
     ASSERT_TRUE(name_opt.has_value());
     EXPECT_EQ(*name_opt, "TryMidCB");
 
-    hook_manager_->remove_hook("TryMidCB");
+    EXPECT_TRUE(hook_manager_->remove_hook("TryMidCB"));
 }
 
 TEST_F(HookManagerTest, TryWithMidHook_NotFound)
@@ -1042,7 +1042,110 @@ TEST_F(HookManagerTest, RealMidHook_CreateDisabledAutoEnable)
     EXPECT_TRUE(hook_manager_->disable_hook("MidDisabledAE"));
     EXPECT_EQ(*hook_manager_->get_hook_status("MidDisabledAE"), HookStatus::Disabled);
 
-    hook_manager_->remove_hook("MidDisabledAE");
+    EXPECT_TRUE(hook_manager_->remove_hook("MidDisabledAE"));
+}
+
+TEST_F(HookManagerTest, ConcurrentEnableDisable)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "ConcurrentHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    constexpr int num_threads = 4;
+    constexpr int iterations = 50;
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < num_threads; ++i)
+    {
+        threads.emplace_back([this, i]()
+                             {
+            for (int j = 0; j < iterations; ++j)
+            {
+                if (j % 2 == (i % 2))
+                {
+                    (void)hook_manager_->enable_hook("ConcurrentHook");
+                }
+                else
+                {
+                    (void)hook_manager_->disable_hook("ConcurrentHook");
+                }
+            } });
+    }
+
+    for (auto &t : threads)
+    {
+        t.join();
+    }
+
+    auto status = hook_manager_->get_hook_status("ConcurrentHook");
+    ASSERT_TRUE(status.has_value());
+    EXPECT_TRUE(*status == HookStatus::Active || *status == HookStatus::Disabled);
+}
+
+TEST_F(HookManagerTest, WithInlineHook_DirectEnableDisable)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "DirectEnDisHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    auto cb_result = hook_manager_->with_inline_hook(
+        "DirectEnDisHook",
+        [](InlineHook &hook) -> bool
+        {
+            EXPECT_EQ(hook.get_status(), HookStatus::Active);
+
+            EXPECT_TRUE(hook.disable());
+            EXPECT_EQ(hook.get_status(), HookStatus::Disabled);
+
+            EXPECT_TRUE(hook.enable());
+            EXPECT_EQ(hook.get_status(), HookStatus::Active);
+
+            EXPECT_TRUE(hook.enable());
+
+            return true;
+        });
+
+    ASSERT_TRUE(cb_result.has_value());
+    EXPECT_TRUE(*cb_result);
+}
+
+TEST_F(HookManagerTest, WithMidHook_DirectEnableDisable)
+{
+    auto detour_fn = [](safetyhook::Context &) {};
+
+    auto result = hook_manager_->create_mid_hook(
+        "DirectMidEnDisHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        detour_fn);
+    ASSERT_TRUE(result.has_value());
+
+    auto cb_result = hook_manager_->with_mid_hook(
+        "DirectMidEnDisHook",
+        [](MidHook &hook) -> bool
+        {
+            EXPECT_EQ(hook.get_status(), HookStatus::Active);
+
+            EXPECT_TRUE(hook.disable());
+            EXPECT_EQ(hook.get_status(), HookStatus::Disabled);
+
+            EXPECT_TRUE(hook.enable());
+            EXPECT_EQ(hook.get_status(), HookStatus::Active);
+
+            EXPECT_TRUE(hook.disable());
+
+            return true;
+        });
+
+    ASSERT_TRUE(cb_result.has_value());
+    EXPECT_TRUE(*cb_result);
 }
 
 TEST_F(HookManagerTest, RemoveAllHooks_WithRealHooks)
@@ -1092,5 +1195,157 @@ TEST_F(HookManagerTest, RealInlineHook_DisabledEnableDisableCycle)
     EXPECT_TRUE(hook_manager_->disable_hook("InlineDisabled"));
     EXPECT_EQ(*hook_manager_->get_hook_status("InlineDisabled"), HookStatus::Disabled);
 
-    hook_manager_->remove_hook("InlineDisabled");
+    EXPECT_TRUE(hook_manager_->remove_hook("InlineDisabled"));
+}
+
+TEST_F(HookManagerTest, WithInlineHook_CallbackExecutesSuccessfully)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "CallbackExecHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    bool callback_executed = false;
+    auto hook_result = hook_manager_->with_inline_hook(
+        "CallbackExecHook",
+        [&callback_executed]([[maybe_unused]] InlineHook &hook) -> bool
+        {
+            callback_executed = true;
+            return true;
+        });
+
+    EXPECT_TRUE(hook_result.has_value());
+    EXPECT_TRUE(callback_executed);
+    EXPECT_TRUE(*hook_result);
+}
+
+TEST_F(HookManagerTest, WithMidHook_CallbackExecutesSuccessfully)
+{
+    auto detour_fn = [](safetyhook::Context &) {};
+    auto result = hook_manager_->create_mid_hook(
+        "MidCallbackExecHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        detour_fn);
+    ASSERT_TRUE(result.has_value());
+
+    bool callback_executed = false;
+    auto hook_result = hook_manager_->with_mid_hook(
+        "MidCallbackExecHook",
+        [&callback_executed]([[maybe_unused]] MidHook &hook) -> bool
+        {
+            callback_executed = true;
+            return true;
+        });
+
+    EXPECT_TRUE(hook_result.has_value());
+    EXPECT_TRUE(callback_executed);
+    EXPECT_TRUE(*hook_result);
+}
+
+TEST_F(HookManagerTest, TryWithInlineHook_CallbackExecutesSuccessfully)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "TryCallbackExecHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    bool callback_executed = false;
+    auto hook_result = hook_manager_->try_with_inline_hook(
+        "TryCallbackExecHook",
+        [&callback_executed]([[maybe_unused]] InlineHook &hook) -> bool
+        {
+            callback_executed = true;
+            return true;
+        });
+
+    EXPECT_TRUE(hook_result.has_value());
+    EXPECT_TRUE(callback_executed);
+    EXPECT_TRUE(*hook_result);
+}
+
+TEST_F(HookManagerTest, TryWithMidHook_CallbackExecutesSuccessfully)
+{
+    auto detour_fn = [](safetyhook::Context &) {};
+    auto result = hook_manager_->create_mid_hook(
+        "TryMidCallbackExecHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        detour_fn);
+    ASSERT_TRUE(result.has_value());
+
+    bool callback_executed = false;
+    auto hook_result = hook_manager_->try_with_mid_hook(
+        "TryMidCallbackExecHook",
+        [&callback_executed]([[maybe_unused]] MidHook &hook) -> bool
+        {
+            callback_executed = true;
+            return true;
+        });
+
+    EXPECT_TRUE(hook_result.has_value());
+    EXPECT_TRUE(callback_executed);
+    EXPECT_TRUE(*hook_result);
+}
+
+TEST_F(HookManagerTest, WithInlineHook_ReturnsNulloptForNonExistentHook)
+{
+    bool callback_executed = false;
+    auto hook_result = hook_manager_->with_inline_hook(
+        "NonExistentHook",
+        [&callback_executed]([[maybe_unused]] InlineHook &hook) -> bool
+        {
+            callback_executed = true;
+            return true;
+        });
+
+    EXPECT_FALSE(hook_result.has_value());
+    EXPECT_FALSE(callback_executed);
+}
+
+TEST_F(HookManagerTest, InlineHook_GetOriginal_Noexcept)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "NoexceptHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    auto hook_result = hook_manager_->with_inline_hook(
+        "NoexceptHook",
+        [](InlineHook &hook) -> bool
+        {
+            auto orig = hook.get_original<int (*)(int, int)>();
+            return orig != nullptr;
+        });
+
+    EXPECT_TRUE(hook_result.has_value());
+    EXPECT_TRUE(*hook_result);
+}
+
+TEST_F(HookManagerTest, MidHook_GetDestination_Noexcept)
+{
+    auto detour_fn = [](safetyhook::Context &) {};
+    auto result = hook_manager_->create_mid_hook(
+        "NoexceptMidHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        detour_fn);
+    ASSERT_TRUE(result.has_value());
+
+    auto hook_result = hook_manager_->with_mid_hook(
+        "NoexceptMidHook",
+        [](MidHook &hook) -> bool
+        {
+            auto dest = hook.get_destination();
+            return dest != nullptr;
+        });
+
+    EXPECT_TRUE(hook_result.has_value());
+    EXPECT_TRUE(*hook_result);
 }

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -42,12 +42,16 @@ TEST_F(HookManagerTest, HookStatus)
 {
     HookStatus status1 = HookStatus::Active;
     HookStatus status2 = HookStatus::Disabled;
-    HookStatus status3 = HookStatus::Failed;
-    HookStatus status4 = HookStatus::Removed;
+    HookStatus status3 = HookStatus::Enabling;
+    HookStatus status4 = HookStatus::Disabling;
+    HookStatus status5 = HookStatus::Failed;
+    HookStatus status6 = HookStatus::Removed;
 
     EXPECT_NE(status1, status2);
     EXPECT_NE(status2, status3);
     EXPECT_NE(status3, status4);
+    EXPECT_NE(status4, status5);
+    EXPECT_NE(status5, status6);
 }
 
 TEST_F(HookManagerTest, HookType)
@@ -790,6 +794,8 @@ TEST_F(HookManagerTest, StatusToString_AllValues)
 {
     EXPECT_EQ(Hook::status_to_string(HookStatus::Active), "Active");
     EXPECT_EQ(Hook::status_to_string(HookStatus::Disabled), "Disabled");
+    EXPECT_EQ(Hook::status_to_string(HookStatus::Enabling), "Enabling");
+    EXPECT_EQ(Hook::status_to_string(HookStatus::Disabling), "Disabling");
     EXPECT_EQ(Hook::status_to_string(HookStatus::Failed), "Failed");
     EXPECT_EQ(Hook::status_to_string(HookStatus::Removed), "Removed");
     EXPECT_EQ(Hook::status_to_string(static_cast<HookStatus>(999)), "Unknown");

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -2,6 +2,7 @@
 #include <functional>
 #include <thread>
 #include <chrono>
+#include <latch>
 #include <windows.h>
 
 #include "DetourModKit/hook_manager.hpp"
@@ -1058,11 +1059,13 @@ TEST_F(HookManagerTest, ConcurrentEnableDisable)
     constexpr int num_threads = 4;
     constexpr int iterations = 50;
     std::vector<std::thread> threads;
+    std::latch start_latch(num_threads);
 
     for (int i = 0; i < num_threads; ++i)
     {
-        threads.emplace_back([this, i]()
+        threads.emplace_back([this, i, &start_latch]()
                              {
+            start_latch.arrive_and_wait();
             for (int j = 0; j < iterations; ++j)
             {
                 if (j % 2 == (i % 2))
@@ -1084,6 +1087,16 @@ TEST_F(HookManagerTest, ConcurrentEnableDisable)
     auto status = hook_manager_->get_hook_status("ConcurrentHook");
     ASSERT_TRUE(status.has_value());
     EXPECT_TRUE(*status == HookStatus::Active || *status == HookStatus::Disabled);
+
+    EXPECT_TRUE(hook_manager_->disable_hook("ConcurrentHook"));
+    EXPECT_EQ(*hook_manager_->get_hook_status("ConcurrentHook"), HookStatus::Disabled);
+    int disabled_result = real_hook_target_add(2, 3);
+    EXPECT_EQ(disabled_result, 5);
+
+    EXPECT_TRUE(hook_manager_->enable_hook("ConcurrentHook"));
+    EXPECT_EQ(*hook_manager_->get_hook_status("ConcurrentHook"), HookStatus::Active);
+    int enabled_result = real_hook_target_add(2, 3);
+    EXPECT_NE(enabled_result, 5);
 }
 
 TEST_F(HookManagerTest, WithInlineHook_DirectEnableDisable)
@@ -1195,7 +1208,8 @@ TEST_F(HookManagerTest, RealInlineHook_DisabledEnableDisableCycle)
     EXPECT_TRUE(hook_manager_->disable_hook("InlineDisabled"));
     EXPECT_EQ(*hook_manager_->get_hook_status("InlineDisabled"), HookStatus::Disabled);
 
-    EXPECT_TRUE(hook_manager_->remove_hook("InlineDisabled"));
+    [[maybe_unused]] bool removed = hook_manager_->remove_hook("InlineDisabled");
+    EXPECT_TRUE(removed);
 }
 
 TEST_F(HookManagerTest, WithInlineHook_CallbackExecutesSuccessfully)
@@ -1321,6 +1335,7 @@ TEST_F(HookManagerTest, InlineHook_GetOriginal_Noexcept)
         "NoexceptHook",
         [](InlineHook &hook) -> bool
         {
+            static_assert(noexcept(hook.get_original<int (*)(int, int)>()));
             auto orig = hook.get_original<int (*)(int, int)>();
             return orig != nullptr;
         });
@@ -1342,6 +1357,7 @@ TEST_F(HookManagerTest, MidHook_GetDestination_Noexcept)
         "NoexceptMidHook",
         [](MidHook &hook) -> bool
         {
+            static_assert(noexcept(hook.get_destination()));
             auto dest = hook.get_destination();
             return dest != nullptr;
         });


### PR DESCRIPTION
## Summary

Optimize HookManager for high-frequency hook scenarios (e.g., per-frame game
hooks on player state, camera update) by making hook status transitions lock-free
and reducing mutex contention across the public API.

## Changes

### Lock-free status transitions (`Hook` base class)
- Changed `m_status` from `HookStatus` to `std::atomic<HookStatus>`
- Rewrote `enable()`/`disable()` using atomic compare-and-swap (CAS):
  only one thread wins the transition, losers return immediately
- `get_status()` and `is_enabled()` now use `memory_order_acquire` loads,
  readable from any thread without holding a lock
- This allows safe `hook.enable()`/`hook.disable()` calls directly on a
  `Hook&` reference from within `with_inline_hook`/`with_mid_hook` callbacks
  without deadlock risk

### Reduced lock contention (`HookManager`)
- `enable_hook()`/`disable_hook()` downgraded from `unique_lock` (exclusive)
  to `shared_lock` (reader) since they no longer mutate the hook map — only
  the atomic status field on individual hooks
- Multiple threads can now enable/disable different hooks concurrently without
  blocking each other or blocking `with_*_hook` readers

### API hardening
- `HookManager` constructor moved to `private` to enforce the singleton pattern
  and prevent accidental creation of additional instances
- Added `[[nodiscard]]` to `remove_hook()` to prevent silently ignored failures
- Added `requires std::invocable<F, HookT&>` concept constraints to all
  `with_*_hook` / `try_with_*_hook` templates for clearer compile-time errors

### Cleanup
- Removed unused `get_hook_raw_ptr_locked()` (dead code)

## Tests

- Fixed all `[[nodiscard]]` warnings on `remove_hook` calls in existing tests
- Added `ConcurrentEnableDisable`: 4 threads × 50 iterations toggling the
  same hook — validates atomic CAS under contention
- Added `WithInlineHook_DirectEnableDisable`: calls `hook.enable()`/`disable()`
  directly from a `with_inline_hook` callback — validates lock-free transitions
  work without deadlock
- Added `WithMidHook_DirectEnableDisable`: same pattern for mid hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Thread-safe, lock-free enable/disable with clearer runtime logging and two new intermediate statuses (Enabling/Disabling).

* **API Changes**
  * Accessors tightened (noexcept/type constraints); reentrancy now fails safely at runtime instead of asserting; removal/status queries return actionable booleans.

* **Tests**
  * Expanded tests for concurrent enable/disable, callback execution/return behavior, lifecycle states, and noexcept/accessor guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->