### PR TITLE
fix(memory): resolve concurrency bugs and LRU correctness in cache subsystem

### DIFF
--- a/include/DetourModKit/memory.hpp
+++ b/include/DetourModKit/memory.hpp
@@ -61,8 +61,9 @@ namespace DetourModKit
          * @param cache_size The desired number of entries in the cache. Defaults to 256.
          * @param expiry_ms Cache entry expiry time in milliseconds. Defaults to 50ms.
          * @param shard_count Number of cache shards for concurrent access. Defaults to 16.
-         * @return true if this call performed initialization, false if already initialized.
-         * @note Only the first call to init_cache has effect; subsequent calls return false.
+         * @return true if the cache is ready for use (newly or previously initialized), false on failure.
+         * @note Only the first call configures the cache; subsequent calls return true without reconfiguring.
+         *       To reconfigure, call shutdown_cache() first.
          * @note Starts a background cleanup thread that runs periodically.
          */
         bool init_cache(size_t cache_size = DEFAULT_CACHE_SIZE,

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -810,12 +810,18 @@ void DetourModKit::Memory::shutdown_cache()
 
     // Mark as not initialized and zero shard count.
     // This prevents new readers from entering the critical section.
-    MemoryUtilsCacheInternal::s_cacheInitialized.store(false, std::memory_order_release);
-    MemoryUtilsCacheInternal::s_shardCount.store(0, std::memory_order_release);
+    //
+    // seq_cst is required here and on the reader side to establish a Dekker-style
+    // ordering between s_shardCount (written here, read by readers) and
+    // s_activeReaders (written by readers, read below). Without a single total
+    // order, a reader could observe the old shard count after we observe zero
+    // active readers, leading to use-after-free on the destroyed data structures.
+    MemoryUtilsCacheInternal::s_cacheInitialized.store(false, std::memory_order_seq_cst);
+    MemoryUtilsCacheInternal::s_shardCount.store(0, std::memory_order_seq_cst);
 
     // Wait for in-flight readers to finish before destroying data structures.
     // Readers increment s_activeReaders on entry and decrement on exit.
-    while (MemoryUtilsCacheInternal::s_activeReaders.load(std::memory_order_acquire) > 0)
+    while (MemoryUtilsCacheInternal::s_activeReaders.load(std::memory_order_seq_cst) > 0)
     {
         std::this_thread::yield();
     }
@@ -856,8 +862,8 @@ std::string DetourModKit::Memory::get_cache_stats()
     size_t total_entries = 0;
     size_t total_hard_max = 0;
 
-    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_acq_rel);
-    const size_t active_shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_acquire);
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_seq_cst);
+    const size_t active_shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_seq_cst);
     for (size_t i = 0; i < active_shard_count; ++i)
     {
         total_entries += MemoryUtilsCacheInternal::s_cacheShards[i].entries.size();
@@ -896,9 +902,9 @@ void DetourModKit::Memory::invalidate_range(const void *address, size_t size)
     if (!MemoryUtilsCacheInternal::s_cacheInitialized.load(std::memory_order_acquire))
         return;
 
-    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_acq_rel);
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_seq_cst);
 
-    const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_acquire);
+    const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_seq_cst);
     if (shard_count == 0)
     {
         MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
@@ -921,9 +927,9 @@ bool DetourModKit::Memory::is_readable(const void *address, size_t size)
     DetourModKit::Memory::init_cache();
 
     // Register as active reader to prevent shutdown from destroying data structures
-    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_acq_rel);
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_seq_cst);
 
-    const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_acquire);
+    const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_seq_cst);
     if (shard_count == 0)
     {
         MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
@@ -993,9 +999,9 @@ bool DetourModKit::Memory::is_writable(void *address, size_t size)
     DetourModKit::Memory::init_cache();
 
     // Register as active reader to prevent shutdown from destroying data structures
-    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_acq_rel);
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_seq_cst);
 
-    const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_acquire);
+    const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_seq_cst);
     if (shard_count == 0)
     {
         MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -5,9 +5,10 @@
  * Provides functions for checking memory readability and writability, writing bytes to memory,
  * and managing a memory region cache for performance optimization.
  * The cache uses sharded locks with shared_mutex for high-concurrency read-heavy access.
- * Uses timestamp-keyed map for O(log n) LRU eviction instead of O(n) scan.
+ * Uses monotonic counter-keyed map for O(log n) LRU eviction instead of O(n) scan.
  * In-flight query coalescing prevents cache stampede under high concurrency.
  * On-demand cleanup handles expired entry removal to avoid polluting the miss path.
+ * Active reader count prevents use-after-free during shutdown.
  */
 
 #include "DetourModKit/memory.hpp"
@@ -76,8 +77,8 @@ namespace
     {
         // Map from baseAddress -> CachedMemoryRegionInfo for O(log n) lookup by address
         std::unordered_map<uintptr_t, CachedMemoryRegionInfo> entries;
-        // Map from composite_key -> baseAddress for O(log n) oldest-entry lookup (LRU)
-        // composite_key = (timestamp_ns << 32) | entry_counter to guarantee uniqueness
+        // Map from monotonic counter -> baseAddress for O(log n) oldest-entry lookup (LRU)
+        // Monotonic counter guarantees insertion-order uniqueness for correct eviction
         std::map<uint64_t, uintptr_t> lru_index;
         uint64_t entry_counter{0};
         size_t capacity;
@@ -129,6 +130,11 @@ namespace MemoryUtilsCacheInternal
     // Global cache state mutex to serialize init/clear/shutdown transitions
     // Protects against concurrent state changes that could leave vectors in invalid state
     std::mutex s_cacheStateMutex;
+
+    // Active reader count to prevent use-after-free during shutdown.
+    // Readers increment on entry to is_readable/is_writable and decrement on exit.
+    // shutdown_cache waits for this to reach zero before destroying data structures.
+    std::atomic<int32_t> s_activeReaders{0};
 
     // Background cleanup thread
     std::atomic<bool> s_cleanupThreadRunning{false};
@@ -198,13 +204,12 @@ namespace MemoryUtilsCacheInternal
     }
 
     /**
-     * @brief Finds, validates, and optionally refreshes a cache entry in a shard.
+     * @brief Finds and validates a cache entry in a shard.
      * @param shard The cache shard to search.
      * @param address Address to look up (page-aligned for lookup).
      * @param size Size of the query range.
      * @param current_time_ns Current timestamp in nanoseconds.
      * @param expiry_ns Expiry time in nanoseconds.
-     * @param touch If true, refresh the entry timestamp on hit (LRU update).
      * @return Pointer to the matching entry, or nullptr if not found or expired.
      * @note Must be called with shard mutex held (shared or exclusive).
      */
@@ -265,15 +270,13 @@ namespace MemoryUtilsCacheInternal
     }
 
     /**
-     * @brief Generates a unique composite LRU key from timestamp and counter.
-     * @param shard The cache shard to generate key for.
-     * @param current_time_ns Current timestamp in nanoseconds.
-     * @return A unique 64-bit key: (timestamp << 32) | counter
-     * @note The counter ensures uniqueness even if multiple entries have the same timestamp.
+     * @brief Generates a unique monotonic LRU key from a per-shard counter.
+     * @param counter The shard's monotonically increasing entry counter.
+     * @return A unique 64-bit key that preserves insertion order for LRU eviction.
      */
-    constexpr inline uint64_t generate_lru_key(uint64_t current_time_ns, uint64_t counter) noexcept
+    constexpr inline uint64_t generate_lru_key(uint64_t counter) noexcept
     {
-        return (current_time_ns << 32) | (counter & 0xFFFFFFFFULL);
+        return counter;
     }
 
     /**
@@ -298,8 +301,8 @@ namespace MemoryUtilsCacheInternal
                 shard.lru_index.erase(lru_it);
             }
 
-            // Update existing entry with new composite LRU key
-            const uint64_t new_lru_key = generate_lru_key(current_time_ns, shard.entry_counter++);
+            // Update existing entry with new monotonic LRU key
+            const uint64_t new_lru_key = generate_lru_key(shard.entry_counter++);
             old_entry.baseAddress = base_addr;
             old_entry.regionSize = mbi.RegionSize;
             old_entry.protection = mbi.Protect;
@@ -324,8 +327,8 @@ namespace MemoryUtilsCacheInternal
                 trim_to_max_capacity(shard);
             }
 
-            // Generate unique composite LRU key
-            const uint64_t new_lru_key = generate_lru_key(current_time_ns, shard.entry_counter++);
+            // Generate unique monotonic LRU key
+            const uint64_t new_lru_key = generate_lru_key(shard.entry_counter++);
 
             CachedMemoryRegionInfo new_entry;
             new_entry.baseAddress = base_addr;
@@ -752,10 +755,9 @@ bool DetourModKit::Memory::init_cache(size_t cache_size, unsigned int expiry_ms,
 
 void DetourModKit::Memory::clear_cache()
 {
-    // Hold state mutex to prevent concurrent shutdown and serialize with cleanup thread
+    // Hold state mutex to serialize with shutdown and cleanup thread
     std::lock_guard<std::mutex> state_lock(MemoryUtilsCacheInternal::s_cacheStateMutex);
 
-    // Check if cache is still valid (not shutdown during lock acquisition)
     if (!MemoryUtilsCacheInternal::s_cacheInitialized.load(std::memory_order_acquire))
         return;
 
@@ -763,33 +765,21 @@ void DetourModKit::Memory::clear_cache()
     if (shard_count == 0)
         return;
 
-    // Signal cleanup thread to pause and prevent interference during clear
-    // This ensures no concurrent access to shard mutexes while we clear
-    MemoryUtilsCacheInternal::s_cleanupThreadRunning.store(false, std::memory_order_relaxed);
-
+    // Acquire exclusive lock on each shard and clear entries.
+    // Uses blocking lock to guarantee all entries are cleared.
+    // The background cleanup thread uses try_to_lock on shard mutexes,
+    // so it will skip shards we hold without deadlocking.
     for (size_t i = 0; i < shard_count; ++i)
     {
         auto &mutex_ptr = MemoryUtilsCacheInternal::s_shardMutexes[i];
         if (mutex_ptr)
         {
-            // Use try_lock to avoid blocking if mutex is in bad state (MinGW compatibility)
-            std::unique_lock<std::shared_mutex> lock(*mutex_ptr, std::try_to_lock);
-            if (lock.owns_lock())
-            {
-                MemoryUtilsCacheInternal::s_cacheShards[i].entries.clear();
-                MemoryUtilsCacheInternal::s_cacheShards[i].lru_index.clear();
-                MemoryUtilsCacheInternal::s_inFlight[i].store(0, std::memory_order_relaxed);
-            }
-            else
-            {
-                // Could not acquire lock - reset in-flight flag to unblock any waiters
-                MemoryUtilsCacheInternal::s_inFlight[i].store(0, std::memory_order_relaxed);
-            }
+            std::unique_lock<std::shared_mutex> shard_lock(*mutex_ptr);
+            MemoryUtilsCacheInternal::s_cacheShards[i].entries.clear();
+            MemoryUtilsCacheInternal::s_cacheShards[i].lru_index.clear();
+            MemoryUtilsCacheInternal::s_inFlight[i].store(0, std::memory_order_relaxed);
         }
     }
-
-    // Restart cleanup thread
-    MemoryUtilsCacheInternal::s_cleanupThreadRunning.store(true, std::memory_order_release);
 
     MemoryUtilsCacheInternal::s_stats.cacheHits.store(0, std::memory_order_relaxed);
     MemoryUtilsCacheInternal::s_stats.cacheMisses.store(0, std::memory_order_relaxed);
@@ -804,26 +794,39 @@ void DetourModKit::Memory::clear_cache()
 
 void DetourModKit::Memory::shutdown_cache()
 {
-    // Acquire state lock first to prevent concurrent clear_cache
-    std::lock_guard<std::mutex> state_lock(MemoryUtilsCacheInternal::s_cacheStateMutex);
-
-    // Signal cleanup thread to stop first
+    // Signal and join cleanup thread BEFORE acquiring state mutex.
+    // The cleanup thread acquires s_cacheStateMutex in cleanup_expired_entries(force=true),
+    // so joining while holding the state mutex would deadlock.
     MemoryUtilsCacheInternal::s_cleanupThreadRunning.store(false, std::memory_order_release);
     MemoryUtilsCacheInternal::s_cleanupCv.notify_one();
 
-    // Wait for cleanup thread to finish
     if (MemoryUtilsCacheInternal::s_cleanupThread.joinable())
     {
         MemoryUtilsCacheInternal::s_cleanupThread.join();
     }
 
-    // Now safe to clear data structures
-    const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_acquire);
+    // Acquire state mutex to serialize with clear_cache and protect data teardown
+    std::lock_guard<std::mutex> state_lock(MemoryUtilsCacheInternal::s_cacheStateMutex);
+
+    // Mark as not initialized and zero shard count.
+    // This prevents new readers from entering the critical section.
+    MemoryUtilsCacheInternal::s_cacheInitialized.store(false, std::memory_order_release);
+    MemoryUtilsCacheInternal::s_shardCount.store(0, std::memory_order_release);
+
+    // Wait for in-flight readers to finish before destroying data structures.
+    // Readers increment s_activeReaders on entry and decrement on exit.
+    while (MemoryUtilsCacheInternal::s_activeReaders.load(std::memory_order_acquire) > 0)
+    {
+        std::this_thread::yield();
+    }
+
+    // All readers have exited - safe to destroy data structures
+    const size_t shard_count = MemoryUtilsCacheInternal::s_cacheShards.size();
     for (size_t i = 0; i < shard_count; ++i)
     {
         if (MemoryUtilsCacheInternal::s_shardMutexes[i])
         {
-            std::unique_lock<std::shared_mutex> lock(*MemoryUtilsCacheInternal::s_shardMutexes[i]);
+            std::unique_lock<std::shared_mutex> shard_lock(*MemoryUtilsCacheInternal::s_shardMutexes[i]);
             MemoryUtilsCacheInternal::s_cacheShards[i].entries.clear();
             MemoryUtilsCacheInternal::s_cacheShards[i].lru_index.clear();
         }
@@ -832,9 +835,6 @@ void DetourModKit::Memory::shutdown_cache()
     MemoryUtilsCacheInternal::s_cacheShards.clear();
     MemoryUtilsCacheInternal::s_shardMutexes.clear();
     MemoryUtilsCacheInternal::s_inFlight.reset();
-
-    MemoryUtilsCacheInternal::s_cacheInitialized.store(false, std::memory_order_relaxed);
-    MemoryUtilsCacheInternal::s_shardCount.store(0, std::memory_order_relaxed);
 
     Logger::get_instance().debug("MemoryCache: Shutdown complete.");
 }
@@ -852,14 +852,18 @@ std::string DetourModKit::Memory::get_cache_stats()
     const size_t max_entries_per_shard = MemoryUtilsCacheInternal::s_maxEntriesPerShard.load(std::memory_order_acquire);
     const unsigned int expiry_ms = MemoryUtilsCacheInternal::s_configuredExpiryMs.load(std::memory_order_acquire);
 
-    // Calculate total entries and hard max
+    // Calculate total entries and hard max with reader guard
     size_t total_entries = 0;
     size_t total_hard_max = 0;
-    for (size_t i = 0; i < shard_count; ++i)
+
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_acq_rel);
+    const size_t active_shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_acquire);
+    for (size_t i = 0; i < active_shard_count; ++i)
     {
         total_entries += MemoryUtilsCacheInternal::s_cacheShards[i].entries.size();
         total_hard_max += MemoryUtilsCacheInternal::s_cacheShards[i].max_capacity;
     }
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
 
     std::ostringstream oss;
     oss << "MemoryCache Stats (Shards: " << shard_count
@@ -889,8 +893,23 @@ void DetourModKit::Memory::invalidate_range(const void *address, size_t size)
     if (!address || size == 0)
         return;
 
+    if (!MemoryUtilsCacheInternal::s_cacheInitialized.load(std::memory_order_acquire))
+        return;
+
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_acq_rel);
+
+    const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_acquire);
+    if (shard_count == 0)
+    {
+        MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
+        return;
+    }
+
     const uintptr_t addr_val = reinterpret_cast<uintptr_t>(address);
     MemoryUtilsCacheInternal::invalidate_range_internal(addr_val, size);
+
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
+
     MemoryUtilsCacheInternal::request_cleanup();
 }
 
@@ -901,18 +920,22 @@ bool DetourModKit::Memory::is_readable(const void *address, size_t size)
 
     DetourModKit::Memory::init_cache();
 
-    const uintptr_t query_addr_val = reinterpret_cast<uintptr_t>(address);
+    // Register as active reader to prevent shutdown from destroying data structures
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_acq_rel);
+
     const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_acquire);
-
     if (shard_count == 0)
+    {
+        MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
         return false;
+    }
 
+    const uintptr_t query_addr_val = reinterpret_cast<uintptr_t>(address);
     const size_t shard_idx = compute_shard_index(query_addr_val, shard_count);
     const uint64_t now_ns = current_time_ns();
     const uint64_t expiry_ns = static_cast<uint64_t>(MemoryUtilsCacheInternal::s_configuredExpiryMs.load(std::memory_order_acquire)) * 1'000'000ULL;
 
     // Fast path: shared lock for concurrent read access (multiple readers allowed)
-    // Also touch=true to refresh LRU timestamp on hit for frequently-accessed addresses
     {
         std::shared_lock<std::shared_mutex> lock(*MemoryUtilsCacheInternal::s_shardMutexes[shard_idx], std::try_to_lock);
         if (lock.owns_lock())
@@ -924,6 +947,7 @@ bool DetourModKit::Memory::is_readable(const void *address, size_t size)
             {
                 const bool result = MemoryUtilsCacheInternal::check_read_permission(cached_info->protection);
                 MemoryUtilsCacheInternal::s_stats.cacheHits.fetch_add(1, std::memory_order_relaxed);
+                MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
                 return result;
             }
         }
@@ -934,7 +958,12 @@ bool DetourModKit::Memory::is_readable(const void *address, size_t size)
     // Cache miss: call VirtualQuery with stampede coalescing
     MEMORY_BASIC_INFORMATION mbi;
     if (!MemoryUtilsCacheInternal::query_and_update_cache(shard_idx, address, mbi))
+    {
+        MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
         return false;
+    }
+
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
 
     if (mbi.State != MEM_COMMIT)
         return false;
@@ -953,9 +982,6 @@ bool DetourModKit::Memory::is_readable(const void *address, size_t size)
     if (!is_fully_contained)
         return false;
 
-    // Signal background cleanup thread or trigger on-demand cleanup
-    MemoryUtilsCacheInternal::request_cleanup();
-
     return true;
 }
 
@@ -966,18 +992,22 @@ bool DetourModKit::Memory::is_writable(void *address, size_t size)
 
     DetourModKit::Memory::init_cache();
 
-    const uintptr_t query_addr_val = reinterpret_cast<uintptr_t>(address);
+    // Register as active reader to prevent shutdown from destroying data structures
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_add(1, std::memory_order_acq_rel);
+
     const size_t shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_acquire);
-
     if (shard_count == 0)
+    {
+        MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
         return false;
+    }
 
+    const uintptr_t query_addr_val = reinterpret_cast<uintptr_t>(address);
     const size_t shard_idx = compute_shard_index(query_addr_val, shard_count);
     const uint64_t now_ns = current_time_ns();
     const uint64_t expiry_ns = static_cast<uint64_t>(MemoryUtilsCacheInternal::s_configuredExpiryMs.load(std::memory_order_acquire)) * 1'000'000ULL;
 
-    // Fast path: shared lock for concurrent read access
-    // Also touch=true to refresh LRU timestamp on hit for frequently-accessed addresses
+    // Fast path: shared lock for concurrent read access (multiple readers allowed)
     {
         std::shared_lock<std::shared_mutex> lock(*MemoryUtilsCacheInternal::s_shardMutexes[shard_idx], std::try_to_lock);
         if (lock.owns_lock())
@@ -989,6 +1019,7 @@ bool DetourModKit::Memory::is_writable(void *address, size_t size)
             {
                 const bool result = MemoryUtilsCacheInternal::check_write_permission(cached_info->protection);
                 MemoryUtilsCacheInternal::s_stats.cacheHits.fetch_add(1, std::memory_order_relaxed);
+                MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
                 return result;
             }
         }
@@ -998,7 +1029,12 @@ bool DetourModKit::Memory::is_writable(void *address, size_t size)
 
     MEMORY_BASIC_INFORMATION mbi;
     if (!MemoryUtilsCacheInternal::query_and_update_cache(shard_idx, address, mbi))
+    {
+        MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
         return false;
+    }
+
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
 
     if (mbi.State != MEM_COMMIT)
         return false;
@@ -1016,9 +1052,6 @@ bool DetourModKit::Memory::is_writable(void *address, size_t size)
     const bool is_fully_contained = query_addr_val >= region_start_addr && query_end_addr <= region_end_addr;
     if (!is_fully_contained)
         return false;
-
-    // Signal background cleanup thread or trigger on-demand cleanup
-    MemoryUtilsCacheInternal::request_cleanup();
 
     return true;
 }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -842,6 +842,17 @@ void DetourModKit::Memory::shutdown_cache()
     MemoryUtilsCacheInternal::s_shardMutexes.clear();
     MemoryUtilsCacheInternal::s_inFlight.reset();
 
+    // Reset all stats and config so a subsequent init_cache starts from a clean state
+    MemoryUtilsCacheInternal::s_stats.cacheHits.store(0, std::memory_order_relaxed);
+    MemoryUtilsCacheInternal::s_stats.cacheMisses.store(0, std::memory_order_relaxed);
+    MemoryUtilsCacheInternal::s_stats.invalidations.store(0, std::memory_order_relaxed);
+    MemoryUtilsCacheInternal::s_stats.coalescedQueries.store(0, std::memory_order_relaxed);
+    MemoryUtilsCacheInternal::s_stats.onDemandCleanups.store(0, std::memory_order_relaxed);
+    MemoryUtilsCacheInternal::s_lastCleanupTimeNs.store(0, std::memory_order_relaxed);
+    MemoryUtilsCacheInternal::s_configuredExpiryMs.store(0, std::memory_order_relaxed);
+    MemoryUtilsCacheInternal::s_activeReaders.store(0, std::memory_order_relaxed);
+    MemoryUtilsCacheInternal::s_cleanupRequested.store(false, std::memory_order_relaxed);
+
     Logger::get_instance().debug("MemoryCache: Shutdown complete.");
 }
 
@@ -866,8 +877,13 @@ std::string DetourModKit::Memory::get_cache_stats()
     const size_t active_shard_count = MemoryUtilsCacheInternal::s_shardCount.load(std::memory_order_seq_cst);
     for (size_t i = 0; i < active_shard_count; ++i)
     {
-        total_entries += MemoryUtilsCacheInternal::s_cacheShards[i].entries.size();
-        total_hard_max += MemoryUtilsCacheInternal::s_cacheShards[i].max_capacity;
+        auto &mutex_ptr = MemoryUtilsCacheInternal::s_shardMutexes[i];
+        if (mutex_ptr)
+        {
+            std::shared_lock<std::shared_mutex> shard_lock(*mutex_ptr);
+            total_entries += MemoryUtilsCacheInternal::s_cacheShards[i].entries.size();
+            total_hard_max += MemoryUtilsCacheInternal::s_cacheShards[i].max_capacity;
+        }
     }
     MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
 
@@ -914,9 +930,12 @@ void DetourModKit::Memory::invalidate_range(const void *address, size_t size)
     const uintptr_t addr_val = reinterpret_cast<uintptr_t>(address);
     MemoryUtilsCacheInternal::invalidate_range_internal(addr_val, size);
 
-    MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
-
+    // request_cleanup may trigger on-demand cleanup_expired_entries(force=false)
+    // which iterates shards without s_cacheStateMutex. Keep s_activeReaders > 0
+    // so shutdown_cache cannot destroy shards during the cleanup pass.
     MemoryUtilsCacheInternal::request_cleanup();
+
+    MemoryUtilsCacheInternal::s_activeReaders.fetch_sub(1, std::memory_order_release);
 }
 
 bool DetourModKit::Memory::is_readable(const void *address, size_t size)

--- a/tests/test_memory.cpp
+++ b/tests/test_memory.cpp
@@ -25,19 +25,7 @@ protected:
     }
 };
 
-class MemoryTestWithShutdown : public ::testing::Test
-{
-protected:
-    void SetUp() override
-    {
-        Memory::init_cache();
-    }
 
-    void TearDown() override
-    {
-        Memory::shutdown_cache();
-    }
-};
 
 TEST_F(MemoryTest, InitMemoryCache)
 {
@@ -232,33 +220,6 @@ TEST_F(MemoryTest, MultipleRegions)
     EXPECT_TRUE(Memory::is_readable(buffer2, sizeof(buffer2)));
     EXPECT_TRUE(Memory::is_writable(buffer1, sizeof(buffer1)));
     EXPECT_TRUE(Memory::is_writable(buffer2, sizeof(buffer2)));
-}
-
-TEST_F(MemoryTest, ThreadSafety)
-{
-    const int num_threads = 4;
-    const int iterations = 100;
-
-    std::vector<std::thread> threads;
-
-    for (int i = 0; i < num_threads; ++i)
-    {
-        threads.emplace_back([iterations]()
-                             {
-            char buffer[100] = {0};
-            for (int j = 0; j < iterations; ++j)
-            {
-                Memory::is_readable(buffer, sizeof(buffer));
-                Memory::is_writable(buffer, sizeof(buffer));
-            } });
-    }
-
-    for (auto &t : threads)
-    {
-        t.join();
-    }
-
-    SUCCEED();
 }
 
 TEST_F(MemoryTest, CacheAfterClear)
@@ -846,10 +807,10 @@ TEST_F(MemoryTest, InvalidateRangeIncrementsCounter)
 TEST_F(MemoryTest, HardUpperBoundEnforced)
 {
     Memory::shutdown_cache();
-    // Initialize with 2 entries capacity per shard (with 2x hard max = 4)
+    // 1 shard, capacity=2, hard_max = capacity * 2 = 4
     Memory::init_cache(2, 60000, 1);
 
-    // Allocate multiple pages in different regions to force cache growth
+    // Allocate 10 distinct pages to force cache past capacity
     std::vector<void *> regions;
     for (int i = 0; i < 10; ++i)
     {
@@ -859,37 +820,35 @@ TEST_F(MemoryTest, HardUpperBoundEnforced)
         EXPECT_TRUE(Memory::is_readable(mem, 1));
     }
 
-    // Check stats to see total entries
     std::string stats = Memory::get_cache_stats();
-    EXPECT_NE(stats.find("TotalEntries:"), std::string::npos);
+    // Extract TotalEntries value and verify it respects hard upper bound
+    auto pos = stats.find("TotalEntries: ");
+    ASSERT_NE(pos, std::string::npos);
+    size_t total_entries = std::stoull(stats.substr(pos + 14));
+    EXPECT_LE(total_entries, 4u);
 
-    // Cleanup
     for (void *mem : regions)
     {
         VirtualFree(mem, 0, MEM_RELEASE);
     }
 }
 
-TEST_F(MemoryTestWithShutdown, BackgroundCleanupThreadRuns)
+TEST_F(MemoryTest, BackgroundCleanupThreadRuns)
 {
+    Memory::shutdown_cache();
+    Memory::init_cache(16, 10, 4);
+
     char buffer[100] = {0};
     EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
 
-    // Wait for background cleanup to run at least once
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    // Wait long enough for background cleanup to process expired entries (10ms expiry + interval)
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
-    // Cache should still work
-    EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
-}
-
-TEST_F(MemoryTestWithShutdown, ShutdownCacheTerminatesCleanupThread)
-{
-    char buffer[100] = {0};
+    // Cache should still work after background cleanup
     EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
 
-    // Shutdown is called automatically in TearDown
-    // Just verify the cache functions before shutdown
-    EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
+    std::string stats = Memory::get_cache_stats();
+    EXPECT_FALSE(stats.empty());
 }
 
 TEST_F(MemoryTest, InvalidateRangeTriggersBackgroundCleanup)
@@ -907,41 +866,6 @@ TEST_F(MemoryTest, InvalidateRangeTriggersBackgroundCleanup)
 
     // Cache should still work after invalidation
     EXPECT_TRUE(Memory::is_readable(mem, 64));
-
-    VirtualFree(mem, 0, MEM_RELEASE);
-}
-
-TEST_F(MemoryTest, CoalescedQueriesAccumulated)
-{
-    Memory::shutdown_cache();
-    Memory::init_cache(32, 60000, 1);
-
-    void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-    ASSERT_NE(mem, nullptr);
-
-    // Multiple threads hitting same address should coalesce
-    const int num_threads = 8;
-    const int iterations = 50;
-
-    std::vector<std::thread> threads;
-    for (int i = 0; i < num_threads; ++i)
-    {
-        threads.emplace_back([&]()
-                             {
-            for (int j = 0; j < iterations; ++j)
-            {
-                Memory::is_readable(mem, 64);
-            } });
-    }
-
-    for (auto &t : threads)
-    {
-        t.join();
-    }
-
-    std::string stats = Memory::get_cache_stats();
-    // Should have some coalesced queries
-    EXPECT_NE(stats.find("Coalesced:"), std::string::npos);
 
     VirtualFree(mem, 0, MEM_RELEASE);
 }
@@ -985,7 +909,7 @@ TEST_F(MemoryTest, ClearCacheResetsOnDemandCleanupStat)
     EXPECT_NE(stats.find("OnDemandCleanups: 0"), std::string::npos);
 }
 
-TEST_F(MemoryTest, OnDemandCleanupFiresOnInterval)
+TEST_F(MemoryTest, ExpiredEntryTriggersReFetch)
 {
     Memory::shutdown_cache();
     Memory::init_cache(16, 10, 4);
@@ -993,17 +917,21 @@ TEST_F(MemoryTest, OnDemandCleanupFiresOnInterval)
     char buffer[100] = {0};
     EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
 
-    // Wait for on-demand cleanup interval (1 second) to potentially trigger
-    // In practice, this test verifies the mechanism exists without blocking too long
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Wait for cache entry to expire (10ms expiry)
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
+    // Re-query should succeed (re-fetch from OS) and register as a miss
     EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
 
     std::string stats = Memory::get_cache_stats();
-    EXPECT_FALSE(stats.empty());
+    // At least 1 miss from the expired-entry re-fetch
+    auto pos = stats.find("Misses: ");
+    ASSERT_NE(pos, std::string::npos);
+    uint64_t misses = std::stoull(stats.substr(pos + 8));
+    EXPECT_GE(misses, 1u);
 }
 
-TEST_F(MemoryTest, CacheStampedeFollowerYields)
+TEST_F(MemoryTest, CacheHitPerformance_SingleThread)
 {
     Memory::shutdown_cache();
     Memory::init_cache(32, 60000, 1);
@@ -1011,36 +939,16 @@ TEST_F(MemoryTest, CacheStampedeFollowerYields)
     void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
     ASSERT_NE(mem, nullptr);
 
-    // Single thread repeatedly accessing - should complete quickly without yielding
     auto start = std::chrono::high_resolution_clock::now();
-    for (int i = 0; i < 100; ++i)
+    for (int i = 0; i < 1000; ++i)
     {
         EXPECT_TRUE(Memory::is_readable(mem, 64));
     }
     auto end = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 
-    // Should be fast - no exponential backoff sleep since cache hits
+    // 1000 cache-hit reads should complete well under 1 second
     EXPECT_LT(duration, 1000);
-
-    VirtualFree(mem, 0, MEM_RELEASE);
-}
-
-TEST_F(MemoryTest, OnDemandCleanupAfterLongDelay)
-{
-    Memory::shutdown_cache();
-    Memory::init_cache(16, 20, 4);
-
-    void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
-    ASSERT_NE(mem, nullptr);
-
-    EXPECT_TRUE(Memory::is_readable(mem, 64));
-
-    // Wait for entries to potentially expire
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    // Should still work - either cache hit with refreshed timestamp or miss with re-query
-    EXPECT_TRUE(Memory::is_readable(mem, 64));
 
     VirtualFree(mem, 0, MEM_RELEASE);
 }
@@ -1052,4 +960,71 @@ TEST_F(MemoryTest, CacheStatsIncludeHardMax)
 
     std::string stats = Memory::get_cache_stats();
     EXPECT_NE(stats.find("HardMax/Shard:"), std::string::npos);
+}
+
+TEST_F(MemoryTest, ShutdownAfterConcurrentWorkload)
+{
+    Memory::shutdown_cache();
+    Memory::init_cache(32, 60000, 4);
+
+    void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    ASSERT_NE(mem, nullptr);
+
+    std::atomic<bool> keep_reading{true};
+    std::atomic<int> reads_completed{0};
+
+    const int num_threads = 4;
+    std::vector<std::thread> readers;
+    for (int i = 0; i < num_threads; ++i)
+    {
+        readers.emplace_back([&]()
+                             {
+            while (keep_reading.load(std::memory_order_acquire))
+            {
+                Memory::is_readable(mem, 64);
+                reads_completed.fetch_add(1, std::memory_order_relaxed);
+            } });
+    }
+
+    while (reads_completed.load(std::memory_order_relaxed) < 1000)
+    {
+        std::this_thread::yield();
+    }
+
+    keep_reading.store(false, std::memory_order_release);
+
+    for (auto &t : readers)
+    {
+        t.join();
+    }
+
+    // Shutdown after heavy concurrent usage must complete cleanly
+    Memory::shutdown_cache();
+
+    // Re-init and verify cache still works after teardown
+    EXPECT_TRUE(Memory::init_cache());
+    EXPECT_TRUE(Memory::is_readable(mem, 64));
+
+    VirtualFree(mem, 0, MEM_RELEASE);
+}
+
+TEST_F(MemoryTest, ReinitAfterShutdown_DataIntegrity)
+{
+    void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    ASSERT_NE(mem, nullptr);
+
+    for (int round = 0; round < 3; ++round)
+    {
+        Memory::shutdown_cache();
+        EXPECT_TRUE(Memory::init_cache(16, 5000, 4));
+
+        EXPECT_TRUE(Memory::is_readable(mem, 64));
+        EXPECT_TRUE(Memory::is_writable(mem, 64));
+
+        std::string stats = Memory::get_cache_stats();
+        EXPECT_NE(stats.find("Hits:"), std::string::npos);
+        EXPECT_NE(stats.find("Misses:"), std::string::npos);
+    }
+
+    VirtualFree(mem, 0, MEM_RELEASE);
 }

--- a/tests/test_memory.cpp
+++ b/tests/test_memory.cpp
@@ -47,12 +47,10 @@ TEST_F(MemoryTest, InitMemoryCache)
 
 TEST_F(MemoryTest, InitMemoryCache_CustomParams)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
 
     bool result = Memory::init_cache(64, 10000);
     EXPECT_TRUE(result);
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, ClearMemoryCache)
@@ -345,7 +343,7 @@ TEST(MemoryErrorTest, ErrorToString)
 
 TEST_F(MemoryTest, CacheExpiry)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(64, 10);
 
     char buffer[100] = {0};
@@ -354,13 +352,11 @@ TEST_F(MemoryTest, CacheExpiry)
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, CacheBehavior_Overlapping)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(64, 10000);
 
     char buffer[100] = {0};
@@ -368,8 +364,6 @@ TEST_F(MemoryTest, CacheBehavior_Overlapping)
     EXPECT_TRUE(Memory::is_readable(buffer, 50));
     EXPECT_TRUE(Memory::is_readable(buffer, 100));
     EXPECT_TRUE(Memory::is_readable(buffer + 10, 40));
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, IsMemoryReadable_ReservedMemory)
@@ -454,7 +448,7 @@ TEST_F(MemoryTest, IsMemoryReadable_ExecuteReadWrite)
 
 TEST_F(MemoryTest, CacheLRUEviction)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(2, 60000);
 
     void *mem1 = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -473,8 +467,6 @@ TEST_F(MemoryTest, CacheLRUEviction)
     VirtualFree(mem1, 0, MEM_RELEASE);
     VirtualFree(mem2, 0, MEM_RELEASE);
     VirtualFree(mem3, 0, MEM_RELEASE);
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, IsMemoryReadable_SizeOverflow)
@@ -538,7 +530,7 @@ TEST_F(MemoryTest, write_bytes_Success)
 
 TEST_F(MemoryTest, IsMemoryWritable_ValidWritable)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(4, 60000);
 
     void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -549,7 +541,6 @@ TEST_F(MemoryTest, IsMemoryWritable_ValidWritable)
     EXPECT_TRUE(Memory::is_writable(mem, 1));
 
     VirtualFree(mem, 0, MEM_RELEASE);
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, write_bytes_PageReadOnly)
@@ -622,19 +613,18 @@ TEST_F(MemoryTest, IsMemoryReadable_CrossRegionBoundary)
 
 TEST_F(MemoryTest, InitCacheWithShards)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     bool result = Memory::init_cache(32, 5000, 4);
     EXPECT_TRUE(result);
 
+    // Subsequent init with different params returns true but does not reconfigure
     result = Memory::init_cache(64, 10000, 8);
     EXPECT_TRUE(result);
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, InvalidateRangeBasic)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(32, 60000, 4);
 
     char buffer[100] = {0};
@@ -654,7 +644,7 @@ TEST_F(MemoryTest, InvalidateRangeNull)
 
 TEST_F(MemoryTest, WriteBytesInvalidatesCache)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(32, 60000, 4);
 
     void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
@@ -674,12 +664,11 @@ TEST_F(MemoryTest, WriteBytesInvalidatesCache)
     EXPECT_TRUE(Memory::is_writable(target, 64));
 
     VirtualFree(mem, 0, MEM_RELEASE);
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, InvalidateRangeDoesNotAffectOtherRegions)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(32, 60000, 4);
 
     char buffer1[100] = {0};
@@ -698,19 +687,23 @@ TEST_F(MemoryTest, ThreadSafetyHighConcurrency)
 {
     const int num_threads = 8;
     const int iterations = 500;
+    std::atomic<int> success_count{0};
 
     std::vector<std::thread> threads;
 
     for (int i = 0; i < num_threads; ++i)
     {
-        threads.emplace_back([iterations, i]()
+        threads.emplace_back([iterations, i, &success_count]()
                              {
-            char buffers[4][100];
+            char buffers[4][100] = {};
             for (int j = 0; j < iterations; ++j)
             {
-                int buf_idx = (i + j) % 4;
-                Memory::is_readable(buffers[buf_idx], sizeof(buffers[buf_idx]));
-                Memory::is_writable(buffers[buf_idx], sizeof(buffers[buf_idx]));
+                const int buf_idx = (i + j) % 4;
+                if (Memory::is_readable(buffers[buf_idx], sizeof(buffers[buf_idx])) &&
+                    Memory::is_writable(buffers[buf_idx], sizeof(buffers[buf_idx])))
+                {
+                    success_count.fetch_add(1, std::memory_order_relaxed);
+                }
             } });
     }
 
@@ -719,12 +712,12 @@ TEST_F(MemoryTest, ThreadSafetyHighConcurrency)
         t.join();
     }
 
-    SUCCEED();
+    EXPECT_EQ(success_count.load(), num_threads * iterations);
 }
 
 TEST_F(MemoryTest, CacheStatsWithShards)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 5000, 4);
 
     char buffer[100] = {0};
@@ -739,7 +732,7 @@ TEST_F(MemoryTest, CacheStatsWithShards)
 
 TEST_F(MemoryTest, InvalidateRangeAcrossShards)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(8, 60000, 4);
 
     void *mem1 = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -758,12 +751,11 @@ TEST_F(MemoryTest, InvalidateRangeAcrossShards)
 
     VirtualFree(mem1, 0, MEM_RELEASE);
     VirtualFree(mem2, 0, MEM_RELEASE);
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, CacheStampedeCoalescing)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(32, 60000, 4);
 
     void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -798,12 +790,11 @@ TEST_F(MemoryTest, CacheStampedeCoalescing)
     EXPECT_NE(stats.find("Coalesced:"), std::string::npos);
 
     VirtualFree(mem, 0, MEM_RELEASE);
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, CacheStatsAvailableInRelease)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 5000, 4);
 
     char buffer[100] = {0};
@@ -818,12 +809,11 @@ TEST_F(MemoryTest, CacheStatsAvailableInRelease)
     EXPECT_NE(stats.find("Coalesced:"), std::string::npos);
     EXPECT_NE(stats.find("Hit Rate:"), std::string::npos);
 
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, ClearCacheResetsAllStats)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 5000, 4);
 
     char buffer[100] = {0};
@@ -837,13 +827,11 @@ TEST_F(MemoryTest, ClearCacheResetsAllStats)
     std::string stats = Memory::get_cache_stats();
     EXPECT_NE(stats.find("Hits: 0"), std::string::npos);
     EXPECT_NE(stats.find("Misses: 0"), std::string::npos);
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, InvalidateRangeIncrementsCounter)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 60000, 4);
 
     char buffer[100] = {0};
@@ -853,13 +841,11 @@ TEST_F(MemoryTest, InvalidateRangeIncrementsCounter)
 
     std::string stats = Memory::get_cache_stats();
     EXPECT_NE(stats.find("Invalidations:"), std::string::npos);
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, HardUpperBoundEnforced)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     // Initialize with 2 entries capacity per shard (with 2x hard max = 4)
     Memory::init_cache(2, 60000, 1);
 
@@ -882,7 +868,6 @@ TEST_F(MemoryTest, HardUpperBoundEnforced)
     {
         VirtualFree(mem, 0, MEM_RELEASE);
     }
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTestWithShutdown, BackgroundCleanupThreadRuns)
@@ -909,7 +894,7 @@ TEST_F(MemoryTestWithShutdown, ShutdownCacheTerminatesCleanupThread)
 
 TEST_F(MemoryTest, InvalidateRangeTriggersBackgroundCleanup)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 60000, 4);
 
     void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -924,12 +909,11 @@ TEST_F(MemoryTest, InvalidateRangeTriggersBackgroundCleanup)
     EXPECT_TRUE(Memory::is_readable(mem, 64));
 
     VirtualFree(mem, 0, MEM_RELEASE);
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, CoalescedQueriesAccumulated)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(32, 60000, 1);
 
     void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -960,24 +944,21 @@ TEST_F(MemoryTest, CoalescedQueriesAccumulated)
     EXPECT_NE(stats.find("Coalesced:"), std::string::npos);
 
     VirtualFree(mem, 0, MEM_RELEASE);
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, DefaultExpiryIs50ms)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     // Use default parameters (50ms expiry)
     Memory::init_cache(16, DEFAULT_CACHE_EXPIRY_MS, 4);
 
     std::string stats = Memory::get_cache_stats();
     EXPECT_NE(stats.find("Expiry: 50ms"), std::string::npos);
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, OnDemandCleanupStatExists)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 100, 4);
 
     char buffer[100] = {0};
@@ -985,13 +966,11 @@ TEST_F(MemoryTest, OnDemandCleanupStatExists)
 
     std::string stats = Memory::get_cache_stats();
     EXPECT_NE(stats.find("OnDemandCleanups:"), std::string::npos);
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, ClearCacheResetsOnDemandCleanupStat)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 100, 4);
 
     char buffer[100] = {0};
@@ -1004,13 +983,11 @@ TEST_F(MemoryTest, ClearCacheResetsOnDemandCleanupStat)
 
     std::string stats = Memory::get_cache_stats();
     EXPECT_NE(stats.find("OnDemandCleanups: 0"), std::string::npos);
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, OnDemandCleanupFiresOnInterval)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 10, 4);
 
     char buffer[100] = {0};
@@ -1024,13 +1001,11 @@ TEST_F(MemoryTest, OnDemandCleanupFiresOnInterval)
 
     std::string stats = Memory::get_cache_stats();
     EXPECT_FALSE(stats.empty());
-
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, CacheStampedeFollowerYields)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(32, 60000, 1);
 
     void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -1049,12 +1024,11 @@ TEST_F(MemoryTest, CacheStampedeFollowerYields)
     EXPECT_LT(duration, 1000);
 
     VirtualFree(mem, 0, MEM_RELEASE);
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, OnDemandCleanupAfterLongDelay)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 20, 4);
 
     void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -1069,16 +1043,13 @@ TEST_F(MemoryTest, OnDemandCleanupAfterLongDelay)
     EXPECT_TRUE(Memory::is_readable(mem, 64));
 
     VirtualFree(mem, 0, MEM_RELEASE);
-    Memory::clear_cache();
 }
 
 TEST_F(MemoryTest, CacheStatsIncludeHardMax)
 {
-    Memory::clear_cache();
+    Memory::shutdown_cache();
     Memory::init_cache(16, 5000, 4);
 
     std::string stats = Memory::get_cache_stats();
     EXPECT_NE(stats.find("HardMax/Shard:"), std::string::npos);
-
-    Memory::clear_cache();
 }

--- a/tests/test_memory.cpp
+++ b/tests/test_memory.cpp
@@ -841,10 +841,10 @@ TEST_F(MemoryTest, BackgroundCleanupThreadRuns)
     char buffer[100] = {0};
     EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
 
-    // Wait long enough for background cleanup to process expired entries (10ms expiry + interval)
-    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    // Background cleanup thread runs every 1 second; sleep long enough for at least one pass
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
 
-    // Cache should still work after background cleanup
+    // Cache should still work after background cleanup has run
     EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
 
     std::string stats = Memory::get_cache_stats();
@@ -917,18 +917,23 @@ TEST_F(MemoryTest, ExpiredEntryTriggersReFetch)
     char buffer[100] = {0};
     EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
 
+    // Capture miss count after warm-up
+    std::string stats_before = Memory::get_cache_stats();
+    auto pos_before = stats_before.find("Misses: ");
+    ASSERT_NE(pos_before, std::string::npos);
+    const uint64_t prev_misses = std::stoull(stats_before.substr(pos_before + 8));
+
     // Wait for cache entry to expire (10ms expiry)
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
 
-    // Re-query should succeed (re-fetch from OS) and register as a miss
+    // Re-query should succeed (re-fetch from OS) and register as a new miss
     EXPECT_TRUE(Memory::is_readable(buffer, sizeof(buffer)));
 
-    std::string stats = Memory::get_cache_stats();
-    // At least 1 miss from the expired-entry re-fetch
-    auto pos = stats.find("Misses: ");
-    ASSERT_NE(pos, std::string::npos);
-    uint64_t misses = std::stoull(stats.substr(pos + 8));
-    EXPECT_GE(misses, 1u);
+    std::string stats_after = Memory::get_cache_stats();
+    auto pos_after = stats_after.find("Misses: ");
+    ASSERT_NE(pos_after, std::string::npos);
+    const uint64_t misses = std::stoull(stats_after.substr(pos_after + 8));
+    EXPECT_GE(misses, prev_misses + 1u);
 }
 
 TEST_F(MemoryTest, CacheHitPerformance_SingleThread)
@@ -962,7 +967,7 @@ TEST_F(MemoryTest, CacheStatsIncludeHardMax)
     EXPECT_NE(stats.find("HardMax/Shard:"), std::string::npos);
 }
 
-TEST_F(MemoryTest, ShutdownAfterConcurrentWorkload)
+TEST_F(MemoryTest, ShutdownWhileReadersActive)
 {
     Memory::shutdown_cache();
     Memory::init_cache(32, 60000, 4);
@@ -970,8 +975,11 @@ TEST_F(MemoryTest, ShutdownAfterConcurrentWorkload)
     void *mem = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
     ASSERT_NE(mem, nullptr);
 
+    // Warm up cache so readers hit the fast path
+    EXPECT_TRUE(Memory::is_readable(mem, 64));
+
     std::atomic<bool> keep_reading{true};
-    std::atomic<int> reads_completed{0};
+    std::atomic<int> readers_entered{0};
 
     const int num_threads = 4;
     std::vector<std::thread> readers;
@@ -979,18 +987,30 @@ TEST_F(MemoryTest, ShutdownAfterConcurrentWorkload)
     {
         readers.emplace_back([&]()
                              {
+            readers_entered.fetch_add(1, std::memory_order_release);
             while (keep_reading.load(std::memory_order_acquire))
             {
                 Memory::is_readable(mem, 64);
-                reads_completed.fetch_add(1, std::memory_order_relaxed);
             } });
     }
 
-    while (reads_completed.load(std::memory_order_relaxed) < 1000)
+    // Wait until all readers are actively reading
+    while (readers_entered.load(std::memory_order_acquire) < num_threads)
     {
         std::this_thread::yield();
     }
 
+    // Shutdown on a separate thread while readers are still active.
+    // shutdown_cache waits for s_activeReaders == 0 before destroying data.
+    // Readers that re-enter is_readable after shutdown will call init_cache,
+    // which blocks on s_cacheStateMutex until shutdown completes.
+    std::thread shutdown_thread([&]()
+                                { Memory::shutdown_cache(); });
+
+    // Let shutdown and readers race briefly
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    // Signal readers to stop, then join them
     keep_reading.store(false, std::memory_order_release);
 
     for (auto &t : readers)
@@ -998,10 +1018,9 @@ TEST_F(MemoryTest, ShutdownAfterConcurrentWorkload)
         t.join();
     }
 
-    // Shutdown after heavy concurrent usage must complete cleanly
-    Memory::shutdown_cache();
+    shutdown_thread.join();
 
-    // Re-init and verify cache still works after teardown
+    // Re-init and verify cache still works after concurrent shutdown
     EXPECT_TRUE(Memory::init_cache());
     EXPECT_TRUE(Memory::is_readable(mem, 64));
 


### PR DESCRIPTION
## Summary

Fix critical concurrency bugs in the memory cache that caused flaky tests
(hangs, `shared_mutex_pthread::try_lock` assertion failures, exit code
`0xc0000409`) and would cause issues in real game mod usage with
per-frame hot-path calls (player state, camera updates).

- **Fix LRU key truncation**: `generate_lru_key` used `(timestamp_ns << 32) | counter`
  which discarded the upper 32 bits of nanosecond timestamps, breaking eviction
  order. Replaced with monotonic counter-only key for correct insertion-order eviction.
- **Fix `clear_cache()` killing background thread**: `clear_cache()` set
  `s_cleanupThreadRunning = false` then back to `true` without joining or
  restarting the thread, silently killing it. Also used `try_to_lock` which
  could skip shards entirely. Now uses blocking locks and leaves the cleanup
  thread untouched.
- **Fix `shutdown_cache()` deadlock**: Thread join was inside `s_cacheStateMutex`
  lock, but the cleanup thread acquires the same mutex in
  `cleanup_expired_entries(force=true)`, causing a potential deadlock. Moved
  join before mutex acquisition.
- **Fix `shutdown_cache()` use-after-free**: Added `s_activeReaders` atomic
  counter so shutdown waits for all in-flight `is_readable`/`is_writable` calls
  to drain before destroying shard vectors and mutexes.
- **Remove hot-path cleanup overhead**: Removed `request_cleanup()` from
  `is_readable`/`is_writable` (called every frame in game mods). The background
  thread handles periodic cleanup; `request_cleanup` is now only called from
  `invalidate_range` (infrequent).
- **Fix tests**: Tests that needed cache reconfiguration now use
  `shutdown_cache(); init_cache(params)` instead of `clear_cache(); init_cache(params)`,
  since `clear_cache` correctly does not reset the initialized flag.

## Root Cause of Flaky Tests

| Symptom | Root Cause |
|---------|-----------|
| Hang at `MemoryTest.write_bytes` | `clear_cache()` killed background thread; `TearDown` → `shutdown_cache()` → `join()` on dead thread caused MinGW pthreads hang |
| Hang at `MemoryTest.OnDemandCleanupAfterLongDelay` | `clear_cache(); init_cache(params)` was a no-op (cache already initialized), test ran with wrong expiry config |
| `shared_mutex_pthread::try_lock` assertion (0xc0000409) | `shutdown_cache()` destroyed mutex objects while concurrent readers still held shared locks (use-after-free race) |

## Test plan

- [x] Run `ctest --preset mingw-debug` — all memory tests pass without hangs
- [x] Run memory tests in a loop (10+ iterations) to verify no flaky failures
- [x] Verify CI passes on both MinGW and MSVC presets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified init_cache semantics: returns true when cache is ready (new or already initialized); false only on failure. Note added that reconfiguration requires shutdown.

* **Behavior Changes**
  * Cache lookups no longer refresh entry recency; eviction ordering uses monotonic per-shard counters.
  * Shutdown waits for active readers before teardown; clearing simplified and opportunistic cleanup calls reduced.

* **Tests**
  * Tests updated to use shutdown-based resets; coverage expanded for expiry, shutdown/reinit, stats, hit-performance; obsolete cleanup tests removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->