### PR TITLE
fix(scanner): improve const-correctness, hot-path performance, and anchor selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,12 +377,12 @@ void InitializeMyMod() {
             std::string aob_sig_str = "48 89 ?? ?? 57";
             ptrdiff_t pattern_offset = 0;
 
-            std::vector<std::byte> pattern_bytes = DMKScanner::parse_aob(aob_sig_str);
-            if (!pattern_bytes.empty()) {
-                std::byte* found_pattern = DMKScanner::find_pattern(
-                    reinterpret_cast<std::byte*>(module_info.lpBaseOfDll),
+            auto pattern = DMKScanner::parse_aob(aob_sig_str);
+            if (pattern.has_value()) {
+                const std::byte* found_pattern = DMKScanner::find_pattern(
+                    reinterpret_cast<const std::byte*>(module_info.lpBaseOfDll),
                     module_info.SizeOfImage,
-                    pattern_bytes
+                    *pattern
                 );
                 if (found_pattern) {
                     target_function_address = reinterpret_cast<uintptr_t>(found_pattern) + pattern_offset;

--- a/include/DetourModKit/scanner.hpp
+++ b/include/DetourModKit/scanner.hpp
@@ -21,7 +21,7 @@ namespace DetourModKit
         struct CompiledPattern
         {
             std::vector<std::byte> bytes; ///< Pattern bytes (wildcard positions contain arbitrary values)
-            std::vector<uint8_t> mask;    ///< 1 = match this byte, 0 = wildcard (skip)
+            std::vector<std::byte> mask;   ///< 0xFF = match this byte, 0x00 = wildcard (skip)
 
             /**
              * @brief Returns the size of the pattern.
@@ -52,11 +52,11 @@ namespace DetourModKit
          * @param start_address Pointer to the beginning of the memory region to scan.
          * @param region_size The size (in bytes) of the memory region to scan.
          * @param pattern The compiled pattern to search for.
-         * @return std::byte* Pointer to the first occurrence of the pattern within
+         * @return const std::byte* Pointer to the first occurrence of the pattern within
          *         the specified region. Returns nullptr if pattern not found.
          */
-        std::byte *find_pattern(std::byte *start_address, size_t region_size,
-                               const CompiledPattern &pattern);
+        const std::byte *find_pattern(const std::byte *start_address, size_t region_size,
+                                      const CompiledPattern &pattern);
     } // namespace Scanner
 } // namespace DetourModKit
 

--- a/src/hook_manager.cpp
+++ b/src/hook_manager.cpp
@@ -231,7 +231,7 @@ std::expected<std::string, HookError> HookManager::create_inline_hook_aob(
         return std::unexpected(HookError::InvalidTargetAddress);
     }
 
-    std::byte *found_address_start = find_pattern(reinterpret_cast<std::byte *>(module_base), module_size, pattern.value());
+    const std::byte *found_address_start = find_pattern(reinterpret_cast<const std::byte *>(module_base), module_size, pattern.value());
     if (!found_address_start)
     {
         m_logger.error("HookManager: AOB pattern not found for inline hook '{}'. Pattern: \"{}\".", name, aob_pattern_str);
@@ -355,7 +355,7 @@ std::expected<std::string, HookError> HookManager::create_mid_hook_aob(
         return std::unexpected(HookError::InvalidTargetAddress);
     }
 
-    std::byte *found_address_start = find_pattern(reinterpret_cast<std::byte *>(module_base), module_size, pattern.value());
+    const std::byte *found_address_start = find_pattern(reinterpret_cast<const std::byte *>(module_base), module_size, pattern.value());
     if (!found_address_start)
     {
         m_logger.error("HookManager: AOB pattern not found for mid hook '{}'. Pattern: \"{}\".", name, aob_pattern_str);
@@ -401,6 +401,10 @@ void HookManager::remove_all_hooks()
     {
         m_logger.debug("HookManager: remove_all_hooks called, but no hooks were active to remove.");
     }
+
+    // Allow shutdown() to be called again after a full reset.
+    // Safe because the manager is now in a clean state with no hooks to double-free.
+    m_shutdown_called.store(false, std::memory_order_release);
 }
 
 bool HookManager::enable_hook(const std::string &hook_id)

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -10,106 +10,39 @@
 #include <vector>
 #include <string>
 #include <sstream>
-#include <iomanip>
 #include <cctype>
 #include <stdexcept>
-#include <limits>
 #include <cstddef>
 #include <cstring>
 
 using namespace DetourModKit;
 using namespace DetourModKit::String;
 
-// Anonymous namespace for internal helpers
 namespace
 {
     /**
-     * @struct ParsedPatternByte
-     * @brief Internal helper struct representing a parsed AOB element.
+     * @brief Returns a commonality score for a byte value in typical x64 PE code sections.
+     * @details Higher scores indicate bytes that appear more frequently, making them
+     *          poor candidates for anchor-based scanning.
      */
-    struct ParsedPatternByte
+    static constexpr uint8_t byte_frequency_class(uint8_t b) noexcept
     {
-        std::byte value;  /**< Byte value (used if not a wildcard). */
-        bool is_wildcard; /**< True if this element represents '??' or '?'. */
-    };
-
-    /**
-     * @brief Internal parser: Converts AOB string to a structured vector of ParsedPatternByte.
-     * @details Parses the input string token by token (space-separated).
-     *          Validates each token for format ('??', '?', or two hex digits).
-     *          Uses the Logger for detailed debug/error messages.
-     * @param aob_str Raw AOB string (e.g., "48 ?? 8B").
-     * @return std::vector<ParsedPatternByte> Vector of parsed structs, or empty on error.
-     */
-    std::vector<ParsedPatternByte> parse_aobInternal(std::string_view aob_str)
-    {
-        std::vector<ParsedPatternByte> pattern_elements;
-        std::string trimmed_aob = trim(std::string(aob_str));
-        std::istringstream iss(trimmed_aob);
-        std::string token;
-        Logger &logger = Logger::get_instance();
-        int token_idx = 0;
-
-        if (trimmed_aob.empty())
+        switch (b)
         {
-            if (!aob_str.empty())
-            {
-                logger.warning("AOB Parser: Input string became empty after trimming.");
-            }
-            return pattern_elements;
+        case 0x00: return 10; // null padding, very common
+        case 0xCC: return 9;  // INT3, debug padding
+        case 0x90: return 9;  // NOP
+        case 0xFF: return 8;  // call/jmp indirect, common
+        case 0x48: return 8;  // REX.W prefix, ubiquitous in x64
+        case 0x8B: return 7;  // MOV reg, r/m
+        case 0x89: return 7;  // MOV r/m, reg
+        case 0x0F: return 7;  // two-byte opcode escape
+        case 0xE8: return 6;  // CALL rel32
+        case 0xE9: return 6;  // JMP rel32
+        case 0x83: return 6;  // arithmetic imm8
+        case 0xC3: return 5;  // RET
+        default:   return 0;  // uncommon, ideal anchor
         }
-
-        logger.debug("AOB Parser: Parsing string: '{}'", trimmed_aob);
-
-        while (iss >> token)
-        {
-            token_idx++;
-            if (token == "??" || token == "?")
-            {
-                pattern_elements.push_back({std::byte{0x00}, true});
-            }
-            else if (token.length() == 2 && std::isxdigit(static_cast<unsigned char>(token[0])) && std::isxdigit(static_cast<unsigned char>(token[1])))
-            {
-                try
-                {
-                    unsigned long ulong_val = std::stoul(token, nullptr, 16);
-                    if (ulong_val > 0xFF)
-                    {
-                        throw std::out_of_range("Value parsed exceeds byte range (0xFF).");
-                    }
-                    pattern_elements.push_back({static_cast<std::byte>(ulong_val), false});
-                }
-                catch (const std::out_of_range &oor)
-                {
-                    logger.error("AOB Parser: Hex conversion out of range for '{}' (Pos {}): {}", token, token_idx, oor.what());
-                    return {};
-                }
-                catch (const std::invalid_argument &ia)
-                {
-                    logger.error("AOB Parser: Invalid argument for hex conversion '{}' (Pos {}): {}", token, token_idx, ia.what());
-                    return {};
-                }
-            }
-            else
-            {
-                std::ostringstream oss_err;
-                oss_err << "AOB Parser: Invalid token '" << token << "' at position " << token_idx
-                        << ". Expected hex byte (e.g., FF), '?', or '?\?'.";
-                logger.log(LogLevel::Error, oss_err.str());
-                return {};
-            }
-        }
-
-        if (pattern_elements.empty() && token_idx > 0)
-        {
-            logger.error("AOB Parser: Processed tokens but resulting pattern is empty.");
-        }
-        else if (!pattern_elements.empty())
-        {
-            logger.debug("AOB Parser: Parsed {} elements.", pattern_elements.size());
-        }
-
-        return pattern_elements;
     }
 } // anonymous namespace
 
@@ -121,35 +54,80 @@ std::optional<Scanner::CompiledPattern> DetourModKit::Scanner::parse_aob(std::st
 {
     Logger &logger = Logger::get_instance();
 
-    std::vector<ParsedPatternByte> internal_pattern = parse_aobInternal(aob_str);
-
-    if (internal_pattern.empty())
+    std::string trimmed_aob = trim(std::string(aob_str));
+    if (trimmed_aob.empty())
     {
-        if (!trim(std::string(aob_str)).empty())
+        if (!aob_str.empty())
+        {
+            logger.warning("AOB Parser: Input string became empty after trimming.");
+        }
+        return std::nullopt;
+    }
+
+    CompiledPattern result;
+    std::istringstream iss(trimmed_aob);
+    std::string token;
+    size_t token_idx = 0;
+
+    while (iss >> token)
+    {
+        token_idx++;
+        if (token == "??" || token == "?")
+        {
+            result.bytes.push_back(std::byte{0x00});
+            result.mask.push_back(std::byte{0x00});
+        }
+        else if (token.length() == 2 && std::isxdigit(static_cast<unsigned char>(token[0])) && std::isxdigit(static_cast<unsigned char>(token[1])))
+        {
+            try
+            {
+                unsigned long ulong_val = std::stoul(token, nullptr, 16);
+                if (ulong_val > 0xFF)
+                {
+                    throw std::out_of_range("Value parsed exceeds byte range (0xFF).");
+                }
+                result.bytes.push_back(static_cast<std::byte>(ulong_val));
+                result.mask.push_back(std::byte{0xFF});
+            }
+            catch (const std::out_of_range &oor)
+            {
+                logger.error("AOB Parser: Hex conversion out of range for '{}' (Pos {}): {}", token, token_idx, oor.what());
+                return std::nullopt;
+            }
+            catch (const std::invalid_argument &ia)
+            {
+                logger.error("AOB Parser: Invalid argument for hex conversion '{}' (Pos {}): {}", token, token_idx, ia.what());
+                return std::nullopt;
+            }
+        }
+        else
+        {
+            std::ostringstream oss_err;
+            oss_err << "AOB Parser: Invalid token '" << token << "' at position " << token_idx
+                    << ". Expected hex byte (e.g., FF), '?' or '?\?'.";
+            logger.log(LogLevel::Error, oss_err.str());
+            return std::nullopt;
+        }
+    }
+
+    if (result.empty())
+    {
+        if (token_idx > 0)
+        {
+            logger.error("AOB Parser: Processed tokens but resulting pattern is empty.");
+        }
+        else if (!trimmed_aob.empty())
         {
             logger.warning("AOB: Parsing AOB string '{}' resulted in an empty pattern.", aob_str);
         }
         return std::nullopt;
     }
 
-    CompiledPattern result;
-    result.bytes.reserve(internal_pattern.size());
-    result.mask.reserve(internal_pattern.size());
-
-    for (const auto &element : internal_pattern)
-    {
-        result.bytes.push_back(element.value);
-        result.mask.push_back(element.is_wildcard ? 0 : 1);
-    }
-
-    logger.debug("AOB: Compiled pattern with {} bytes, {} wildcards.",
-                 result.bytes.size(),
-                 std::count(result.mask.begin(), result.mask.end(), 0));
     return result;
 }
 
-std::byte *DetourModKit::Scanner::find_pattern(std::byte *start_address, size_t region_size,
-                                              const CompiledPattern &pattern)
+const std::byte *DetourModKit::Scanner::find_pattern(const std::byte *start_address, size_t region_size,
+                                                     const CompiledPattern &pattern)
 {
     Logger &logger = Logger::get_instance();
     const size_t pattern_size = pattern.size();
@@ -166,71 +144,60 @@ std::byte *DetourModKit::Scanner::find_pattern(std::byte *start_address, size_t 
     }
     if (region_size < pattern_size)
     {
-        logger.warning("find_pattern: Search region ({} bytes) is smaller than pattern ({} bytes).", region_size, pattern_size);
         return nullptr;
     }
 
-    logger.debug("find_pattern: Scanning {} bytes from {} for a {} byte pattern.",
-                 region_size, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(start_address)), pattern_size);
-
-    // Count wildcards for optimization decisions
-    int wildcard_count = 0;
-    size_t first_non_wildcard = pattern_size; // invalid index = all wildcards
+    // Select the best anchor byte: the non-wildcard byte with the lowest frequency score.
+    // Ties are broken by first occurrence for deterministic behavior.
+    size_t best_anchor = pattern_size; // invalid = all wildcards
+    uint8_t best_score = UINT8_MAX;
     for (size_t i = 0; i < pattern_size; ++i)
     {
-        if (pattern.mask[i] == 0)
+        if (pattern.mask[i] != std::byte{0x00})
         {
-            wildcard_count++;
-        }
-        else if (first_non_wildcard == pattern_size)
-        {
-            first_non_wildcard = i;
+            uint8_t score = byte_frequency_class(static_cast<uint8_t>(pattern.bytes[i]));
+            if (best_anchor == pattern_size || score < best_score)
+            {
+                best_anchor = i;
+                best_score = score;
+                if (score == 0)
+                {
+                    break; // Cannot improve on score 0
+                }
+            }
         }
     }
 
-    if (wildcard_count > 0)
+    // All wildcards: matches immediately at start
+    if (best_anchor == pattern_size)
     {
-        logger.debug("find_pattern: Pattern contains {} wildcard(s).", wildcard_count);
-    }
-
-    // Optimization: If pattern is ALL wildcards, return start_address (matches immediately)
-    if (first_non_wildcard == pattern_size)
-    {
-        logger.warning("find_pattern: Pattern is all wildcards. Returning start address.");
         return start_address;
     }
 
-    // Optimization: Use memchr to find the first non-wildcard byte, then verify full pattern
-    // This dramatically reduces the number of full pattern comparisons needed
-    const std::byte target_byte = pattern.bytes[first_non_wildcard];
+    const std::byte target_byte = pattern.bytes[best_anchor];
     const unsigned char target_val = static_cast<unsigned char>(target_byte);
 
-    // memchr searches for the anchor byte at its actual position within candidates.
-    // Valid pattern start positions: [start_address, start_address + (region_size - pattern_size)]
-    // The anchor byte is at offset first_non_wildcard within the pattern, so we search
-    // for it in [start_address + first_non_wildcard, start_address + (region_size - pattern_size) + first_non_wildcard]
-    std::byte *search_start = start_address + first_non_wildcard;
-    const std::byte *const search_end = start_address + (region_size - pattern_size) + first_non_wildcard;
+    const std::byte *search_start = start_address + best_anchor;
+    const std::byte *const search_end = start_address + (region_size - pattern_size) + best_anchor;
 
     while (search_start <= search_end)
     {
-        void *found = memchr(search_start, static_cast<int>(target_val),
-                             static_cast<size_t>(search_end - search_start + 1));
+        const void *found = memchr(search_start, static_cast<int>(target_val),
+                                   static_cast<size_t>(search_end - search_start + 1));
 
         if (!found)
         {
             break;
         }
 
-        std::byte *current_scan_ptr = static_cast<std::byte *>(found);
-
-        std::byte *pattern_start = current_scan_ptr - first_non_wildcard;
+        const std::byte *current_scan_ptr = static_cast<const std::byte *>(found);
+        const std::byte *pattern_start = current_scan_ptr - best_anchor;
 
         // Verify the full pattern at this position
         bool match_found = true;
         for (size_t j = 0; j < pattern_size; ++j)
         {
-            if (pattern.mask[j] != 0 && pattern_start[j] != pattern.bytes[j])
+            if (pattern.mask[j] != std::byte{0x00} && pattern_start[j] != pattern.bytes[j])
             {
                 match_found = false;
                 break;
@@ -239,10 +206,6 @@ std::byte *DetourModKit::Scanner::find_pattern(std::byte *start_address, size_t 
 
         if (match_found)
         {
-            uintptr_t absolute_match_address = reinterpret_cast<uintptr_t>(pattern_start);
-            uintptr_t rva_offset = absolute_match_address - reinterpret_cast<uintptr_t>(start_address);
-            logger.info("find_pattern: Pattern match found at address: {} (RVA: {})",
-                        DetourModKit::Format::format_address(absolute_match_address), DetourModKit::Format::format_address(rva_offset));
             return pattern_start;
         }
 
@@ -250,6 +213,5 @@ std::byte *DetourModKit::Scanner::find_pattern(std::byte *start_address, size_t 
         search_start = current_scan_ptr + 1;
     }
 
-    logger.warning("find_pattern: Pattern not found in the specified memory region.");
     return nullptr;
 }

--- a/tests/test_scanner.cpp
+++ b/tests/test_scanner.cpp
@@ -307,7 +307,7 @@ TEST(ScannerTest, find_pattern_null_address)
     auto pattern = Scanner::parse_aob("48 8B 05");
     ASSERT_TRUE(pattern.has_value());
 
-    auto result = Scanner::find_pattern(nullptr, 100, *pattern);
+    auto result = Scanner::find_pattern(static_cast<const std::byte *>(nullptr), 100, *pattern);
     EXPECT_EQ(result, nullptr);
 }
 
@@ -333,10 +333,10 @@ TEST(ScannerTest, parse_aob_byte_values)
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result->size(), 4u);
 
-    EXPECT_EQ(result->mask[0], 1);
-    EXPECT_EQ(result->mask[1], 1);
-    EXPECT_EQ(result->mask[2], 1);
-    EXPECT_EQ(result->mask[3], 1);
+    EXPECT_EQ(result->mask[0], std::byte{0xFF});
+    EXPECT_EQ(result->mask[1], std::byte{0xFF});
+    EXPECT_EQ(result->mask[2], std::byte{0xFF});
+    EXPECT_EQ(result->mask[3], std::byte{0xFF});
 
     EXPECT_EQ(result->bytes[0], std::byte{0x00});
     EXPECT_EQ(result->bytes[1], std::byte{0xFF});
@@ -350,11 +350,11 @@ TEST(ScannerTest, parse_aob_wildcard_mask)
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(result->size(), 4u);
 
-    EXPECT_EQ(result->mask[0], 1);
-    EXPECT_EQ(result->mask[2], 1);
+    EXPECT_EQ(result->mask[0], std::byte{0xFF});
+    EXPECT_EQ(result->mask[2], std::byte{0xFF});
 
-    EXPECT_EQ(result->mask[1], 0);
-    EXPECT_EQ(result->mask[3], 0);
+    EXPECT_EQ(result->mask[1], std::byte{0x00});
+    EXPECT_EQ(result->mask[3], std::byte{0x00});
 }
 
 TEST(ScannerTest, find_pattern_wildcard_before_start)
@@ -458,4 +458,52 @@ TEST(ScannerTest, find_pattern_long_wildcard_prefix)
 
     auto result2 = Scanner::find_pattern(small.data(), small.size(), *pattern);
     EXPECT_EQ(result2, nullptr);
+}
+
+TEST(ScannerTest, find_pattern_anchor_selection)
+{
+    // Fill data with 0x00 (very common byte). Place a pattern where the first
+    // non-wildcard is 0x00 but a later byte is rare (0x37). The smarter anchor
+    // should still find the correct match by anchoring on the rare byte.
+    std::vector<std::byte> data(512, std::byte{0x00});
+
+    // Place the real match at offset 200: 00 37 00
+    data[200] = std::byte{0x00};
+    data[201] = std::byte{0x37};
+    data[202] = std::byte{0x00};
+
+    auto pattern = Scanner::parse_aob("00 37 00");
+    ASSERT_TRUE(pattern.has_value());
+
+    auto result = Scanner::find_pattern(data.data(), data.size(), *pattern);
+
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result - data.data(), 200);
+}
+
+TEST(ScannerTest, parse_aob_invariant)
+{
+    auto result = Scanner::parse_aob("48 ?? 8B 05 ?? ??");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->bytes.size(), result->mask.size());
+
+    auto single = Scanner::parse_aob("CC");
+    ASSERT_TRUE(single.has_value());
+    EXPECT_EQ(single->bytes.size(), single->mask.size());
+}
+
+TEST(ScannerTest, find_pattern_const_correctness)
+{
+    const std::vector<std::byte> data = {
+        std::byte{0x00}, std::byte{0x00},
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x05},
+        std::byte{0x00}, std::byte{0x00}};
+
+    auto pattern = Scanner::parse_aob("48 8B 05");
+    ASSERT_TRUE(pattern.has_value());
+
+    const std::byte *result = Scanner::find_pattern(data.data(), data.size(), *pattern);
+
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result - data.data(), 2);
 }


### PR DESCRIPTION
## Summary
- `find_pattern` now takes/returns `const std::byte*` for correct read-only semantics
- Mask type changed from `std::vector<uint8_t>` to `std::vector<std::byte>` (SIMD-ready `0xFF`/`0x00`)
- Eliminated two-phase parse; `parse_aob` builds `CompiledPattern` in a single pass
- Removed all hot-path logging from `find_pattern` (no heap allocations or mutex contention during scans)
- Smarter `memchr` anchor selection via byte frequency heuristic — avoids common x64 bytes (`0x00`, `0x90`, `0xCC`, `0x48`)
- Fixed flaky `HookManagerTest.ShutdownWithHooks` by resetting shutdown latch in `remove_all_hooks()`
- Updated README.md to reflect new API changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized pattern scanning performance with improved byte selection strategy for more efficient detection
  * Fixed hook manager reset functionality to allow hooks to be reinitialized after shutdown

* **Documentation**
  * Updated README code examples demonstrating pattern scanning usage

* **Tests**
  * Expanded test coverage for pattern matching accuracy and reset behavior validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->