### PR TITLE
fix(config): deduplicate hex parsing, add range check, and remove unused includes

### DIFF
--- a/include/DetourModKit/config.hpp
+++ b/include/DetourModKit/config.hpp
@@ -1,10 +1,9 @@
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
-#include <vector>
-#include <string>
 #include <functional>
-#include <optional>
+#include <string>
+#include <vector>
 
 namespace DetourModKit
 {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -85,11 +85,11 @@ namespace
             }
 
             // Convert via strtoul — no exception overhead on invalid input
+            errno = 0;
             char *end_ptr = nullptr;
             const unsigned long value = std::strtoul(token.c_str() + hex_start, &end_ptr, 16);
             if (end_ptr == token.c_str() + hex_start || errno == ERANGE)
             {
-                errno = 0;
                 continue;
             }
             if (value > static_cast<unsigned long>(std::numeric_limits<int>::max()))
@@ -240,7 +240,10 @@ namespace
         {
             current_value = parse_hex_key_list(ini_value_str);
         }
-        // else: keep default_value which was set in constructor
+        else
+        {
+            current_value = default_value;
+        }
 
         if (setter)
         {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -15,17 +15,15 @@
 #include "SimpleIni.h"
 
 #include <windows.h>
+#include <cerrno>
+#include <cstdlib>
 #include <filesystem>
-#include <cctype>
-#include <algorithm>
-#include <string>
-#include <stdexcept>
-#include <sstream>
-#include <vector>
+#include <limits>
 #include <memory>
-#include <variant>
-#include <typeinfo>
 #include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
 
 using namespace DetourModKit;
 using namespace DetourModKit::Filesystem;
@@ -34,6 +32,77 @@ using namespace DetourModKit::String;
 // Anonymous namespace for internal helpers and storage
 namespace
 {
+    /**
+     * @brief Parses a comma-separated string of hex values into a vector of ints.
+     * @details Handles 0x/0X prefixes, inline semicolon comments, whitespace,
+     *          and gracefully skips invalid or out-of-range tokens.
+     * @param input The raw string to parse.
+     * @return std::vector<int> Parsed valid hex values.
+     */
+    std::vector<int> parse_hex_key_list(const std::string &input)
+    {
+        std::vector<int> result;
+
+        // Strip trailing comment from the full line
+        const size_t comment_pos = input.find(';');
+        const std::string effective = trim(
+            (comment_pos != std::string::npos) ? input.substr(0, comment_pos) : input);
+        if (effective.empty())
+        {
+            return result;
+        }
+
+        // Walk comma-delimited tokens without istringstream overhead
+        size_t pos = 0;
+        while (pos < effective.size())
+        {
+            const size_t comma = effective.find(',', pos);
+            const size_t end = (comma != std::string::npos) ? comma : effective.size();
+            const std::string token = trim(effective.substr(pos, end - pos));
+            pos = end + 1;
+
+            if (token.empty())
+            {
+                continue;
+            }
+
+            // Strip optional 0x/0X prefix
+            size_t hex_start = 0;
+            if (token.size() >= 2 && token[0] == '0' && (token[1] == 'x' || token[1] == 'X'))
+            {
+                hex_start = 2;
+            }
+            if (hex_start >= token.size())
+            {
+                continue;
+            }
+
+            // Validate all remaining characters are hex digits
+            const std::string_view hex_part(token.data() + hex_start, token.size() - hex_start);
+            if (hex_part.find_first_not_of("0123456789abcdefABCDEF") != std::string_view::npos)
+            {
+                continue;
+            }
+
+            // Convert via strtoul — no exception overhead on invalid input
+            char *end_ptr = nullptr;
+            const unsigned long value = std::strtoul(token.c_str() + hex_start, &end_ptr, 16);
+            if (end_ptr == token.c_str() + hex_start || errno == ERANGE)
+            {
+                errno = 0;
+                continue;
+            }
+            if (value > static_cast<unsigned long>(std::numeric_limits<int>::max()))
+            {
+                continue;
+            }
+
+            result.push_back(static_cast<int>(value));
+        }
+
+        return result;
+    }
+
     /**
      * @brief Base class for typed configuration items.
      * @details This allows storing different types of configuration items
@@ -169,59 +238,7 @@ namespace
         const char *ini_value_str = ini.GetValue(section.c_str(), ini_key.c_str(), nullptr);
         if (ini_value_str != nullptr)
         {
-            // Parse the INI value string into a vector
-            current_value.clear();
-            std::string str_no_comment = ini_value_str;
-            size_t comment_pos = str_no_comment.find(';');
-            if (comment_pos != std::string::npos)
-            {
-                str_no_comment = str_no_comment.substr(0, comment_pos);
-            }
-            std::string trimmed_val = trim(str_no_comment);
-
-            if (!trimmed_val.empty())
-            {
-                std::istringstream iss(trimmed_val);
-                std::string token;
-                while (std::getline(iss, token, ','))
-                {
-                    size_t token_comment_pos = token.find(';');
-                    if (token_comment_pos != std::string::npos)
-                    {
-                        token = token.substr(0, token_comment_pos);
-                    }
-                    std::string trimmed_token = trim(token);
-                    if (trimmed_token.empty())
-                    {
-                        continue;
-                    }
-
-                    std::string hex_part = trimmed_token;
-                    if (hex_part.size() >= 2 && hex_part[0] == '0' && (hex_part[1] == 'x' || hex_part[1] == 'X'))
-                    {
-                        hex_part = hex_part.substr(2);
-                        if (hex_part.empty())
-                        {
-                            continue;
-                        }
-                    }
-
-                    if (hex_part.find_first_not_of("0123456789abcdefABCDEF") != std::string::npos)
-                    {
-                        continue;
-                    }
-
-                    try
-                    {
-                        unsigned long code_ul = std::stoul(hex_part, nullptr, 16);
-                        current_value.push_back(static_cast<int>(code_ul));
-                    }
-                    catch (const std::exception &)
-                    {
-                        // Skip invalid tokens
-                    }
-                }
-            }
+            current_value = parse_hex_key_list(ini_value_str);
         }
         // else: keep default_value which was set in constructor
 
@@ -325,48 +342,7 @@ void DetourModKit::Config::register_key_list(const std::string &section, const s
                                                    const std::string &default_value_str)
 {
     std::lock_guard<std::mutex> lock(getConfigMutex());
-    // Parse the default_value_str into a vector<int>
-    std::vector<int> default_keys_vector;
-    std::string str_no_comment = default_value_str;
-    size_t comment_pos = str_no_comment.find(';');
-    if (comment_pos != std::string::npos)
-    {
-        str_no_comment = str_no_comment.substr(0, comment_pos);
-    }
-    std::string trimmed_val = trim(str_no_comment);
-
-    if (!trimmed_val.empty())
-    {
-        std::istringstream iss(trimmed_val);
-        std::string token;
-        while (std::getline(iss, token, ','))
-        {
-            std::string trimmed_token = trim(token);
-            if (trimmed_token.empty())
-                continue;
-
-            std::string hex_part = trimmed_token;
-            if (hex_part.size() >= 2 && hex_part[0] == '0' && (hex_part[1] == 'x' || hex_part[1] == 'X'))
-            {
-                hex_part = hex_part.substr(2);
-                if (hex_part.empty())
-                    continue;
-            }
-
-            if (hex_part.find_first_not_of("0123456789abcdefABCDEF") != std::string::npos)
-                continue;
-
-            try
-            {
-                unsigned long code_ul = std::stoul(hex_part, nullptr, 16);
-                default_keys_vector.push_back(static_cast<int>(code_ul));
-            }
-            catch (const std::exception &)
-            {
-                // Skip invalid
-            }
-        }
-    }
+    std::vector<int> default_keys_vector = parse_hex_key_list(default_value_str);
 
     getRegisteredConfigItems().push_back(
         std::make_unique<CallbackConfigItem<std::vector<int>>>(section, ini_key, log_key_name, std::move(setter), default_keys_vector));

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -546,6 +546,37 @@ TEST_F(ConfigTest, RegisterKeyList_DefaultOverflow)
     EXPECT_EQ(val[0], 0x43);
 }
 
+// Tests that hex values exceeding INT_MAX are skipped by the range check
+TEST_F(ConfigTest, KeyList_ValueExceedingIntMax)
+{
+    std::ofstream ini_file(test_ini_file_);
+    ini_file << "[TestSection]\n";
+    // 0x80000000 = 2147483648 which exceeds INT_MAX (2147483647) on 32-bit int
+    ini_file << "Keys=0x80000000, 0x41\n";
+    ini_file.close();
+
+    std::vector<int> test_value;
+    Config::register_key_list("TestSection", "Keys", "keys", [&test_value](const std::vector<int> &v)
+                                    { test_value = v; }, "");
+
+    EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
+
+    EXPECT_EQ(test_value.size(), 1u);
+    EXPECT_EQ(test_value[0], 0x41);
+}
+
+// Tests that hex values exceeding INT_MAX in default string are skipped
+TEST_F(ConfigTest, RegisterKeyList_DefaultValueExceedingIntMax)
+{
+    std::vector<int> val;
+    // 0x80000000 exceeds INT_MAX, should be skipped
+    Config::register_key_list("S", "K4", "k4", [&val](const std::vector<int> &v)
+                                    { val = v; }, "0x80000000, 0x44");
+    Config::load(test_ini_file_.string());
+    EXPECT_EQ(val.size(), 1u);
+    EXPECT_EQ(val[0], 0x44);
+}
+
 TEST_F(ConfigTest, DuplicateKeyRegistration)
 {
     std::ofstream ini_file(test_ini_file_);


### PR DESCRIPTION
## Summary
- Extract shared `parse_hex_key_list` helper and wire it into both `register_key_list` and `vector<int>::load`, eliminating ~40 lines of duplicated inline parsing
- Replace `std::istringstream` + `std::stoul` with manual comma-walk and `std::strtoul` to avoid stream construction overhead and exception-based error handling
- Add `INT_MAX` range check so hex values exceeding `int` range are gracefully skipped instead of silently narrowing
- Use `std::string_view` for hex digit validation to avoid an extra string copy
- Remove unused includes (`<optional>`, `<variant>`, `<typeinfo>`, `<cctype>`, `<algorithm>`, `<sstream>`) from config.hpp and config.cpp

## Test plan
- [x] All 38 existing `ConfigTest.*` tests pass
- [x] New `KeyList_ValueExceedingIntMax` test: verifies `0x80000000` is skipped from INI file
- [x] New `RegisterKeyList_DefaultValueExceedingIntMax` test: verifies `0x80000000` is skipped from default string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hexadecimal key-list configuration parsing: handles extra whitespace, optional 0x prefixes, inline comments, and gracefully skips values that exceed system limits; missing entries now fall back to their configured defaults.

* **Tests**
  * Added test coverage for hex parsing edge cases, including values that exceed integer limits, to ensure stable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->