### PR TITLE
perf: optimize hot-path allocations and StringPool lookup

### DIFF
--- a/include/DetourModKit/format.hpp
+++ b/include/DetourModKit/format.hpp
@@ -1,5 +1,4 @@
-#ifndef FORMAT_HPP
-#define FORMAT_HPP
+#pragma once
 
 /**
  * @file format.hpp
@@ -103,7 +102,10 @@ namespace DetourModKit
                 return "[]";
             }
 
-            std::string result = "[";
+            // "0x" + 2+ hex digits ≈ 4 chars per entry, plus ", " separator
+            std::string result;
+            result.reserve(1 + values.size() * 6 + 1);
+            result += '[';
             for (size_t i = 0; i < values.size(); ++i)
             {
                 if (i > 0)
@@ -112,7 +114,7 @@ namespace DetourModKit
                 }
                 result += format_hex(values[i], 2);
             }
-            result += "]";
+            result += ']';
             return result;
         }
 
@@ -138,5 +140,3 @@ namespace DetourModKit
 
     } // namespace Format
 } // namespace DetourModKit
-
-#endif // FORMAT_HPP

--- a/src/async_logger.cpp
+++ b/src/async_logger.cpp
@@ -62,6 +62,22 @@ namespace DetourModKit
         return pool;
     }
 
+    StringPool::PoolSlot *StringPool::claim_free_slot() noexcept
+    {
+        Block *block = head_.load(std::memory_order_acquire);
+        for (Block *b = block; b; b = b->next)
+        {
+            if (b->free_list)
+            {
+                PoolSlot *slot = b->free_list;
+                b->free_list = slot->next_free;
+                --b->slot_count;
+                return slot;
+            }
+        }
+        return nullptr;
+    }
+
     std::string *StringPool::allocate(size_t size)
     {
         if (size > MEMORY_POOL_BLOCK_SIZE - sizeof(PoolSlot) - 16)
@@ -73,17 +89,7 @@ namespace DetourModKit
 
         {
             std::lock_guard<std::mutex> lock(pool_mutex_);
-            Block *block = head_.load(std::memory_order_acquire);
-            for (Block *b = block; b; b = b->next)
-            {
-                if (b->free_list)
-                {
-                    slot = b->free_list;
-                    b->free_list = slot->next_free;
-                    --b->slot_count;
-                    break;
-                }
-            }
+            slot = claim_free_slot();
         }
 
         if (!slot)
@@ -91,17 +97,7 @@ namespace DetourModKit
             grow_pool();
 
             std::lock_guard<std::mutex> lock(pool_mutex_);
-            Block *block = head_.load(std::memory_order_acquire);
-            for (Block *b = block; b; b = b->next)
-            {
-                if (b->free_list)
-                {
-                    slot = b->free_list;
-                    b->free_list = slot->next_free;
-                    --b->slot_count;
-                    break;
-                }
-            }
+            slot = claim_free_slot();
         }
 
         if (slot)
@@ -125,19 +121,19 @@ namespace DetourModKit
         Block *block = head_.load(std::memory_order_acquire);
         for (Block *b = block; b; b = b->next)
         {
-            PoolSlot *slots = reinterpret_cast<PoolSlot *>(b->data);
+            const auto *block_begin = reinterpret_cast<const char *>(b->data);
+            const auto *block_end = block_begin + POOL_SLOTS_PER_BLOCK * sizeof(PoolSlot);
+            const auto *raw_ptr = reinterpret_cast<const char *>(ptr);
 
-            for (size_t i = 0; i < POOL_SLOTS_PER_BLOCK; ++i)
+            if (raw_ptr >= block_begin && raw_ptr < block_end)
             {
-                PoolSlot *slot = &slots[i];
-                if (&slot->str == ptr)
-                {
-                    slot->str.~basic_string();
-                    slot->next_free = b->free_list;
-                    b->free_list = slot;
-                    ++b->slot_count;
-                    return;
-                }
+                auto offset = static_cast<size_t>(raw_ptr - block_begin);
+                PoolSlot *slot = reinterpret_cast<PoolSlot *>(b->data) + (offset / sizeof(PoolSlot));
+                slot->str.~basic_string();
+                slot->next_free = b->free_list;
+                b->free_list = slot;
+                ++b->slot_count;
+                return;
             }
         }
 
@@ -235,7 +231,6 @@ namespace DetourModKit
             overflow = nullptr;
         }
         length = 0;
-        buffer.fill(0);
     }
 
     DynamicMPMCQueue::DynamicMPMCQueue(size_t capacity)


### PR DESCRIPTION
## Summary
- **format.hpp**: Switch to `#pragma once`; pre-allocate output buffer in `format_int_vector` via `reserve()` to avoid repeated heap reallocations
- **StringPool::deallocate**: Replace O(blocks × slots) linear scan with O(blocks) pointer range check for faster pool return on the consumer thread
- **StringPool::allocate**: Consolidate duplicated free-slot scanning into the existing `claim_free_slot()` helper
- **LogMessage::reset**: Remove redundant `buffer.fill(0)` — the `length` field already tracks valid data, eliminating a 256-byte memset per message lifecycle

## Test plan
- [x] All 415 existing tests pass with zero regressions
- [x] FormatTest, AsyncLoggerTest, LogMessageTest, DynamicMPMCQueueTest all green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved include guard mechanism for better compile efficiency.
  * Optimized string construction in formatting operations through memory pre-allocation.
  * Streamlined memory management logic for slot allocation and deallocation with centralized helper methods.
  * Enhanced performance by removing unnecessary buffer zeroing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->