### PR TITLE
feat(scanner): add RIP-relative instruction resolution utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in g
 
 ## Features
 
-* **AOB Scanner:** Find array-of-bytes (signatures) in memory with wildcard support.
+* **AOB Scanner:** Find array-of-bytes (signatures) in memory with wildcard support. Includes RIP-relative instruction resolution for extracting absolute addresses from x86-64 code.
 * **Hook Manager:** A C++ wrapper around [SafetyHook](https://github.com/cursey/safetyhook) for creating and managing inline and mid-function hooks, by direct address or AOB scan.
 * **Configuration System:** Load settings from INI files. Mods register their configuration variables (defined in the mod's code) and the kit handles parsing and value assignment. (Powered by [SimpleIni](https://github.com/brofield/simpleini)).
 * **Logger:** A flexible singleton logger for outputting messages to a log file. Supports configurable log levels, timestamps, and prefixes. Features **async logging** for high-throughput scenarios and **format string placeholders** for concise log messages.

--- a/include/DetourModKit/scanner.hpp
+++ b/include/DetourModKit/scanner.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <optional>
 #include <cstdint>
+#include <span>
 
 namespace DetourModKit
 {
@@ -21,7 +22,7 @@ namespace DetourModKit
         struct CompiledPattern
         {
             std::vector<std::byte> bytes; ///< Pattern bytes (wildcard positions contain arbitrary values)
-            std::vector<std::byte> mask;   ///< 0xFF = match this byte, 0x00 = wildcard (skip)
+            std::vector<std::byte> mask;  ///< 0xFF = match this byte, 0x00 = wildcard (skip)
 
             /**
              * @brief Returns the size of the pattern.
@@ -57,6 +58,46 @@ namespace DetourModKit
          */
         const std::byte *find_pattern(const std::byte *start_address, size_t region_size,
                                       const CompiledPattern &pattern);
+        // Common x86-64 RIP-relative opcode prefixes (bytes preceding the disp32 field)
+        inline constexpr std::byte PREFIX_MOV_RAX_RIP[] = {std::byte{0x48}, std::byte{0x8B}, std::byte{0x05}};
+        inline constexpr std::byte PREFIX_MOV_RCX_RIP[] = {std::byte{0x48}, std::byte{0x8B}, std::byte{0x0D}};
+        inline constexpr std::byte PREFIX_MOV_RDX_RIP[] = {std::byte{0x48}, std::byte{0x8B}, std::byte{0x15}};
+        inline constexpr std::byte PREFIX_MOV_RBX_RIP[] = {std::byte{0x48}, std::byte{0x8B}, std::byte{0x1D}};
+        inline constexpr std::byte PREFIX_LEA_RAX_RIP[] = {std::byte{0x48}, std::byte{0x8D}, std::byte{0x05}};
+        inline constexpr std::byte PREFIX_LEA_RCX_RIP[] = {std::byte{0x48}, std::byte{0x8D}, std::byte{0x0D}};
+        inline constexpr std::byte PREFIX_LEA_RDX_RIP[] = {std::byte{0x48}, std::byte{0x8D}, std::byte{0x15}};
+        inline constexpr std::byte PREFIX_CALL_REL32[] = {std::byte{0xE8}};
+        inline constexpr std::byte PREFIX_JMP_REL32[] = {std::byte{0xE9}};
+
+        /**
+         * @brief Resolves an absolute address from an x86-64 RIP-relative instruction.
+         * @details Extracts the int32 displacement at the given offset within the instruction
+         *          and computes the absolute target: instruction_address + instruction_length + displacement.
+         * @param instruction_address Pointer to the first byte of the instruction.
+         * @param displacement_offset Byte offset from instruction_address to the disp32 field.
+         * @param instruction_length Total length of the instruction in bytes.
+         * @return The resolved absolute address, or std::nullopt on null input or unreadable displacement.
+         */
+        std::optional<uintptr_t> resolve_rip_relative(const std::byte *instruction_address,
+                                                      size_t displacement_offset,
+                                                      size_t instruction_length);
+
+        /**
+         * @brief Scans forward from a starting address for an opcode prefix, then resolves the RIP-relative target.
+         * @details Searches up to search_length bytes for the given opcode prefix. Once found,
+         *          the displacement is assumed to immediately follow the prefix. The absolute address
+         *          is computed as: found_address + instruction_length + displacement.
+         * @param search_start Pointer to the beginning of the search region.
+         * @param search_length Maximum number of bytes to search forward.
+         * @param opcode_prefix The opcode byte sequence to search for (disp32 must follow immediately).
+         * @param instruction_length Total length of the instruction in bytes.
+         * @return The resolved absolute address, or std::nullopt if prefix not found or displacement unreadable.
+         */
+        std::optional<uintptr_t> find_and_resolve_rip_relative(const std::byte *search_start,
+                                                               size_t search_length,
+                                                               std::span<const std::byte> opcode_prefix,
+                                                               size_t instruction_length);
+
     } // namespace Scanner
 } // namespace DetourModKit
 

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -1,9 +1,10 @@
 /**
  * @file scanner.cpp
- * @brief Implementation of Array-of-Bytes (AOB) parsing and scanning.
+ * @brief Implementation of Array-of-Bytes (AOB) parsing, scanning, and RIP-relative resolution.
  */
 
 #include "DetourModKit/scanner.hpp"
+#include "DetourModKit/memory.hpp"
 #include "DetourModKit/logger.hpp"
 #include "DetourModKit/format.hpp"
 
@@ -13,6 +14,7 @@
 #include <cctype>
 #include <stdexcept>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 
 using namespace DetourModKit;
@@ -29,26 +31,35 @@ namespace
     {
         switch (b)
         {
-        case 0x00: return 10; // null padding, very common
-        case 0xCC: return 9;  // INT3, debug padding
-        case 0x90: return 9;  // NOP
-        case 0xFF: return 8;  // call/jmp indirect, common
-        case 0x48: return 8;  // REX.W prefix, ubiquitous in x64
-        case 0x8B: return 7;  // MOV reg, r/m
-        case 0x89: return 7;  // MOV r/m, reg
-        case 0x0F: return 7;  // two-byte opcode escape
-        case 0xE8: return 6;  // CALL rel32
-        case 0xE9: return 6;  // JMP rel32
-        case 0x83: return 6;  // arithmetic imm8
-        case 0xC3: return 5;  // RET
-        default:   return 0;  // uncommon, ideal anchor
+        case 0x00:
+            return 10; // null padding, very common
+        case 0xCC:
+            return 9; // INT3, debug padding
+        case 0x90:
+            return 9; // NOP
+        case 0xFF:
+            return 8; // call/jmp indirect, common
+        case 0x48:
+            return 8; // REX.W prefix, ubiquitous in x64
+        case 0x8B:
+            return 7; // MOV reg, r/m
+        case 0x89:
+            return 7; // MOV r/m, reg
+        case 0x0F:
+            return 7; // two-byte opcode escape
+        case 0xE8:
+            return 6; // CALL rel32
+        case 0xE9:
+            return 6; // JMP rel32
+        case 0x83:
+            return 6; // arithmetic imm8
+        case 0xC3:
+            return 5; // RET
+        default:
+            return 0; // uncommon, ideal anchor
         }
     }
 } // anonymous namespace
-
-// ============================================================================
-// AOB Scanner API: parse_aob and find_pattern with CompiledPattern
-// ============================================================================
 
 std::optional<Scanner::CompiledPattern> DetourModKit::Scanner::parse_aob(std::string_view aob_str)
 {
@@ -214,4 +225,64 @@ const std::byte *DetourModKit::Scanner::find_pattern(const std::byte *start_addr
     }
 
     return nullptr;
+}
+
+std::optional<uintptr_t> DetourModKit::Scanner::resolve_rip_relative(const std::byte *instruction_address,
+                                                                     size_t displacement_offset,
+                                                                     size_t instruction_length)
+{
+    if (!instruction_address)
+    {
+        return std::nullopt;
+    }
+
+    const std::byte *disp_ptr = instruction_address + displacement_offset;
+    if (!Memory::is_readable(disp_ptr, sizeof(int32_t)))
+    {
+        return std::nullopt;
+    }
+
+    int32_t displacement;
+    std::memcpy(&displacement, disp_ptr, sizeof(int32_t));
+
+    auto base = reinterpret_cast<uintptr_t>(instruction_address);
+    return base + instruction_length + static_cast<uintptr_t>(static_cast<intptr_t>(displacement));
+}
+
+std::optional<uintptr_t> DetourModKit::Scanner::find_and_resolve_rip_relative(const std::byte *search_start,
+                                                                              size_t search_length,
+                                                                              std::span<const std::byte> opcode_prefix,
+                                                                              size_t instruction_length)
+{
+    if (!search_start || opcode_prefix.empty())
+    {
+        return std::nullopt;
+    }
+
+    const size_t prefix_len = opcode_prefix.size();
+    const size_t min_bytes = prefix_len + sizeof(int32_t);
+    if (search_length < min_bytes)
+    {
+        return std::nullopt;
+    }
+
+    const size_t scan_limit = search_length - min_bytes;
+    const std::byte first = opcode_prefix[0];
+
+    for (size_t i = 0; i <= scan_limit; ++i)
+    {
+        if (search_start[i] != first)
+        {
+            continue;
+        }
+
+        if (prefix_len > 1 && std::memcmp(&search_start[i + 1], opcode_prefix.data() + 1, prefix_len - 1) != 0)
+        {
+            continue;
+        }
+
+        return resolve_rip_relative(&search_start[i], prefix_len, instruction_length);
+    }
+
+    return std::nullopt;
 }

--- a/tests/test_scanner.cpp
+++ b/tests/test_scanner.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
 #include <vector>
 #include <cstring>
+#include <span>
 
 #include "DetourModKit/scanner.hpp"
+#include "DetourModKit/memory.hpp"
 
 using namespace DetourModKit;
 
@@ -506,4 +508,273 @@ TEST(ScannerTest, find_pattern_const_correctness)
 
     ASSERT_NE(result, nullptr);
     EXPECT_EQ(result - data.data(), 2);
+}
+
+class ScannerRipTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        Memory::init_cache();
+    }
+
+    void TearDown() override
+    {
+        Memory::shutdown_cache();
+    }
+};
+
+TEST_F(ScannerRipTest, resolve_rip_relative_positive_displacement)
+{
+    // MOV RAX, [RIP+0x12345678]  =>  48 8B 05 78 56 34 12
+    std::vector<std::byte> code = {
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x05},
+        std::byte{0x78}, std::byte{0x56}, std::byte{0x34}, std::byte{0x12}};
+
+    auto result = Scanner::resolve_rip_relative(code.data(), 3, 7);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t expected = reinterpret_cast<uintptr_t>(code.data()) + 7 + 0x12345678;
+    EXPECT_EQ(*result, expected);
+}
+
+TEST_F(ScannerRipTest, resolve_rip_relative_negative_displacement)
+{
+    // MOV RAX, [RIP-0x10]  =>  48 8B 05 F0 FF FF FF
+    std::vector<std::byte> code = {
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x05},
+        std::byte{0xF0}, std::byte{0xFF}, std::byte{0xFF}, std::byte{0xFF}};
+
+    auto result = Scanner::resolve_rip_relative(code.data(), 3, 7);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t expected = reinterpret_cast<uintptr_t>(code.data()) + 7 + static_cast<uintptr_t>(static_cast<intptr_t>(-16));
+    EXPECT_EQ(*result, expected);
+}
+
+TEST_F(ScannerRipTest, resolve_rip_relative_zero_displacement)
+{
+    std::vector<std::byte> code = {
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x05},
+        std::byte{0x00}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+
+    auto result = Scanner::resolve_rip_relative(code.data(), 3, 7);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, reinterpret_cast<uintptr_t>(code.data()) + 7);
+}
+
+TEST_F(ScannerRipTest, resolve_rip_relative_call_rel32)
+{
+    // CALL rel32  =>  E8 10 00 00 00
+    std::vector<std::byte> code = {
+        std::byte{0xE8},
+        std::byte{0x10}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+
+    auto result = Scanner::resolve_rip_relative(code.data(), 1, 5);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t expected = reinterpret_cast<uintptr_t>(code.data()) + 5 + 0x10;
+    EXPECT_EQ(*result, expected);
+}
+
+TEST_F(ScannerRipTest, resolve_rip_relative_null_address)
+{
+    auto result = Scanner::resolve_rip_relative(nullptr, 3, 7);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_mov_rax_rip)
+{
+    // Padding + MOV RAX, [RIP+0x00000020]
+    std::vector<std::byte> code = {
+        std::byte{0x90}, std::byte{0x90}, std::byte{0x90}, // NOP padding
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x05}, // MOV RAX, [RIP+disp32]
+        std::byte{0x20}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
+        std::byte{0x90}, std::byte{0x90}};
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_MOV_RAX_RIP, 7);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t instr_addr = reinterpret_cast<uintptr_t>(&code[3]);
+    EXPECT_EQ(*result, instr_addr + 7 + 0x20);
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_lea_rax_rip)
+{
+    // LEA RAX, [RIP+0x100]
+    std::vector<std::byte> code = {
+        std::byte{0x48}, std::byte{0x8D}, std::byte{0x05},
+        std::byte{0x00}, std::byte{0x01}, std::byte{0x00}, std::byte{0x00}};
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_LEA_RAX_RIP, 7);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t expected = reinterpret_cast<uintptr_t>(code.data()) + 7 + 0x100;
+    EXPECT_EQ(*result, expected);
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_call_rel32)
+{
+    std::vector<std::byte> code = {
+        std::byte{0x55}, // PUSH RBP
+        std::byte{0xE8}, // CALL rel32
+        std::byte{0xFF}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
+        std::byte{0x90}};
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_CALL_REL32, 5);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t instr_addr = reinterpret_cast<uintptr_t>(&code[1]);
+    EXPECT_EQ(*result, instr_addr + 5 + 0xFF);
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_jmp_rel32)
+{
+    std::vector<std::byte> code = {
+        std::byte{0xE9},
+        std::byte{0x05}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_JMP_REL32, 5);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t expected = reinterpret_cast<uintptr_t>(code.data()) + 5 + 0x05;
+    EXPECT_EQ(*result, expected);
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_prefix_not_found)
+{
+    std::vector<std::byte> code = {
+        std::byte{0x90}, std::byte{0x90}, std::byte{0x90},
+        std::byte{0x90}, std::byte{0x90}, std::byte{0x90}};
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_MOV_RAX_RIP, 7);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_null_start)
+{
+    auto result = Scanner::find_and_resolve_rip_relative(
+        nullptr, 100,
+        Scanner::PREFIX_MOV_RAX_RIP, 7);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_region_too_small)
+{
+    std::vector<std::byte> code = {
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x05}};
+
+    // Region is smaller than prefix + disp32
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_MOV_RAX_RIP, 7);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_first_match_wins)
+{
+    // Two MOV RAX, [RIP+disp32] with different displacements
+    std::vector<std::byte> code = {
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x05},
+        std::byte{0x10}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x05},
+        std::byte{0x20}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_MOV_RAX_RIP, 7);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t expected = reinterpret_cast<uintptr_t>(code.data()) + 7 + 0x10;
+    EXPECT_EQ(*result, expected);
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_partial_prefix_no_false_match)
+{
+    // 48 8B followed by wrong third byte, then the real prefix
+    std::vector<std::byte> code = {
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x0D}, // MOV RCX, not RAX
+        std::byte{0xFF}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00},
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x05}, // MOV RAX
+        std::byte{0x30}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_MOV_RAX_RIP, 7);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t instr_addr = reinterpret_cast<uintptr_t>(&code[7]);
+    EXPECT_EQ(*result, instr_addr + 7 + 0x30);
+}
+
+TEST_F(ScannerRipTest, resolve_rip_relative_custom_instruction_form)
+{
+    // MOVSS XMM0, [RIP+disp32] => F3 0F 10 05 <disp32>  (prefix_len=4, instr_len=8)
+    std::vector<std::byte> code = {
+        std::byte{0xF3}, std::byte{0x0F}, std::byte{0x10}, std::byte{0x05},
+        std::byte{0x40}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+
+    auto result = Scanner::resolve_rip_relative(code.data(), 4, 8);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t expected = reinterpret_cast<uintptr_t>(code.data()) + 8 + 0x40;
+    EXPECT_EQ(*result, expected);
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_empty_prefix)
+{
+    std::vector<std::byte> code = {std::byte{0x90}};
+    std::span<const std::byte> empty;
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(), empty, 5);
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_prefix_at_boundary)
+{
+    // Prefix starts at the last valid position
+    std::vector<std::byte> code = {
+        std::byte{0x90}, std::byte{0x90}, std::byte{0x90},
+        std::byte{0xE8},
+        std::byte{0x0A}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_CALL_REL32, 5);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t instr_addr = reinterpret_cast<uintptr_t>(&code[3]);
+    EXPECT_EQ(*result, instr_addr + 5 + 0x0A);
+}
+
+TEST_F(ScannerRipTest, find_and_resolve_mov_rcx_rip)
+{
+    std::vector<std::byte> code = {
+        std::byte{0x48}, std::byte{0x8B}, std::byte{0x0D},
+        std::byte{0x50}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+
+    auto result = Scanner::find_and_resolve_rip_relative(
+        code.data(), code.size(),
+        Scanner::PREFIX_MOV_RCX_RIP, 7);
+
+    ASSERT_TRUE(result.has_value());
+    uintptr_t expected = reinterpret_cast<uintptr_t>(code.data()) + 7 + 0x50;
+    EXPECT_EQ(*result, expected);
 }


### PR DESCRIPTION
## Summary
- Add `resolve_rip_relative` and `find_and_resolve_rip_relative` to the Scanner namespace for extracting absolute addresses from x86-64 RIP-relative instructions
- Include `constexpr` opcode prefix constants for common forms (MOV r64, LEA r64, CALL/JMP rel32)
- Safe displacement extraction via `memcpy` with `is_readable` validation and proper `int32_t` → `intptr_t` sign extension

## Test plan
- [x] 18 new tests covering positive/negative/zero displacements, all prefix constants, CALL/JMP rel32, boundary conditions, null/empty inputs, partial prefix rejection, custom instruction forms, and first-match-wins behavior
- [x] All 58 scanner tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RIP-relative instruction resolution for x86-64 architecture, enabling extraction of absolute addresses from RIP-relative code patterns.
  * Introduced scanning capabilities to detect and resolve specific instruction prefixes (MOV, LEA, CALL, JMP).

* **Documentation**
  * Updated README to describe AOB Scanner's RIP-relative instruction resolution support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->