### PR TITLE
fix: resolve critical thread safety, UB, and concurrency bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This project uses CMake with [CMake Presets](https://cmake.org/cmake/help/latest
     │   │   ├── async_logger.hpp      <-- Async logging system
     │   │   ├── config.hpp
     │   │   ├── format.hpp            <-- Format utilities
-    │   │   ├── math.hpp              <-- DirectXMath-powered math utilities
+    │   │   ├── math.hpp              <-- Math utilities (angle conversions)
     │   │   ├── memory.hpp            <-- Memory utilities
     │   │   ├── filesystem.hpp        <-- Filesystem utilities
     │   │   ├── hook_manager.hpp      <-- Hook management

--- a/include/DetourModKit/async_logger.hpp
+++ b/include/DetourModKit/async_logger.hpp
@@ -82,7 +82,8 @@ namespace DetourModKit
         StringPool();
         ~StringPool() noexcept;
 
-        void grow_pool();
+        /// Must be called with pool_mutex_ held.
+        void grow_pool_locked();
         PoolSlot *claim_free_slot() noexcept;
         void release_slot(PoolSlot *slot) noexcept;
 

--- a/include/DetourModKit/format.hpp
+++ b/include/DetourModKit/format.hpp
@@ -76,7 +76,11 @@ namespace DetourModKit
         inline std::string format_hex(ptrdiff_t value)
         {
             if (value < 0)
-                return std::format("-0x{:X}", static_cast<size_t>(-value));
+            {
+                // Two's complement negation via unsigned cast avoids UB on PTRDIFF_MIN
+                const auto magnitude = static_cast<size_t>(~static_cast<size_t>(value) + 1u);
+                return std::format("-0x{:X}", magnitude);
+            }
             return std::format("0x{:X}", static_cast<size_t>(value));
         }
 

--- a/include/DetourModKit/math.hpp
+++ b/include/DetourModKit/math.hpp
@@ -3,7 +3,7 @@
  * @file math.hpp
  * @brief Provides basic mathematical utility functions.
  */
-#include <DirectXMath.h>
+#include <numbers>
 
 namespace DetourModKit
 {
@@ -12,13 +12,13 @@ namespace DetourModKit
         /// Converts an angle from degrees to radians.
         constexpr float degrees_to_radians(float degrees) noexcept
         {
-            return degrees * (DirectX::XM_PI / 180.0f);
+            return degrees * (std::numbers::pi_v<float> / 180.0f);
         }
 
         /// Converts an angle from radians to degrees.
         constexpr float radians_to_degrees(float radians) noexcept
         {
-            return radians * (180.0f / DirectX::XM_PI);
+            return radians * (180.0f / std::numbers::pi_v<float>);
         }
 
     } // namespace Math

--- a/src/async_logger.cpp
+++ b/src/async_logger.cpp
@@ -11,17 +11,20 @@ namespace DetourModKit
 {
     StringPool::StringPool()
     {
-        grow_pool();
+        std::lock_guard<std::mutex> lock(pool_mutex_);
+        grow_pool_locked();
     }
 
     StringPool::~StringPool() noexcept
     {
+        // Acquire the mutex to synchronize with any in-flight deallocate() calls
+        std::lock_guard<std::mutex> lock(pool_mutex_);
+
         Block *current = head_.load(std::memory_order_relaxed);
         while (current)
         {
             Block *next = current->next;
 
-            // Destroy any PoolSlot objects that were constructed via placement-new
             PoolSlot *slots = reinterpret_cast<PoolSlot *>(current->data);
             for (size_t i = 0; i < POOL_SLOTS_PER_BLOCK; ++i)
             {
@@ -34,12 +37,11 @@ namespace DetourModKit
             ::operator delete(current);
             current = next;
         }
+        head_.store(nullptr, std::memory_order_relaxed);
     }
 
-    void StringPool::grow_pool()
+    void StringPool::grow_pool_locked()
     {
-        std::lock_guard<std::mutex> lock(pool_mutex_);
-
         Block *existing = head_.load(std::memory_order_relaxed);
         size_t count = 0;
         for (Block *b = existing; b; b = b->next)
@@ -98,21 +100,17 @@ namespace DetourModKit
     {
         if (size > MEMORY_POOL_BLOCK_SIZE - sizeof(PoolSlot) - 16)
         {
-            return new std::string();
+            auto *ptr = new (std::nothrow) std::string();
+            return ptr;
         }
 
-        PoolSlot *slot = nullptr;
+        std::lock_guard<std::mutex> lock(pool_mutex_);
 
-        {
-            std::lock_guard<std::mutex> lock(pool_mutex_);
-            slot = claim_free_slot();
-        }
-
+        PoolSlot *slot = claim_free_slot();
         if (!slot)
         {
-            grow_pool();
-
-            std::lock_guard<std::mutex> lock(pool_mutex_);
+            // Grow while holding the lock to prevent TOCTOU on block count
+            grow_pool_locked();
             slot = claim_free_slot();
         }
 
@@ -122,39 +120,41 @@ namespace DetourModKit
             return &slot->str;
         }
 
-        return new std::string();
+        // Pool exhausted — fall back to heap (nothrow to support noexcept callers)
+        auto *ptr = new (std::nothrow) std::string();
+        return ptr;
     }
 
     void StringPool::deallocate(std::string *ptr) noexcept
     {
         if (!ptr)
-        {
             return;
-        }
 
-        std::unique_lock<std::mutex> lock(pool_mutex_);
-
-        Block *block = head_.load(std::memory_order_acquire);
-        for (Block *b = block; b; b = b->next)
         {
-            const auto *block_begin = reinterpret_cast<const char *>(b->data);
-            const auto *block_end = block_begin + POOL_SLOTS_PER_BLOCK * sizeof(PoolSlot);
-            const auto *raw_ptr = reinterpret_cast<const char *>(ptr);
+            std::lock_guard<std::mutex> lock(pool_mutex_);
 
-            if (raw_ptr >= block_begin && raw_ptr < block_end)
+            Block *block = head_.load(std::memory_order_relaxed);
+            for (Block *b = block; b; b = b->next)
             {
-                auto offset = static_cast<size_t>(raw_ptr - block_begin);
-                PoolSlot *slot = reinterpret_cast<PoolSlot *>(b->data) + (offset / sizeof(PoolSlot));
-                slot->str.clear();
-                slot->str.shrink_to_fit();
-                slot->next_free = b->free_list;
-                b->free_list = slot;
-                ++b->slot_count;
-                return;
+                const auto *block_begin = reinterpret_cast<const char *>(b->data);
+                const auto *block_end = block_begin + POOL_SLOTS_PER_BLOCK * sizeof(PoolSlot);
+                const auto *raw_ptr = reinterpret_cast<const char *>(ptr);
+
+                if (raw_ptr >= block_begin && raw_ptr < block_end)
+                {
+                    auto offset = static_cast<size_t>(raw_ptr - block_begin);
+                    PoolSlot *slot = reinterpret_cast<PoolSlot *>(b->data) + (offset / sizeof(PoolSlot));
+                    slot->str.clear();
+                    slot->str.shrink_to_fit();
+                    slot->next_free = b->free_list;
+                    b->free_list = slot;
+                    ++b->slot_count;
+                    return;
+                }
             }
         }
 
-        lock.unlock();
+        // Not from the pool — heap-allocated fallback
         delete ptr;
     }
 
@@ -180,11 +180,21 @@ namespace DetourModKit
             overflow = StringPool::instance().allocate(msg_size);
             if (overflow)
             {
-                overflow->assign(std::move(msg));
-                length = overflow->size();
+                try
+                {
+                    overflow->assign(std::move(msg));
+                    length = overflow->size();
+                }
+                catch (...)
+                {
+                    StringPool::instance().deallocate(overflow);
+                    overflow = nullptr;
+                    length = 0;
+                }
             }
             else
             {
+                // Allocation failed (OOM) — message is silently dropped
                 length = 0;
             }
         }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -62,9 +62,11 @@ namespace DetourModKit
 
     void Logger::reconfigure(const std::string &prefix, const std::string &file_name, const std::string &timestamp_fmt)
     {
-        std::lock_guard<std::mutex> lock(*log_mutex_ptr_);
+        // Acquire both async_mutex_ and log_mutex_ to prevent concurrent log() calls
+        // from reading partially-updated string members during reconfiguration
+        std::scoped_lock lock(async_mutex_, *log_mutex_ptr_);
 
-        shutdown_called_ = false;
+        shutdown_called_.store(false, std::memory_order_release);
 
         if (log_file_stream_ptr_->is_open() && log_file_stream_ptr_->good())
         {
@@ -234,6 +236,12 @@ namespace DetourModKit
                 *log_file_stream_ptr_ << "[" << get_timestamp() << "] "
                                       << "[" << std::setw(7) << std::left << level_str << "] :: "
                                       << message << '\n';
+
+                // Flush on warnings/errors to ensure critical messages survive crashes
+                if (level >= LogLevel::Warning)
+                {
+                    log_file_stream_ptr_->flush();
+                }
             }
             else if (level >= LogLevel::Error)
             {
@@ -257,13 +265,17 @@ namespace DetourModKit
             {
                 throw std::runtime_error("localtime_s failed to convert time.");
             }
-#else
-            std::tm *timeinfo_ptr = std::localtime(&in_time_t);
-            if (!timeinfo_ptr)
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+            // MinGW: localtime_s has reversed parameter order (ISO C11 Annex K)
+            if (localtime_s(&timeinfo_struct, &in_time_t) != 0)
             {
-                throw std::runtime_error("std::localtime returned a null pointer.");
+                throw std::runtime_error("localtime_s failed to convert time.");
             }
-            timeinfo_struct = *timeinfo_ptr;
+#else
+            if (localtime_r(&in_time_t, &timeinfo_struct) == nullptr)
+            {
+                throw std::runtime_error("localtime_r failed to convert time.");
+            }
 #endif
             std::ostringstream oss;
             oss << std::put_time(&timeinfo_struct, timestamp_format_.c_str());

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -474,8 +474,8 @@ namespace MemoryUtilsCacheInternal
 
         for (size_t i = 0; i < shard_count; ++i)
         {
-            std::unique_lock<SrwSharedMutex> lock(*s_shardMutexes[i], std::try_to_lock);
-            if (lock.owns_lock())
+            std::unique_lock<SrwSharedMutex> shard_lock(*s_shardMutexes[i], std::try_to_lock);
+            if (shard_lock.owns_lock())
             {
                 cleanup_expired_entries_in_shard(s_cacheShards[i], current_ts, expiry_ns);
                 // Also trim to hard upper bound

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -449,17 +449,21 @@ namespace MemoryUtilsCacheInternal
      */
     void cleanup_expired_entries(bool force) noexcept
     {
-        if (s_cacheShards.empty())
-            return;
-
-        // Background cleanup thread passes force=true and must hold state mutex
-        // to prevent racing with shutdown_cache() which clears vectors.
-        // On-demand cleanup passes force=false and is protected by cache initialization.
-        std::unique_lock<std::mutex> lock;
+        // Always hold state mutex to prevent racing with shutdown_cache()
+        // which clears the shard vectors. try_lock for on-demand to avoid
+        // blocking the hot path; forced cleanup blocks to guarantee progress.
+        std::unique_lock<std::mutex> lock(s_cacheStateMutex, std::defer_lock);
         if (force)
         {
-            lock = std::unique_lock<std::mutex>(s_cacheStateMutex);
+            lock.lock();
         }
+        else if (!lock.try_lock())
+        {
+            return; // Shutdown or forced cleanup in progress, skip
+        }
+
+        if (s_cacheShards.empty())
+            return;
 
         const size_t shard_count = s_shardCount.load(std::memory_order_acquire);
         if (shard_count == 0)

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -1300,3 +1300,144 @@ TEST_F(AsyncLoggerTest, MultiThread_EnqueueStress)
 
     logger.shutdown();
 }
+
+TEST(StringPoolTest, AllocateDeallocate_BasicCycle)
+{
+    auto &pool = StringPool::instance();
+
+    std::string *s = pool.allocate(32);
+    ASSERT_NE(s, nullptr);
+
+    s->assign("hello pool");
+    EXPECT_EQ(*s, "hello pool");
+
+    pool.deallocate(s);
+}
+
+TEST(StringPoolTest, AllocateDeallocate_MultipleSlots)
+{
+    auto &pool = StringPool::instance();
+
+    constexpr size_t kCount = 32;
+    std::vector<std::string *> ptrs;
+    ptrs.reserve(kCount);
+
+    for (size_t i = 0; i < kCount; ++i)
+    {
+        std::string *s = pool.allocate(64);
+        ASSERT_NE(s, nullptr);
+        s->assign("slot_" + std::to_string(i));
+        ptrs.push_back(s);
+    }
+
+    for (size_t i = 0; i < kCount; ++i)
+    {
+        EXPECT_EQ(*ptrs[i], "slot_" + std::to_string(i));
+    }
+
+    for (auto *p : ptrs)
+    {
+        pool.deallocate(p);
+    }
+}
+
+TEST(StringPoolTest, HeapFallback_OversizedAllocation)
+{
+    auto &pool = StringPool::instance();
+
+    std::string *s = pool.allocate(MEMORY_POOL_BLOCK_SIZE);
+    ASSERT_NE(s, nullptr);
+
+    s->assign("heap fallback string");
+    EXPECT_EQ(*s, "heap fallback string");
+
+    pool.deallocate(s);
+}
+
+TEST(StringPoolTest, ConcurrentAllocateDeallocate)
+{
+    auto &pool = StringPool::instance();
+
+    constexpr int kThreads = 4;
+    constexpr int kOpsPerThread = 100;
+    std::atomic<int> success_count{0};
+
+    std::vector<std::thread> threads;
+    for (int t = 0; t < kThreads; ++t)
+    {
+        threads.emplace_back([&, t]()
+                             {
+            for (int i = 0; i < kOpsPerThread; ++i)
+            {
+                std::string *s = pool.allocate(32);
+                if (s)
+                {
+                    s->assign("t" + std::to_string(t) + "_" + std::to_string(i));
+                    success_count.fetch_add(1, std::memory_order_relaxed);
+                    pool.deallocate(s);
+                }
+            } });
+    }
+
+    for (auto &th : threads)
+    {
+        th.join();
+    }
+
+    EXPECT_EQ(success_count.load(), kThreads * kOpsPerThread);
+}
+
+TEST(StringPoolTest, ReuseAfterDeallocate)
+{
+    auto &pool = StringPool::instance();
+
+    std::string *s1 = pool.allocate(16);
+    ASSERT_NE(s1, nullptr);
+    s1->assign("first");
+    pool.deallocate(s1);
+
+    std::string *s2 = pool.allocate(16);
+    ASSERT_NE(s2, nullptr);
+    s2->assign("second");
+    EXPECT_EQ(*s2, "second");
+    pool.deallocate(s2);
+}
+
+TEST(LogMessageTest, Reset_ClearsOverflow)
+{
+    std::string long_msg(LogMessage::MAX_INLINE_SIZE + 100, 'Z');
+    LogMessage msg(LogLevel::Info, long_msg);
+    EXPECT_NE(msg.overflow, nullptr);
+    EXPECT_TRUE(msg.is_valid());
+
+    msg.reset();
+
+    EXPECT_EQ(msg.overflow, nullptr);
+    EXPECT_EQ(msg.length, 0u);
+    EXPECT_EQ(msg.message().size(), 0u);
+}
+
+TEST(LogMessageTest, Reset_InlineMessage)
+{
+    LogMessage msg(LogLevel::Info, "short message");
+    EXPECT_EQ(msg.overflow, nullptr);
+    EXPECT_TRUE(msg.is_valid());
+
+    msg.reset();
+
+    EXPECT_EQ(msg.length, 0u);
+    EXPECT_EQ(msg.message().size(), 0u);
+}
+
+TEST(LogMessageTest, MoveOverflowMessage_ClearsSource)
+{
+    std::string long_msg(LogMessage::MAX_INLINE_SIZE + 50, 'Q');
+    LogMessage src(LogLevel::Error, long_msg);
+    ASSERT_NE(src.overflow, nullptr);
+
+    LogMessage dst(std::move(src));
+
+    EXPECT_NE(dst.overflow, nullptr);
+    EXPECT_EQ(dst.message().size(), LogMessage::MAX_INLINE_SIZE + 50);
+    EXPECT_EQ(src.overflow, nullptr);
+}

--- a/tests/test_format.cpp
+++ b/tests/test_format.cpp
@@ -1,4 +1,7 @@
 #include <gtest/gtest.h>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -157,4 +160,50 @@ TEST(FormatTest, FormatAddress_Width)
 
     std::string result_max = Format::format_address(UINTPTR_MAX);
     EXPECT_EQ(result_max.size(), sizeof(uintptr_t) * 2 + 2);
+}
+
+TEST(FormatTest, FormatHex_PtrdiffPositive)
+{
+    ptrdiff_t value = 0x1234;
+    std::string result = Format::format_hex(value);
+    EXPECT_EQ(result, "0x1234");
+}
+
+TEST(FormatTest, FormatHex_PtrdiffNegative)
+{
+    ptrdiff_t value = -0x10;
+    std::string result = Format::format_hex(value);
+    EXPECT_EQ(result, "-0x10");
+}
+
+TEST(FormatTest, FormatHex_PtrdiffZero)
+{
+    ptrdiff_t value = 0;
+    std::string result = Format::format_hex(value);
+    EXPECT_EQ(result, "0x0");
+}
+
+TEST(FormatTest, FormatHex_PtrdiffMinNoUB)
+{
+    // This previously caused signed overflow UB via -PTRDIFF_MIN
+    ptrdiff_t value = PTRDIFF_MIN;
+    std::string result = Format::format_hex(value);
+    EXPECT_FALSE(result.empty());
+    EXPECT_EQ(result.substr(0, 1), "-");
+    EXPECT_NE(result.find("0x"), std::string::npos);
+}
+
+TEST(FormatTest, FormatHex_PtrdiffMax)
+{
+    ptrdiff_t value = PTRDIFF_MAX;
+    std::string result = Format::format_hex(value);
+    EXPECT_FALSE(result.empty());
+    EXPECT_EQ(result.substr(0, 2), "0x");
+}
+
+TEST(FormatTest, FormatHex_PtrdiffMinusOne)
+{
+    ptrdiff_t value = -1;
+    std::string result = Format::format_hex(value);
+    EXPECT_EQ(result, "-0x1");
 }

--- a/tests/test_math.cpp
+++ b/tests/test_math.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest.h>
 #include <cmath>
-#include <DirectXMath.h>
+#include <numbers>
 
 #include "DetourModKit/math.hpp"
 
 using namespace DetourModKit;
 
-static constexpr float PI = DirectX::XM_PI;
+static constexpr float PI = std::numbers::pi_v<float>;
 
 TEST(MathTest, degrees_to_radians_Zero)
 {


### PR DESCRIPTION
## Summary

Pre-release audit of the v2.0.0 codebase identified 3 critical, 4 high-severity, and 2 medium-severity issues. This PR resolves all actionable findings.

### Critical fixes
- **StringPool destructor race (C1):** Acquire `pool_mutex_` before traversing block list in destructor
- **StringPool TOCTOU (C2):** Rename `grow_pool()` → `grow_pool_locked()`; `allocate()` holds lock for entire claim+grow sequence
- **noexcept + throwing allocator (C3):** Heap fallback uses `new(std::nothrow)`; LogMessage wraps overflow assign in try/catch

### High-severity fixes
- **MinGW localtime thread safety (H1):** Add `localtime_s` branch for `__MINGW32__`/`__MINGW64__`
- **Logger::reconfigure() data race (H2):** Use `std::scoped_lock` on both `async_mutex_` and `log_mutex_ptr_`
- **Memory cache cleanup race (H4):** `cleanup_expired_entries()` always acquires `s_cacheStateMutex`

### Medium-severity fixes
- **format_hex(PTRDIFF_MIN) UB (M1):** Bitwise two's complement negation instead of `-value`
- **Sync-mode flush (M4):** Flush on Warning/Error to prevent crash log loss
- **DirectXMath dependency (L3):** Replace `XM_PI` with `std::numbers::pi_v<float>`

### Tests added (14 new → 461 total)
- StringPool: basic cycle, multiple slots, heap fallback, concurrent access, slot reuse
- LogMessage: reset overflow, reset inline, move clears source
- format_hex(ptrdiff_t): positive, negative, zero, PTRDIFF_MIN, PTRDIFF_MAX, -1

## Test plan
- [x] All 461 tests pass on MinGW debug build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging thread-safety and memory-allocation robustness; safer pool handling and overflow recovery.
  * Fixed hexadecimal formatting for negative values.
  * Enhanced timestamp handling across platforms.

* **Performance Improvements**
  * Automatic flush for warning-level and higher messages.
  * Optimized cache cleanup to reduce contention.

* **Chores**
  * Removed external math dependency; now uses standard library math utilities.

* **Tests**
  * Added unit tests for logger, formatting, and math conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->