### PR TITLE
feat(input): support for reading analog stick inputs with configurable deadzone thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in g
 * **Filesystem Utilities:** Basic filesystem operations, notably getting the current module's runtime directory.
 * **Math Utilities:** Provides basic mathematical utility functions (e.g., angle conversions).
 * **Input System:** Hotkey monitoring with a background polling thread.
-  * **Input sources & modes:** Supports keyboard, mouse, and XInput gamepad input via a unified `InputCode` tagged type (`InputSource` + button code). Press (edge-triggered) and hold (level-triggered) input modes with modifier combinations (AND logic for modifiers, OR logic for trigger keys). Gamepad analog triggers (LT/RT) are treated as digital buttons with a configurable deadzone threshold. Focus-aware by default — input events are ignored when the process does not own the foreground window.
+  * **Input sources & modes:** Supports keyboard, mouse, and XInput gamepad input via a unified `InputCode` tagged type (`InputSource` + button code). Press (edge-triggered) and hold (level-triggered) input modes with modifier combinations (AND logic for modifiers, OR logic for trigger keys). Gamepad analog triggers (LT/RT) and thumbstick axes are treated as digital buttons with configurable deadzone thresholds. Focus-aware by default — input events are ignored when the process does not own the foreground window.
   * **Threading & lifecycle:** Available as an RAII `InputPoller` building block or via the thread-safe `InputManager` singleton for convenience. Two-phase initialization (construct then start) for safe thread launching. `condition_variable_any` with `stop_token` for responsive cooperative shutdown. Exception-safe callback invocation. Automatic hold release on shutdown. DLL-safe when used with `DMK_Shutdown()` before `DLL_PROCESS_DETACH`.
   * **Performance:** O(1) hash-map-backed `is_binding_active()` query for lock-free cross-thread state reads (e.g., from render hooks at 60+ fps). Lock-free `is_running()` via atomic flag. O(1) reverse name lookup for `input_code_to_name()`.
   * **Gamepad & polling:** XInput is polled once per cycle and skipped entirely when no gamepad bindings are registered. Reconnection attempts are throttled to every 2 seconds when no controller is connected, avoiding the per-cycle overhead of `XInputGetState` on disconnected slots.
@@ -541,8 +541,31 @@ The configuration system recognizes the following named input codes (case-insens
 | **Numpad** | `Numpad0`–`Numpad9`, `NumpadAdd`, `NumpadSubtract`, `NumpadMultiply`, `NumpadDivide`, `NumpadDecimal` |
 | **Mouse** | `Mouse1` (left), `Mouse2` (right), `Mouse3` (middle), `Mouse4`, `Mouse5` |
 | **Gamepad** | `Gamepad_A`, `Gamepad_B`, `Gamepad_X`, `Gamepad_Y`, `Gamepad_LB`, `Gamepad_RB`, `Gamepad_LT`, `Gamepad_RT`, `Gamepad_Start`, `Gamepad_Back`, `Gamepad_LS`, `Gamepad_RS`, `Gamepad_DpadUp`, `Gamepad_DpadDown`, `Gamepad_DpadLeft`, `Gamepad_DpadRight` |
+| **Gamepad sticks** | `Gamepad_LSUp`, `Gamepad_LSDown`, `Gamepad_LSLeft`, `Gamepad_LSRight`, `Gamepad_RSUp`, `Gamepad_RSDown`, `Gamepad_RSLeft`, `Gamepad_RSRight` |
 
 Hex VK codes with `0x` prefix (e.g., `0x72` for F3) are also accepted and default to keyboard input.
+
+## Gamepad Compatibility
+
+Gamepad support uses the **XInput** API. The following controllers are supported natively:
+
+| Controller | Supported |
+| --- | --- |
+| Xbox 360 | Yes (native XInput) |
+| Xbox One / Series X\|S | Yes (native XInput) |
+| GameSir (XInput mode) | Yes (switch controller to XInput mode) |
+| PS4 DualShock 4 | Via [DS4Windows](https://github.com/Ryochan7/DS4Windows) or Steam Input |
+| PS5 DualSense | Via [DualSenseX](https://github.com/Jehan-HENRY/DualSenseX) or Steam Input |
+| Nintendo Switch Pro | Via [BetterJoy](https://github.com/Davidobot/BetterJoy) or Steam Input |
+| Generic USB gamepads | Only if the controller exposes an XInput interface |
+
+**Why XInput only?** DetourModKit's input system is designed for mod hotkeys and toggles, not for replacing a game's primary input handling. XInput covers Xbox controllers natively, and the vast majority of PC players using non-Xbox controllers already use Steam Input or similar remapping tools that present their controller as XInput. Adding DirectInput or Windows.Gaming.Input would significantly increase complexity for a use case where XInput + keyboard/mouse covers nearly all real users.
+
+**Limitations:**
+
+* Maximum 4 controllers (XInput hard limit, indices 0-3).
+* Analog triggers (LT/RT) and thumbstick axes are treated as digital buttons with configurable deadzone thresholds.
+* No event-driven hot-plug detection; controller connection is checked via polling (reconnection attempts are throttled to every 2 seconds when disconnected).
 
 ## Projects Using DetourModKit
 

--- a/include/DetourModKit/input.hpp
+++ b/include/DetourModKit/input.hpp
@@ -111,13 +111,16 @@ namespace DetourModKit
          * @param gamepad_index XInput controller index (0-3) to poll for gamepad bindings.
          * @param trigger_threshold Analog trigger deadzone threshold (0-255). Trigger values
          *                          above this threshold are considered "pressed".
+         * @param stick_threshold Thumbstick deadzone threshold (0-32767). Axis values
+         *                        exceeding this threshold in any direction are "pressed".
          * @note The polling thread does not start until start() is called.
          */
         explicit InputPoller(std::vector<InputBinding> bindings,
                              std::chrono::milliseconds poll_interval = DEFAULT_POLL_INTERVAL,
                              bool require_focus = true,
                              int gamepad_index = 0,
-                             int trigger_threshold = GamepadCode::TriggerThreshold);
+                             int trigger_threshold = GamepadCode::TriggerThreshold,
+                             int stick_threshold = GamepadCode::StickThreshold);
 
         ~InputPoller();
 
@@ -211,6 +214,7 @@ namespace DetourModKit
 
         int gamepad_index_;
         int trigger_threshold_;
+        int stick_threshold_;
         bool has_gamepad_bindings_;
     };
 
@@ -314,6 +318,13 @@ namespace DetourModKit
         void set_trigger_threshold(int threshold);
 
         /**
+         * @brief Sets the thumbstick deadzone threshold for gamepad bindings.
+         * @param threshold Axis values exceeding this threshold (0-32767) are "pressed".
+         * @note Must be called before start(). Has no effect while the poller is running.
+         */
+        void set_stick_threshold(int threshold);
+
+        /**
          * @brief Starts the input polling thread with all registered bindings.
          * @details Constructs an internal InputPoller with the current bindings
          *          and begins monitoring. Subsequent register calls are ignored
@@ -364,6 +375,7 @@ namespace DetourModKit
         bool require_focus_ = true;
         int gamepad_index_ = 0;
         int trigger_threshold_ = GamepadCode::TriggerThreshold;
+        int stick_threshold_ = GamepadCode::StickThreshold;
     };
 } // namespace DetourModKit
 

--- a/include/DetourModKit/input_codes.hpp
+++ b/include/DetourModKit/input_codes.hpp
@@ -84,10 +84,11 @@ namespace DetourModKit
 
     /**
      * @namespace GamepadCode
-     * @brief XInput-compatible gamepad button codes and synthetic trigger identifiers.
+     * @brief XInput-compatible gamepad button codes and synthetic analog identifiers.
      * @details Digital button codes match XInput XINPUT_GAMEPAD_* bitmask values.
-     *          LeftTrigger and RightTrigger are synthetic codes for analog triggers
-     *          treated as digital inputs with a configurable deadzone threshold.
+     *          LeftTrigger/RightTrigger and thumbstick direction codes are synthetic
+     *          identifiers for analog inputs treated as digital with configurable
+     *          deadzone thresholds.
      */
     namespace GamepadCode
     {
@@ -110,8 +111,23 @@ namespace DetourModKit
         inline constexpr int LeftTrigger = 0x10000;
         inline constexpr int RightTrigger = 0x10001;
 
+        /// Synthetic codes for thumbstick axes treated as digital inputs.
+        /// Each direction fires when the axis exceeds the stick deadzone threshold.
+        inline constexpr int LeftStickUp = 0x10002;
+        inline constexpr int LeftStickDown = 0x10003;
+        inline constexpr int LeftStickLeft = 0x10004;
+        inline constexpr int LeftStickRight = 0x10005;
+        inline constexpr int RightStickUp = 0x10006;
+        inline constexpr int RightStickDown = 0x10007;
+        inline constexpr int RightStickLeft = 0x10008;
+        inline constexpr int RightStickRight = 0x10009;
+
         /// Default analog trigger threshold (0-255 range, values above are "pressed").
         inline constexpr int TriggerThreshold = 30;
+
+        /// Default thumbstick deadzone threshold (0-32767 range).
+        /// Matches XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE (7849).
+        inline constexpr int StickThreshold = 7849;
     } // namespace GamepadCode
 
     /**

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -26,12 +26,14 @@ namespace DetourModKit
          * @param gamepad_state Cached XInput state for the current poll cycle.
          * @param gamepad_connected Whether the gamepad is connected.
          * @param trigger_threshold Analog trigger deadzone threshold.
+         * @param stick_threshold Thumbstick deadzone threshold.
          * @return true if the input is currently pressed.
          */
         bool is_code_pressed(const InputCode &code,
                              const XINPUT_STATE &gamepad_state,
                              bool gamepad_connected,
-                             int trigger_threshold) noexcept
+                             int trigger_threshold,
+                             int stick_threshold) noexcept
         {
             switch (code.source)
             {
@@ -44,15 +46,37 @@ namespace DetourModKit
                 {
                     return false;
                 }
-                if (code.code == GamepadCode::LeftTrigger)
+                // Fast path: digital button bitmask (all codes below synthetic range)
+                if (code.code < GamepadCode::LeftTrigger)
                 {
+                    return (gamepad_state.Gamepad.wButtons & static_cast<WORD>(code.code)) != 0;
+                }
+                // Synthetic analog codes
+                switch (code.code)
+                {
+                case GamepadCode::LeftTrigger:
                     return gamepad_state.Gamepad.bLeftTrigger > trigger_threshold;
-                }
-                if (code.code == GamepadCode::RightTrigger)
-                {
+                case GamepadCode::RightTrigger:
                     return gamepad_state.Gamepad.bRightTrigger > trigger_threshold;
+                case GamepadCode::LeftStickUp:
+                    return gamepad_state.Gamepad.sThumbLY > stick_threshold;
+                case GamepadCode::LeftStickDown:
+                    return gamepad_state.Gamepad.sThumbLY < -stick_threshold;
+                case GamepadCode::LeftStickLeft:
+                    return gamepad_state.Gamepad.sThumbLX < -stick_threshold;
+                case GamepadCode::LeftStickRight:
+                    return gamepad_state.Gamepad.sThumbLX > stick_threshold;
+                case GamepadCode::RightStickUp:
+                    return gamepad_state.Gamepad.sThumbRY > stick_threshold;
+                case GamepadCode::RightStickDown:
+                    return gamepad_state.Gamepad.sThumbRY < -stick_threshold;
+                case GamepadCode::RightStickLeft:
+                    return gamepad_state.Gamepad.sThumbRX < -stick_threshold;
+                case GamepadCode::RightStickRight:
+                    return gamepad_state.Gamepad.sThumbRX > stick_threshold;
+                default:
+                    return false;
                 }
-                return (gamepad_state.Gamepad.wButtons & static_cast<WORD>(code.code)) != 0;
             }
             }
             return false;
@@ -92,13 +116,15 @@ namespace DetourModKit
                              std::chrono::milliseconds poll_interval,
                              bool require_focus,
                              int gamepad_index,
-                             int trigger_threshold)
+                             int trigger_threshold,
+                             int stick_threshold)
         : bindings_(std::move(bindings)),
           poll_interval_(std::clamp(poll_interval, MIN_POLL_INTERVAL, MAX_POLL_INTERVAL)),
           require_focus_(require_focus),
           active_states_(std::make_unique<std::atomic<uint8_t>[]>(bindings_.size())),
           gamepad_index_(std::clamp(gamepad_index, 0, 3)),
           trigger_threshold_(std::clamp(trigger_threshold, 0, 255)),
+          stick_threshold_(std::clamp(stick_threshold, 0, 32767)),
           has_gamepad_bindings_(scan_for_gamepad_bindings(bindings_))
     {
         name_index_.reserve(bindings_.size());
@@ -199,7 +225,8 @@ namespace DetourModKit
     void InputPoller::poll_loop(std::stop_token stop_token)
     {
         const size_t count = bindings_.size();
-        const int threshold = trigger_threshold_;
+        const int trigger_thresh = trigger_threshold_;
+        const int stick_thresh = stick_threshold_;
 
         constexpr auto gamepad_reconnect_interval = std::chrono::seconds{2};
         bool gamepad_was_connected = false;
@@ -244,7 +271,7 @@ namespace DetourModKit
                     bool modifiers_held = true;
                     for (const auto &mod : binding.modifiers)
                     {
-                        if (!is_code_pressed(mod, gamepad_state, gamepad_connected, threshold))
+                        if (!is_code_pressed(mod, gamepad_state, gamepad_connected, trigger_thresh, stick_thresh))
                         {
                             modifiers_held = false;
                             break;
@@ -255,7 +282,7 @@ namespace DetourModKit
                     {
                         for (const auto &key : binding.keys)
                         {
-                            if (is_code_pressed(key, gamepad_state, gamepad_connected, threshold))
+                            if (is_code_pressed(key, gamepad_state, gamepad_connected, trigger_thresh, stick_thresh))
                             {
                                 any_pressed = true;
                                 break;
@@ -456,6 +483,12 @@ namespace DetourModKit
         trigger_threshold_ = std::clamp(threshold, 0, 255);
     }
 
+    void InputManager::set_stick_threshold(int threshold)
+    {
+        std::lock_guard lock(mutex_);
+        stick_threshold_ = std::clamp(threshold, 0, 32767);
+    }
+
     void InputManager::start(std::chrono::milliseconds poll_interval)
     {
         std::lock_guard lock(mutex_);
@@ -482,7 +515,8 @@ namespace DetourModKit
         }
 
         poller_ = std::make_unique<InputPoller>(std::move(pending_bindings_), poll_interval,
-                                                require_focus_, gamepad_index_, trigger_threshold_);
+                                                require_focus_, gamepad_index_, trigger_threshold_,
+                                                stick_threshold_);
         pending_bindings_.clear();
         poller_->start();
         running_.store(true, std::memory_order_release);

--- a/src/input_codes.cpp
+++ b/src/input_codes.cpp
@@ -168,6 +168,16 @@ namespace DetourModKit
             {"Gamepad_DpadDown",   {InputSource::Gamepad, GamepadCode::DpadDown}},
             {"Gamepad_DpadLeft",   {InputSource::Gamepad, GamepadCode::DpadLeft}},
             {"Gamepad_DpadRight",  {InputSource::Gamepad, GamepadCode::DpadRight}},
+
+            // --- Gamepad thumbstick axes (digital) ---
+            {"Gamepad_LSUp",       {InputSource::Gamepad, GamepadCode::LeftStickUp}},
+            {"Gamepad_LSDown",     {InputSource::Gamepad, GamepadCode::LeftStickDown}},
+            {"Gamepad_LSLeft",     {InputSource::Gamepad, GamepadCode::LeftStickLeft}},
+            {"Gamepad_LSRight",    {InputSource::Gamepad, GamepadCode::LeftStickRight}},
+            {"Gamepad_RSUp",       {InputSource::Gamepad, GamepadCode::RightStickUp}},
+            {"Gamepad_RSDown",     {InputSource::Gamepad, GamepadCode::RightStickDown}},
+            {"Gamepad_RSLeft",     {InputSource::Gamepad, GamepadCode::RightStickLeft}},
+            {"Gamepad_RSRight",    {InputSource::Gamepad, GamepadCode::RightStickRight}},
         };
         // clang-format on
 

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -967,3 +967,35 @@ TEST_F(ConfigTest, RegisterKeyCombo_MouseDefault)
     ASSERT_EQ(combo.modifiers.size(), 1u);
     EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
 }
+
+TEST_F(ConfigTest, RegisterKeyCombo_ThumbstickDefault)
+{
+    Config::KeyCombo combo;
+
+    Config::register_key_combo("Hotkeys", "LS", "ls", [&combo](const Config::KeyCombo &c)
+                               { combo = c; }, "Gamepad_LB+Gamepad_LSUp");
+
+    ASSERT_EQ(combo.keys.size(), 1u);
+    EXPECT_EQ(combo.keys[0], gamepad_button(GamepadCode::LeftStickUp));
+    ASSERT_EQ(combo.modifiers.size(), 1u);
+    EXPECT_EQ(combo.modifiers[0], gamepad_button(GamepadCode::LeftBumper));
+}
+
+TEST_F(ConfigTest, KeyCombo_ThumbstickFromFile)
+{
+    std::ofstream ini_file(test_ini_file_);
+    ini_file << "[Hotkeys]\n";
+    ini_file << "StickCombo=Gamepad_RSLeft,Gamepad_RSRight\n";
+    ini_file.close();
+
+    Config::KeyCombo combo;
+
+    Config::register_key_combo("Hotkeys", "StickCombo", "stick", [&combo](const Config::KeyCombo &c)
+                               { combo = c; }, "");
+
+    EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
+
+    ASSERT_EQ(combo.keys.size(), 2u);
+    EXPECT_EQ(combo.keys[0], gamepad_button(GamepadCode::RightStickLeft));
+    EXPECT_EQ(combo.keys[1], gamepad_button(GamepadCode::RightStickRight));
+}

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -1128,3 +1128,134 @@ TEST(InputCodeNameTest, FormatInputCode)
     // Unknown code falls back to hex
     EXPECT_EQ(format_input_code(keyboard_key(0xFF)), "0xFF");
 }
+
+// --- Thumbstick axis codes ---
+
+TEST(InputCodeNameTest, ParseThumbstickNames)
+{
+    auto lsu = parse_input_name("Gamepad_LSUp");
+    ASSERT_TRUE(lsu.has_value());
+    EXPECT_EQ(lsu->source, InputSource::Gamepad);
+    EXPECT_EQ(lsu->code, GamepadCode::LeftStickUp);
+
+    auto lsd = parse_input_name("Gamepad_LSDown");
+    ASSERT_TRUE(lsd.has_value());
+    EXPECT_EQ(lsd->code, GamepadCode::LeftStickDown);
+
+    auto lsl = parse_input_name("Gamepad_LSLeft");
+    ASSERT_TRUE(lsl.has_value());
+    EXPECT_EQ(lsl->code, GamepadCode::LeftStickLeft);
+
+    auto lsr = parse_input_name("Gamepad_LSRight");
+    ASSERT_TRUE(lsr.has_value());
+    EXPECT_EQ(lsr->code, GamepadCode::LeftStickRight);
+
+    auto rsu = parse_input_name("Gamepad_RSUp");
+    ASSERT_TRUE(rsu.has_value());
+    EXPECT_EQ(rsu->code, GamepadCode::RightStickUp);
+
+    auto rsd = parse_input_name("Gamepad_RSDown");
+    ASSERT_TRUE(rsd.has_value());
+    EXPECT_EQ(rsd->code, GamepadCode::RightStickDown);
+
+    auto rsl = parse_input_name("Gamepad_RSLeft");
+    ASSERT_TRUE(rsl.has_value());
+    EXPECT_EQ(rsl->code, GamepadCode::RightStickLeft);
+
+    auto rsr = parse_input_name("Gamepad_RSRight");
+    ASSERT_TRUE(rsr.has_value());
+    EXPECT_EQ(rsr->code, GamepadCode::RightStickRight);
+}
+
+TEST(InputCodeNameTest, ThumbstickCaseInsensitive)
+{
+    auto code = parse_input_name("gamepad_lsup");
+    ASSERT_TRUE(code.has_value());
+    EXPECT_EQ(*code, gamepad_button(GamepadCode::LeftStickUp));
+}
+
+TEST(InputCodeNameTest, ThumbstickReverseNameLookup)
+{
+    EXPECT_EQ(input_code_to_name(gamepad_button(GamepadCode::LeftStickUp)), "Gamepad_LSUp");
+    EXPECT_EQ(input_code_to_name(gamepad_button(GamepadCode::RightStickRight)), "Gamepad_RSRight");
+}
+
+TEST(InputCodeNameTest, FormatThumbstickCode)
+{
+    EXPECT_EQ(format_input_code(gamepad_button(GamepadCode::LeftStickUp)), "Gamepad_LSUp");
+    EXPECT_EQ(format_input_code(gamepad_button(GamepadCode::RightStickDown)), "Gamepad_RSDown");
+}
+
+TEST_F(InputPollerTest, ThumbstickBindingConstruction)
+{
+    std::vector<InputBinding> bindings;
+
+    InputBinding binding;
+    binding.name = "stick_test";
+    binding.keys = {gamepad_button(GamepadCode::LeftStickUp)};
+    binding.mode = InputMode::Hold;
+    binding.on_state_change = [](bool) {};
+    bindings.push_back(std::move(binding));
+
+    InputPoller poller(std::move(bindings));
+
+    EXPECT_EQ(poller.binding_count(), 1u);
+
+    poller.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds{50});
+    EXPECT_TRUE(poller.is_running());
+
+    poller.shutdown();
+}
+
+TEST_F(InputPollerTest, ThumbstickWithCustomThreshold)
+{
+    std::vector<InputBinding> bindings;
+
+    InputBinding binding;
+    binding.name = "stick_custom";
+    binding.keys = {gamepad_button(GamepadCode::RightStickLeft)};
+    binding.mode = InputMode::Press;
+    binding.on_press = []() {};
+    bindings.push_back(std::move(binding));
+
+    InputPoller poller(std::move(bindings), DEFAULT_POLL_INTERVAL, true, 0,
+                       GamepadCode::TriggerThreshold, 16000);
+
+    poller.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds{50});
+    EXPECT_TRUE(poller.is_running());
+    EXPECT_FALSE(poller.is_binding_active("stick_custom"));
+
+    poller.shutdown();
+}
+
+TEST_F(InputManagerTest, SetStickThreshold)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    mgr.set_stick_threshold(12000);
+    mgr.register_hold("ls_up", {gamepad_button(GamepadCode::LeftStickUp)}, [](bool) {});
+    mgr.start();
+
+    EXPECT_TRUE(mgr.is_running());
+
+    mgr.shutdown();
+}
+
+TEST_F(InputManagerTest, ThumbstickAndButtonMixed)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    mgr.register_press("gp_a", {gamepad_button(GamepadCode::A)}, []() {});
+    mgr.register_hold("ls_up", {gamepad_button(GamepadCode::LeftStickUp)}, [](bool) {});
+    mgr.register_press("rs_right", {gamepad_button(GamepadCode::RightStickRight)},
+                        {gamepad_button(GamepadCode::LeftBumper)}, []() {});
+
+    EXPECT_EQ(mgr.binding_count(), 3u);
+
+    mgr.start();
+    EXPECT_TRUE(mgr.is_running());
+
+    mgr.shutdown();
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended gamepad input support to treat thumbstick axes as digital inputs with configurable deadzone thresholds, alongside analog triggers.
  * Added eight new input codes for thumbstick directional inputs: `Gamepad_LSUp/Down/Left/Right` and `Gamepad_RSUp/Down/Left/Right`.

* **Documentation**
  * Updated gamepad compatibility information with XInput-only support details, supported controller types, and key limitations.

* **Tests**
  * Added test coverage for thumbstick axis input parsing, name mappings, and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->