### PR TITLE
test(hook_manager): add cross-module hook integration tests with DLL target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ include/DetourModKit/    # Public headers — one per module
   string.hpp             # String trim (header-only)
 src/                     # Implementation files (one .cpp per module)
 tests/                   # GoogleTest suites (one test_*.cpp per module)
+  fixtures/              # Test support files (hook_target_lib DLL source)
 external/                # Git submodules (safetyhook, DirectXMath, simpleini)
 CMakeLists.txt           # Single CMakeLists — static library target
 CMakePresets.json        # Build presets (mingw-debug/release, msvc-debug/release)
@@ -135,6 +136,7 @@ hook_manager.with_inline_hook("camera_update", [](const safetyhook::InlineHook &
 
 - **Framework:** GoogleTest. Test entry point is `tests/main.cpp`.
 - **One test file per module:** `tests/test_<module>.cpp` mirrors `src/<module>.cpp`.
+- **Integration tests:** `tests/test_hook_integration.cpp` tests cross-module hooking against `tests/fixtures/hook_target_lib.cpp` (built as a DLL). The DLL exports `extern "C"` functions with volatile magic constants for stable AOB patterns.
 - **Test fixture pattern:** Each suite uses a `::testing::Test` subclass with `SetUp()`/`TearDown()` for temp file cleanup.
 - **Coverage gate:** 80% minimum line coverage enforced in CI. All PRs must pass.
 - **Concurrency tests:** Use `std::atomic<bool> stop` flag pattern with multiple threads. See `AsyncMode_ConcurrentLogAndDisable` in `test_logger.cpp` for the reference pattern.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,15 @@ foreach(_ext_target gtest gtest_main gmock gmock_main)
   endif()
 endforeach()
 
+# Test fixture DLL for cross-module hook integration tests
+add_library(hook_target_lib SHARED
+  "${CMAKE_CURRENT_SOURCE_DIR}/fixtures/hook_target_lib.cpp"
+)
+set_target_properties(hook_target_lib PROPERTIES
+  PREFIX ""
+  OUTPUT_NAME "hook_target_lib"
+)
+
 # Automatically collect all test source files
 # This will include all test_*.cpp files and main.cpp
 file(GLOB TEST_SOURCES
@@ -42,11 +51,20 @@ endforeach()
 # Enable testing for the DetourModKit library
 add_executable(DetourModKit_tests ${TEST_SOURCES})
 
+# Ensure the hook target DLL is built before tests and placed alongside the test exe
+add_dependencies(DetourModKit_tests hook_target_lib)
+add_custom_command(TARGET hook_target_lib POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    $<TARGET_FILE:hook_target_lib>
+    $<TARGET_FILE_DIR:DetourModKit_tests>
+)
+
 # Link GoogleTest and DetourModKit
 target_link_libraries(DetourModKit_tests
   PRIVATE
   DetourModKit
   GTest::gtest_main
+  psapi
 )
 
 # Include directories

--- a/tests/fixtures/hook_target_lib.cpp
+++ b/tests/fixtures/hook_target_lib.cpp
@@ -1,0 +1,40 @@
+#include <windows.h>
+
+extern "C"
+{
+    __declspec(dllexport) __declspec(noinline) int compute_damage(int base, int modifier)
+    {
+        volatile int magic = 0xDEAD;
+        volatile int result = base + modifier + (magic - magic);
+        return result;
+    }
+
+    __declspec(dllexport) __declspec(noinline) int compute_armor(int defense, int level)
+    {
+        volatile int magic = 0xBEEF;
+        volatile int result = defense * level + (magic - magic);
+        return result;
+    }
+
+    __declspec(dllexport) __declspec(noinline) int compute_speed(int agility, int bonus)
+    {
+        volatile int magic = 0xCAFE;
+        volatile int result = agility - bonus + (magic - magic);
+        return result;
+    }
+
+    __declspec(dllexport) __declspec(noinline) int compute_critical(int power, int luck)
+    {
+        volatile int magic = 0xF00D;
+        volatile int result = power + luck * 2 + (magic - magic);
+        return result;
+    }
+}
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+    (void)hModule;
+    (void)ul_reason_for_call;
+    (void)lpReserved;
+    return TRUE;
+}

--- a/tests/test_hook_integration.cpp
+++ b/tests/test_hook_integration.cpp
@@ -1,14 +1,16 @@
-#include <gtest/gtest.h>
-#include <windows.h>
-#include <psapi.h>
-#include <atomic>
-#include <cstddef>
-#include <cstdint>
-#include <string>
-
 #include "DetourModKit/hook_manager.hpp"
 #include "DetourModKit/scanner.hpp"
 #include "DetourModKit/logger.hpp"
+
+#include <gtest/gtest.h>
+#include <windows.h>
+#include <psapi.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <string>
 
 using namespace DetourModKit;
 
@@ -17,33 +19,53 @@ using ComputeArmorFn = int (*)(int, int);
 using ComputeSpeedFn = int (*)(int, int);
 using ComputeCriticalFn = int (*)(int, int);
 
-static ComputeDamageFn g_original_compute_damage = nullptr;
-static ComputeArmorFn g_original_compute_armor = nullptr;
+static ComputeDamageFn s_original_compute_damage = nullptr;
+static ComputeArmorFn s_original_compute_armor = nullptr;
 
-static std::atomic<int> g_detour_call_count{0};
+static std::atomic<int> s_detour_call_count{0};
+
+static constexpr size_t AOB_SIGNATURE_LENGTH = 16;
 
 static int detour_compute_damage(int base, int modifier)
 {
-    g_detour_call_count.fetch_add(1, std::memory_order_relaxed);
-    if (g_original_compute_damage) {
-        return g_original_compute_damage(base, modifier) * 2;
+    s_detour_call_count.fetch_add(1, std::memory_order_relaxed);
+    if (s_original_compute_damage)
+    {
+        return s_original_compute_damage(base, modifier) * 2;
     }
     return (base + modifier) * 2;
 }
 
 static int detour_compute_armor(int defense, int level)
 {
-    g_detour_call_count.fetch_add(1, std::memory_order_relaxed);
-    if (g_original_compute_armor) {
-        return g_original_compute_armor(defense, level) + 999;
+    s_detour_call_count.fetch_add(1, std::memory_order_relaxed);
+    if (s_original_compute_armor)
+    {
+        return s_original_compute_armor(defense, level) + 999;
     }
     return defense * level + 999;
 }
 
 static int detour_compute_speed(int agility, int bonus)
 {
-    g_detour_call_count.fetch_add(1, std::memory_order_relaxed);
+    s_detour_call_count.fetch_add(1, std::memory_order_relaxed);
     return (agility - bonus) * 3;
+}
+
+static std::string build_aob_from_bytes(const unsigned char *bytes, size_t count)
+{
+    std::string aob;
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (i > 0)
+        {
+            aob += ' ';
+        }
+        char hex[4];
+        std::snprintf(hex, sizeof(hex), "%02X", bytes[i]);
+        aob += hex;
+    }
+    return aob;
 }
 
 class HookIntegrationTest : public ::testing::Test
@@ -51,73 +73,75 @@ class HookIntegrationTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        hook_manager_ = &HookManager::get_instance();
-        hook_manager_->remove_all_hooks();
-        g_detour_call_count.store(0);
-        g_original_compute_damage = nullptr;
-        g_original_compute_armor = nullptr;
+        m_hook_manager = &HookManager::get_instance();
+        m_hook_manager->remove_all_hooks();
+        s_detour_call_count.store(0);
+        s_original_compute_damage = nullptr;
+        s_original_compute_armor = nullptr;
 
-        dll_handle_ = LoadLibraryA("hook_target_lib.dll");
-        ASSERT_NE(dll_handle_, nullptr)
+        m_dll_handle = LoadLibraryA("hook_target_lib.dll");
+        ASSERT_NE(m_dll_handle, nullptr)
             << "Failed to load hook_target_lib.dll. Error: " << GetLastError();
 
-        fn_compute_damage_ = reinterpret_cast<ComputeDamageFn>(
-            GetProcAddress(dll_handle_, "compute_damage"));
-        fn_compute_armor_ = reinterpret_cast<ComputeArmorFn>(
-            GetProcAddress(dll_handle_, "compute_armor"));
-        fn_compute_speed_ = reinterpret_cast<ComputeSpeedFn>(
-            GetProcAddress(dll_handle_, "compute_speed"));
-        fn_compute_critical_ = reinterpret_cast<ComputeCriticalFn>(
-            GetProcAddress(dll_handle_, "compute_critical"));
+        m_fn_compute_damage = reinterpret_cast<ComputeDamageFn>(
+            GetProcAddress(m_dll_handle, "compute_damage"));
+        m_fn_compute_armor = reinterpret_cast<ComputeArmorFn>(
+            GetProcAddress(m_dll_handle, "compute_armor"));
+        m_fn_compute_speed = reinterpret_cast<ComputeSpeedFn>(
+            GetProcAddress(m_dll_handle, "compute_speed"));
+        m_fn_compute_critical = reinterpret_cast<ComputeCriticalFn>(
+            GetProcAddress(m_dll_handle, "compute_critical"));
 
-        ASSERT_NE(fn_compute_damage_, nullptr) << "compute_damage export not found";
-        ASSERT_NE(fn_compute_armor_, nullptr) << "compute_armor export not found";
-        ASSERT_NE(fn_compute_speed_, nullptr) << "compute_speed export not found";
-        ASSERT_NE(fn_compute_critical_, nullptr) << "compute_critical export not found";
+        ASSERT_NE(m_fn_compute_damage, nullptr) << "compute_damage export not found";
+        ASSERT_NE(m_fn_compute_armor, nullptr) << "compute_armor export not found";
+        ASSERT_NE(m_fn_compute_speed, nullptr) << "compute_speed export not found";
+        ASSERT_NE(m_fn_compute_critical, nullptr) << "compute_critical export not found";
 
         MODULEINFO mod_info{};
         BOOL info_ok = GetModuleInformation(
-            GetCurrentProcess(), dll_handle_, &mod_info, sizeof(mod_info));
+            GetCurrentProcess(), m_dll_handle, &mod_info, sizeof(mod_info));
         ASSERT_TRUE(info_ok) << "GetModuleInformation failed";
 
-        module_base_ = reinterpret_cast<uintptr_t>(mod_info.lpBaseOfDll);
-        module_size_ = mod_info.SizeOfImage;
+        m_module_base = reinterpret_cast<uintptr_t>(mod_info.lpBaseOfDll);
+        m_module_size = mod_info.SizeOfImage;
     }
 
     void TearDown() override
     {
-        if (hook_manager_) {
-            hook_manager_->remove_all_hooks();
+        if (m_hook_manager)
+        {
+            m_hook_manager->remove_all_hooks();
         }
-        g_original_compute_damage = nullptr;
-        g_original_compute_armor = nullptr;
+        s_original_compute_damage = nullptr;
+        s_original_compute_armor = nullptr;
 
-        if (dll_handle_) {
-            FreeLibrary(dll_handle_);
-            dll_handle_ = nullptr;
+        if (m_dll_handle)
+        {
+            FreeLibrary(m_dll_handle);
+            m_dll_handle = nullptr;
         }
     }
 
-    HookManager *hook_manager_ = nullptr;
-    HMODULE dll_handle_ = nullptr;
+    HookManager *m_hook_manager = nullptr;
+    HMODULE m_dll_handle = nullptr;
 
-    ComputeDamageFn fn_compute_damage_ = nullptr;
-    ComputeArmorFn fn_compute_armor_ = nullptr;
-    ComputeSpeedFn fn_compute_speed_ = nullptr;
-    ComputeCriticalFn fn_compute_critical_ = nullptr;
+    ComputeDamageFn m_fn_compute_damage = nullptr;
+    ComputeArmorFn m_fn_compute_armor = nullptr;
+    ComputeSpeedFn m_fn_compute_speed = nullptr;
+    ComputeCriticalFn m_fn_compute_critical = nullptr;
 
-    uintptr_t module_base_ = 0;
-    size_t module_size_ = 0;
+    uintptr_t m_module_base = 0;
+    size_t m_module_size = 0;
 };
 
 TEST_F(HookIntegrationTest, InlineHook_AlterReturnValue)
 {
-    EXPECT_EQ(fn_compute_damage_(10, 5), 15);
+    EXPECT_EQ(m_fn_compute_damage(10, 5), 15);
 
     void *trampoline = nullptr;
-    auto result = hook_manager_->create_inline_hook(
+    auto result = m_hook_manager->create_inline_hook(
         "DamageHook",
-        reinterpret_cast<uintptr_t>(fn_compute_damage_),
+        reinterpret_cast<uintptr_t>(m_fn_compute_damage),
         reinterpret_cast<void *>(&detour_compute_damage),
         &trampoline);
 
@@ -125,80 +149,84 @@ TEST_F(HookIntegrationTest, InlineHook_AlterReturnValue)
         << "Hook creation failed: " << Hook::error_to_string(result.error());
     ASSERT_NE(trampoline, nullptr);
 
-    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
+    s_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
 
-    int hooked_result = fn_compute_damage_(10, 5);
+    int hooked_result = m_fn_compute_damage(10, 5);
     EXPECT_EQ(hooked_result, 30);
-    EXPECT_GE(g_detour_call_count.load(), 1);
+    EXPECT_GE(s_detour_call_count.load(), 1);
 }
 
 TEST_F(HookIntegrationTest, InlineHook_RemoveRestoresOriginal)
 {
-    EXPECT_EQ(fn_compute_damage_(20, 10), 30);
+    EXPECT_EQ(m_fn_compute_damage(20, 10), 30);
 
     void *trampoline = nullptr;
-    auto result = hook_manager_->create_inline_hook(
+    auto result = m_hook_manager->create_inline_hook(
         "DamageHookRemove",
-        reinterpret_cast<uintptr_t>(fn_compute_damage_),
+        reinterpret_cast<uintptr_t>(m_fn_compute_damage),
         reinterpret_cast<void *>(&detour_compute_damage),
         &trampoline);
     ASSERT_TRUE(result.has_value());
-    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
+    s_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
 
-    EXPECT_EQ(fn_compute_damage_(20, 10), 60);
+    EXPECT_EQ(m_fn_compute_damage(20, 10), 60);
 
-    EXPECT_TRUE(hook_manager_->remove_hook("DamageHookRemove"));
-    g_original_compute_damage = nullptr;
+    EXPECT_TRUE(m_hook_manager->remove_hook("DamageHookRemove"));
+    s_original_compute_damage = nullptr;
 
-    EXPECT_EQ(fn_compute_damage_(20, 10), 30);
+    EXPECT_EQ(m_fn_compute_damage(20, 10), 30);
 }
 
 TEST_F(HookIntegrationTest, InlineHook_MultipleExports)
 {
-    EXPECT_EQ(fn_compute_damage_(5, 3), 8);
-    EXPECT_EQ(fn_compute_armor_(4, 6), 24);
-    EXPECT_EQ(fn_compute_speed_(10, 3), 7);
+    EXPECT_EQ(m_fn_compute_damage(5, 3), 8);
+    EXPECT_EQ(m_fn_compute_armor(4, 6), 24);
+    EXPECT_EQ(m_fn_compute_speed(10, 3), 7);
 
     void *tramp_damage = nullptr;
     void *tramp_armor = nullptr;
     void *tramp_speed = nullptr;
 
-    auto r1 = hook_manager_->create_inline_hook(
+    auto r1 = m_hook_manager->create_inline_hook(
         "MultiDamage",
-        reinterpret_cast<uintptr_t>(fn_compute_damage_),
+        reinterpret_cast<uintptr_t>(m_fn_compute_damage),
         reinterpret_cast<void *>(&detour_compute_damage),
         &tramp_damage);
     ASSERT_TRUE(r1.has_value());
-    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(tramp_damage);
+    s_original_compute_damage = reinterpret_cast<ComputeDamageFn>(tramp_damage);
 
-    auto r2 = hook_manager_->create_inline_hook(
+    auto r2 = m_hook_manager->create_inline_hook(
         "MultiArmor",
-        reinterpret_cast<uintptr_t>(fn_compute_armor_),
+        reinterpret_cast<uintptr_t>(m_fn_compute_armor),
         reinterpret_cast<void *>(&detour_compute_armor),
         &tramp_armor);
     ASSERT_TRUE(r2.has_value());
-    g_original_compute_armor = reinterpret_cast<ComputeArmorFn>(tramp_armor);
+    s_original_compute_armor = reinterpret_cast<ComputeArmorFn>(tramp_armor);
 
-    auto r3 = hook_manager_->create_inline_hook(
+    auto r3 = m_hook_manager->create_inline_hook(
         "MultiSpeed",
-        reinterpret_cast<uintptr_t>(fn_compute_speed_),
+        reinterpret_cast<uintptr_t>(m_fn_compute_speed),
         reinterpret_cast<void *>(&detour_compute_speed),
         &tramp_speed);
     ASSERT_TRUE(r3.has_value());
 
-    EXPECT_EQ(fn_compute_damage_(5, 3), 16);
-    EXPECT_EQ(fn_compute_armor_(4, 6), 1023);
-    EXPECT_EQ(fn_compute_speed_(10, 3), 21);
+    EXPECT_EQ(m_fn_compute_damage(5, 3), 16);
+    EXPECT_EQ(m_fn_compute_armor(4, 6), 1023);
+    EXPECT_EQ(m_fn_compute_speed(10, 3), 21);
 
-    EXPECT_GE(g_detour_call_count.load(), 3);
+    EXPECT_GE(s_detour_call_count.load(), 3);
 
-    auto ids = hook_manager_->get_hook_ids(HookStatus::Active);
+    auto ids = m_hook_manager->get_hook_ids(HookStatus::Active);
     EXPECT_GE(ids.size(), 3u);
 }
 
 TEST_F(HookIntegrationTest, MidHook_InspectAndModifyArgs)
 {
-    EXPECT_EQ(fn_compute_armor_(5, 10), 50);
+#if !defined(__x86_64__) && !defined(_M_X64)
+    GTEST_SKIP() << "Mid hook register test requires x86-64 calling convention";
+#endif
+
+    EXPECT_EQ(m_fn_compute_armor(5, 10), 50);
 
     auto mid_detour = [](safetyhook::Context &ctx)
     {
@@ -206,66 +234,71 @@ TEST_F(HookIntegrationTest, MidHook_InspectAndModifyArgs)
         ctx.rdx = 2;
     };
 
-    auto result = hook_manager_->create_mid_hook(
+    auto result = m_hook_manager->create_mid_hook(
         "ArmorMidHook",
-        reinterpret_cast<uintptr_t>(fn_compute_armor_),
+        reinterpret_cast<uintptr_t>(m_fn_compute_armor),
         mid_detour);
 
     ASSERT_TRUE(result.has_value())
         << "Mid hook creation failed: " << Hook::error_to_string(result.error());
 
-    int hooked_result = fn_compute_armor_(5, 10);
+    int hooked_result = m_fn_compute_armor(5, 10);
     EXPECT_EQ(hooked_result, 200);
 }
 
 TEST_F(HookIntegrationTest, AOBScan_FindAndHook)
 {
-    auto pattern = Scanner::parse_aob("AD DE");
-    ASSERT_TRUE(pattern.has_value()) << "Failed to parse AOB pattern";
+    auto *target_bytes = reinterpret_cast<const unsigned char *>(m_fn_compute_damage);
+    std::string aob_str = build_aob_from_bytes(target_bytes, AOB_SIGNATURE_LENGTH);
+
+    auto pattern = Scanner::parse_aob(aob_str);
+    ASSERT_TRUE(pattern.has_value()) << "Failed to parse AOB pattern: " << aob_str;
 
     const auto *found = Scanner::find_pattern(
-        reinterpret_cast<const std::byte *>(module_base_),
-        module_size_,
+        reinterpret_cast<const std::byte *>(m_module_base),
+        m_module_size,
         pattern.value());
     ASSERT_NE(found, nullptr) << "AOB pattern not found in module";
 
-    auto fn_addr = reinterpret_cast<uintptr_t>(fn_compute_damage_);
+    auto fn_addr = reinterpret_cast<uintptr_t>(m_fn_compute_damage);
     auto found_addr = reinterpret_cast<uintptr_t>(found);
 
-    EXPECT_GE(found_addr, module_base_);
-    EXPECT_LT(found_addr, module_base_ + module_size_);
+    EXPECT_EQ(found_addr, fn_addr)
+        << "AOB match at " << found_addr << " does not equal export at " << fn_addr;
 
     void *trampoline = nullptr;
-    auto result = hook_manager_->create_inline_hook(
+    auto result = m_hook_manager->create_inline_hook(
         "AOBFoundDamageHook",
         fn_addr,
         reinterpret_cast<void *>(&detour_compute_damage),
         &trampoline);
 
     ASSERT_TRUE(result.has_value());
-    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
+    s_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
 
-    EXPECT_EQ(fn_compute_damage_(7, 3), 20);
+    EXPECT_EQ(m_fn_compute_damage(7, 3), 20);
 }
 
 TEST_F(HookIntegrationTest, AOBScan_HookManager_EndToEnd)
 {
-    auto *target_bytes = reinterpret_cast<const unsigned char *>(fn_compute_damage_);
-    std::string aob_str;
-    for (int i = 0; i < 8; ++i) {
-        if (i > 0) {
-            aob_str += ' ';
-        }
-        char hex[4];
-        snprintf(hex, sizeof(hex), "%02X", target_bytes[i]);
-        aob_str += hex;
-    }
+    auto *target_bytes = reinterpret_cast<const unsigned char *>(m_fn_compute_damage);
+    std::string aob_str = build_aob_from_bytes(target_bytes, AOB_SIGNATURE_LENGTH);
+
+    auto pattern = Scanner::parse_aob(aob_str);
+    ASSERT_TRUE(pattern.has_value()) << "Failed to parse AOB pattern: " << aob_str;
+
+    const auto *found = Scanner::find_pattern(
+        reinterpret_cast<const std::byte *>(m_module_base),
+        m_module_size,
+        pattern.value());
+    ASSERT_NE(found, nullptr) << "AOB pattern not found in module";
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(found), reinterpret_cast<uintptr_t>(m_fn_compute_damage));
 
     void *trampoline = nullptr;
-    auto result = hook_manager_->create_inline_hook_aob(
+    auto result = m_hook_manager->create_inline_hook_aob(
         "AOBEndToEnd",
-        module_base_,
-        module_size_,
+        m_module_base,
+        m_module_size,
         aob_str,
         0,
         reinterpret_cast<void *>(&detour_compute_damage),
@@ -275,12 +308,12 @@ TEST_F(HookIntegrationTest, AOBScan_HookManager_EndToEnd)
         << "AOB end-to-end hook failed with pattern: " << aob_str;
     ASSERT_NE(trampoline, nullptr);
 
-    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
+    s_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
 
-    EXPECT_EQ(fn_compute_damage_(8, 2), 20);
+    EXPECT_EQ(m_fn_compute_damage(8, 2), 20);
 
-    EXPECT_TRUE(hook_manager_->remove_hook("AOBEndToEnd"));
-    g_original_compute_damage = nullptr;
+    EXPECT_TRUE(m_hook_manager->remove_hook("AOBEndToEnd"));
+    s_original_compute_damage = nullptr;
 
-    EXPECT_EQ(fn_compute_damage_(8, 2), 10);
+    EXPECT_EQ(m_fn_compute_damage(8, 2), 10);
 }

--- a/tests/test_hook_integration.cpp
+++ b/tests/test_hook_integration.cpp
@@ -1,0 +1,286 @@
+#include <gtest/gtest.h>
+#include <windows.h>
+#include <psapi.h>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "DetourModKit/hook_manager.hpp"
+#include "DetourModKit/scanner.hpp"
+#include "DetourModKit/logger.hpp"
+
+using namespace DetourModKit;
+
+using ComputeDamageFn = int (*)(int, int);
+using ComputeArmorFn = int (*)(int, int);
+using ComputeSpeedFn = int (*)(int, int);
+using ComputeCriticalFn = int (*)(int, int);
+
+static ComputeDamageFn g_original_compute_damage = nullptr;
+static ComputeArmorFn g_original_compute_armor = nullptr;
+
+static std::atomic<int> g_detour_call_count{0};
+
+static int detour_compute_damage(int base, int modifier)
+{
+    g_detour_call_count.fetch_add(1, std::memory_order_relaxed);
+    if (g_original_compute_damage) {
+        return g_original_compute_damage(base, modifier) * 2;
+    }
+    return (base + modifier) * 2;
+}
+
+static int detour_compute_armor(int defense, int level)
+{
+    g_detour_call_count.fetch_add(1, std::memory_order_relaxed);
+    if (g_original_compute_armor) {
+        return g_original_compute_armor(defense, level) + 999;
+    }
+    return defense * level + 999;
+}
+
+static int detour_compute_speed(int agility, int bonus)
+{
+    g_detour_call_count.fetch_add(1, std::memory_order_relaxed);
+    return (agility - bonus) * 3;
+}
+
+class HookIntegrationTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        hook_manager_ = &HookManager::get_instance();
+        hook_manager_->remove_all_hooks();
+        g_detour_call_count.store(0);
+        g_original_compute_damage = nullptr;
+        g_original_compute_armor = nullptr;
+
+        dll_handle_ = LoadLibraryA("hook_target_lib.dll");
+        ASSERT_NE(dll_handle_, nullptr)
+            << "Failed to load hook_target_lib.dll. Error: " << GetLastError();
+
+        fn_compute_damage_ = reinterpret_cast<ComputeDamageFn>(
+            GetProcAddress(dll_handle_, "compute_damage"));
+        fn_compute_armor_ = reinterpret_cast<ComputeArmorFn>(
+            GetProcAddress(dll_handle_, "compute_armor"));
+        fn_compute_speed_ = reinterpret_cast<ComputeSpeedFn>(
+            GetProcAddress(dll_handle_, "compute_speed"));
+        fn_compute_critical_ = reinterpret_cast<ComputeCriticalFn>(
+            GetProcAddress(dll_handle_, "compute_critical"));
+
+        ASSERT_NE(fn_compute_damage_, nullptr) << "compute_damage export not found";
+        ASSERT_NE(fn_compute_armor_, nullptr) << "compute_armor export not found";
+        ASSERT_NE(fn_compute_speed_, nullptr) << "compute_speed export not found";
+        ASSERT_NE(fn_compute_critical_, nullptr) << "compute_critical export not found";
+
+        MODULEINFO mod_info{};
+        BOOL info_ok = GetModuleInformation(
+            GetCurrentProcess(), dll_handle_, &mod_info, sizeof(mod_info));
+        ASSERT_TRUE(info_ok) << "GetModuleInformation failed";
+
+        module_base_ = reinterpret_cast<uintptr_t>(mod_info.lpBaseOfDll);
+        module_size_ = mod_info.SizeOfImage;
+    }
+
+    void TearDown() override
+    {
+        if (hook_manager_) {
+            hook_manager_->remove_all_hooks();
+        }
+        g_original_compute_damage = nullptr;
+        g_original_compute_armor = nullptr;
+
+        if (dll_handle_) {
+            FreeLibrary(dll_handle_);
+            dll_handle_ = nullptr;
+        }
+    }
+
+    HookManager *hook_manager_ = nullptr;
+    HMODULE dll_handle_ = nullptr;
+
+    ComputeDamageFn fn_compute_damage_ = nullptr;
+    ComputeArmorFn fn_compute_armor_ = nullptr;
+    ComputeSpeedFn fn_compute_speed_ = nullptr;
+    ComputeCriticalFn fn_compute_critical_ = nullptr;
+
+    uintptr_t module_base_ = 0;
+    size_t module_size_ = 0;
+};
+
+TEST_F(HookIntegrationTest, InlineHook_AlterReturnValue)
+{
+    EXPECT_EQ(fn_compute_damage_(10, 5), 15);
+
+    void *trampoline = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "DamageHook",
+        reinterpret_cast<uintptr_t>(fn_compute_damage_),
+        reinterpret_cast<void *>(&detour_compute_damage),
+        &trampoline);
+
+    ASSERT_TRUE(result.has_value())
+        << "Hook creation failed: " << Hook::error_to_string(result.error());
+    ASSERT_NE(trampoline, nullptr);
+
+    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
+
+    int hooked_result = fn_compute_damage_(10, 5);
+    EXPECT_EQ(hooked_result, 30);
+    EXPECT_GE(g_detour_call_count.load(), 1);
+}
+
+TEST_F(HookIntegrationTest, InlineHook_RemoveRestoresOriginal)
+{
+    EXPECT_EQ(fn_compute_damage_(20, 10), 30);
+
+    void *trampoline = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "DamageHookRemove",
+        reinterpret_cast<uintptr_t>(fn_compute_damage_),
+        reinterpret_cast<void *>(&detour_compute_damage),
+        &trampoline);
+    ASSERT_TRUE(result.has_value());
+    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
+
+    EXPECT_EQ(fn_compute_damage_(20, 10), 60);
+
+    EXPECT_TRUE(hook_manager_->remove_hook("DamageHookRemove"));
+    g_original_compute_damage = nullptr;
+
+    EXPECT_EQ(fn_compute_damage_(20, 10), 30);
+}
+
+TEST_F(HookIntegrationTest, InlineHook_MultipleExports)
+{
+    EXPECT_EQ(fn_compute_damage_(5, 3), 8);
+    EXPECT_EQ(fn_compute_armor_(4, 6), 24);
+    EXPECT_EQ(fn_compute_speed_(10, 3), 7);
+
+    void *tramp_damage = nullptr;
+    void *tramp_armor = nullptr;
+    void *tramp_speed = nullptr;
+
+    auto r1 = hook_manager_->create_inline_hook(
+        "MultiDamage",
+        reinterpret_cast<uintptr_t>(fn_compute_damage_),
+        reinterpret_cast<void *>(&detour_compute_damage),
+        &tramp_damage);
+    ASSERT_TRUE(r1.has_value());
+    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(tramp_damage);
+
+    auto r2 = hook_manager_->create_inline_hook(
+        "MultiArmor",
+        reinterpret_cast<uintptr_t>(fn_compute_armor_),
+        reinterpret_cast<void *>(&detour_compute_armor),
+        &tramp_armor);
+    ASSERT_TRUE(r2.has_value());
+    g_original_compute_armor = reinterpret_cast<ComputeArmorFn>(tramp_armor);
+
+    auto r3 = hook_manager_->create_inline_hook(
+        "MultiSpeed",
+        reinterpret_cast<uintptr_t>(fn_compute_speed_),
+        reinterpret_cast<void *>(&detour_compute_speed),
+        &tramp_speed);
+    ASSERT_TRUE(r3.has_value());
+
+    EXPECT_EQ(fn_compute_damage_(5, 3), 16);
+    EXPECT_EQ(fn_compute_armor_(4, 6), 1023);
+    EXPECT_EQ(fn_compute_speed_(10, 3), 21);
+
+    EXPECT_GE(g_detour_call_count.load(), 3);
+
+    auto ids = hook_manager_->get_hook_ids(HookStatus::Active);
+    EXPECT_GE(ids.size(), 3u);
+}
+
+TEST_F(HookIntegrationTest, MidHook_InspectAndModifyArgs)
+{
+    EXPECT_EQ(fn_compute_armor_(5, 10), 50);
+
+    auto mid_detour = [](safetyhook::Context &ctx)
+    {
+        ctx.rcx = 100;
+        ctx.rdx = 2;
+    };
+
+    auto result = hook_manager_->create_mid_hook(
+        "ArmorMidHook",
+        reinterpret_cast<uintptr_t>(fn_compute_armor_),
+        mid_detour);
+
+    ASSERT_TRUE(result.has_value())
+        << "Mid hook creation failed: " << Hook::error_to_string(result.error());
+
+    int hooked_result = fn_compute_armor_(5, 10);
+    EXPECT_EQ(hooked_result, 200);
+}
+
+TEST_F(HookIntegrationTest, AOBScan_FindAndHook)
+{
+    auto pattern = Scanner::parse_aob("AD DE");
+    ASSERT_TRUE(pattern.has_value()) << "Failed to parse AOB pattern";
+
+    const auto *found = Scanner::find_pattern(
+        reinterpret_cast<const std::byte *>(module_base_),
+        module_size_,
+        pattern.value());
+    ASSERT_NE(found, nullptr) << "AOB pattern not found in module";
+
+    auto fn_addr = reinterpret_cast<uintptr_t>(fn_compute_damage_);
+    auto found_addr = reinterpret_cast<uintptr_t>(found);
+
+    EXPECT_GE(found_addr, module_base_);
+    EXPECT_LT(found_addr, module_base_ + module_size_);
+
+    void *trampoline = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "AOBFoundDamageHook",
+        fn_addr,
+        reinterpret_cast<void *>(&detour_compute_damage),
+        &trampoline);
+
+    ASSERT_TRUE(result.has_value());
+    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
+
+    EXPECT_EQ(fn_compute_damage_(7, 3), 20);
+}
+
+TEST_F(HookIntegrationTest, AOBScan_HookManager_EndToEnd)
+{
+    auto *target_bytes = reinterpret_cast<const unsigned char *>(fn_compute_damage_);
+    std::string aob_str;
+    for (int i = 0; i < 8; ++i) {
+        if (i > 0) {
+            aob_str += ' ';
+        }
+        char hex[4];
+        snprintf(hex, sizeof(hex), "%02X", target_bytes[i]);
+        aob_str += hex;
+    }
+
+    void *trampoline = nullptr;
+    auto result = hook_manager_->create_inline_hook_aob(
+        "AOBEndToEnd",
+        module_base_,
+        module_size_,
+        aob_str,
+        0,
+        reinterpret_cast<void *>(&detour_compute_damage),
+        &trampoline);
+
+    ASSERT_TRUE(result.has_value())
+        << "AOB end-to-end hook failed with pattern: " << aob_str;
+    ASSERT_NE(trampoline, nullptr);
+
+    g_original_compute_damage = reinterpret_cast<ComputeDamageFn>(trampoline);
+
+    EXPECT_EQ(fn_compute_damage_(8, 2), 20);
+
+    EXPECT_TRUE(hook_manager_->remove_hook("AOBEndToEnd"));
+    g_original_compute_damage = nullptr;
+
+    EXPECT_EQ(fn_compute_damage_(8, 2), 10);
+}


### PR DESCRIPTION
## Summary

- Add `tests/fixtures/hook_target_lib.cpp` — shared library exporting 4 `extern "C"` functions with volatile magic constants for stable AOB patterns.
- Add `tests/test_hook_integration.cpp` — 6 integration tests covering the real-world DLL hooking workflow:
  - Inline hook alters return value via trampoline
  - Hook removal restores original behavior
  - Multiple exports hooked simultaneously
  - Mid hook modifies arguments via `safetyhook::Context` (rcx/rdx)
  - AOB scanner finds magic bytes in loaded DLL memory
  - End-to-end: `create_inline_hook_aob` → verify → remove → verify restored
- Update `tests/CMakeLists.txt` to build the fixture DLL alongside tests.
- Update `AGENTS.md` with integration test documentation.

## Test plan

- [x] 597/597 tests pass (591 previous + 6 new integration tests)
- [x] All 6 cross-module tests pass on MinGW GCC debug build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive Windows integration test suite validating inline hooks, multi-function detours, CPU-context manipulation, and pattern-based (AOB) hooking flows.
  * Included test fixtures to exercise cross-module hooking against a separate test library.

* **Chores**
  * Updated test build/setup to produce and deploy the fixture library alongside the test executable and adjusted test link/runtime setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->