### PR TITLE
ci: skip workflows on docs-only changes

### DIFF
--- a/.github/workflows/coverage-pages.yml
+++ b/.github/workflows/coverage-pages.yml
@@ -3,6 +3,14 @@ name: Coverage Report ≥ 80%
 on:
   push:
     branches: [main]
+    paths:
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'external/**'
+      - 'include/**'
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/coverage-pages.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,6 +3,14 @@ name: PR Check - Tests & Coverage
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'external/**'
+      - 'include/**'
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/pr-check.yml'
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

- Add `paths` filter to `pr-check.yml` and `coverage-pages.yml` so they only trigger on source, build config, or workflow file changes
- Docs-only PRs and pushes (README, `.md` files, etc.) no longer run the full build/test/coverage pipeline
- Manual `workflow_dispatch` is preserved for on-demand runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow triggers to run only when relevant files are modified, improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->