### PR TITLE
fix(build): correct linkage, target-scope release flags, and size optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,12 +151,14 @@ if(MSVC)
 else()
   # -ffunction-sections/-fdata-sections + --gc-sections: GCC/Clang equivalent
   # of MSVC's /Gy + /OPT:REF for dead code elimination.
-  # -s: strip all symbols from the final binary.
   target_compile_options(DetourModKit PRIVATE
     $<$<CONFIG:Release>:-ffunction-sections -fdata-sections>
   )
-  target_link_options(DetourModKit PUBLIC
-    $<$<CONFIG:Release>:-Wl,--gc-sections -s>
+  # --gc-sections is INTERFACE so consumers benefit from dead code elimination
+  # of unused DetourModKit symbols. Symbol stripping (-s) is deliberately left
+  # to the consumer's own build setup.
+  target_link_options(DetourModKit INTERFACE
+    $<$<CONFIG:Release>:-Wl,--gc-sections>
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,16 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(BUILD_SHARED_LIBS OFF) # Build DetourModKit as a static library
-set(CMAKE_POSITION_INDEPENDENT_CODE ON) # Good practice for libraries
+
+# CMAKE_POSITION_INDEPENDENT_CODE is intentionally not set here.
+# On Windows (PE/COFF), all code is position-independent by default;
+# -fPIC is a no-op on MinGW and ignored by MSVC.
+
+# Make CRT linkage explicit and overridable by consumers.
+# Default: dynamic CRT (/MD Release, /MDd Debug).
+if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif()
 
 # --- Compiler Flags ---
 if(MSVC)
@@ -15,8 +24,11 @@ if(MSVC)
   # Add /WX to treat warnings as errors in CI or for strict builds if desired.
   add_compile_options(/W4)
 
-  # Generate separate PDB files to avoid access conflicts
-  set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
+  # Debug builds: embed CodeView debug info directly into .obj files (/Z7)
+  # to avoid PDB file locking issues during parallel builds.
+  # Release builds: no debug info to minimize binary size.
+  set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT
+    "$<$<CONFIG:Debug>:Embedded>$<$<NOT:$<CONFIG:Debug>>:>")
   set(CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pdb")
 
 # Suppress some common noisy MSVC warnings if necessary:
@@ -24,7 +36,14 @@ if(MSVC)
 # add_compile_options(/wd4275) # non dll-interface class 'type' used as base...
 else()
   # GCC/Clang specific flags
-  add_compile_options(-Wall -Wextra -Wpedantic -fexceptions)
+  add_compile_options(-Wall -Wextra -Wpedantic)
+
+  # Override CMake's default -O3 for Release with -O2.
+  # -O2 provides a better code-size/performance tradeoff; the scanner's
+  # SSE2 intrinsics are already hand-optimized and do not benefit from
+  # -O3's aggressive loop unrolling and auto-vectorization.
+  string(REPLACE "-O3" "-O2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 
   # Suppress specific GCC/Clang warnings if they are noisy or from dependencies
   # add_compile_options(-Wno-unused-parameter -Wno-missing-field-initializers)
@@ -121,6 +140,26 @@ if(WIN32)
   target_compile_definitions(DetourModKit PUBLIC NOMINMAX)
 endif()
 
+# --- Target-Scoped Release Optimizations ---
+# Applied per-target so they do not leak into external subdirectory targets.
+if(MSVC)
+  # /Gy: function-level linking, /Gw: global data optimization.
+  # These enable the linker to discard unreferenced code/data via /OPT:REF,ICF.
+  target_compile_options(DetourModKit PRIVATE
+    $<$<CONFIG:Release>:/Gy /Gw>
+  )
+else()
+  # -ffunction-sections/-fdata-sections + --gc-sections: GCC/Clang equivalent
+  # of MSVC's /Gy + /OPT:REF for dead code elimination.
+  # -s: strip all symbols from the final binary.
+  target_compile_options(DetourModKit PRIVATE
+    $<$<CONFIG:Release>:-ffunction-sections -fdata-sections>
+  )
+  target_link_options(DetourModKit PUBLIC
+    $<$<CONFIG:Release>:-Wl,--gc-sections -s>
+  )
+endif()
+
 # Set output name and prefix properties for consistency
 # For most generators (like MinGW Makefiles), PREFIX is "lib" by default for static/shared libs.
 # For MSVC, PREFIX is empty by default for static/shared libs.
@@ -182,10 +221,21 @@ else()
 endif()
 
 # Link necessary system libraries for Windows API calls.
+# INTERFACE so consumers of this static library automatically resolve these
+# import libraries when linking the final DLL/EXE.
+# The XInput import library name differs between toolchains:
+#   MSVC / Windows SDK: xinput.lib  (links against xinput1_4.dll at runtime)
+#   MinGW:              -lxinput1_4 (libxinput1_4.a ships with mingw-w64)
 if(WIN32)
-  target_link_libraries(DetourModKit PRIVATE
-    psapi   # Process information functions
-    xinput1_4  # XInput gamepad polling (xinput1_4.dll ships with Win8+)
+  if(MSVC)
+    set(_DMK_XINPUT_LIB xinput)
+  else()
+    set(_DMK_XINPUT_LIB xinput1_4)
+  endif()
+
+  target_link_libraries(DetourModKit INTERFACE
+    user32          # GetAsyncKeyState, GetForegroundWindow, GetWindowThreadProcessId
+    ${_DMK_XINPUT_LIB} # XInput gamepad polling (xinput1_4.dll ships with Win8+)
   )
 endif()
 
@@ -335,6 +385,22 @@ if(DMK_ENABLE_SANITIZERS AND NOT MSVC)
   add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
   add_link_options(-fsanitize=address,undefined)
   message(STATUS "Sanitizers enabled: ASan + UBSan")
+endif()
+
+# --- Link-Time Optimization ---
+# LTO enables cross-translation-unit optimization and dead code elimination
+# in Release builds. Applied per-target to avoid inflating build times for
+# external subdirectory targets (SafetyHook, Zydis, Zycore).
+include(CheckIPOSupported)
+check_ipo_supported(RESULT _ipo_supported LANGUAGES CXX OUTPUT _ipo_error)
+
+if(_ipo_supported)
+  set_target_properties(DetourModKit PROPERTIES
+    INTERPROCEDURAL_OPTIMIZATION_RELEASE ON
+  )
+  message(STATUS "LTO enabled for DetourModKit Release builds")
+else()
+  message(STATUS "LTO not supported: ${_ipo_error}")
 endif()
 
 # --- Unit Tests ---

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,8 +14,7 @@
       "cacheVariables": {
         "CMAKE_CXX_STANDARD": "23",
         "CMAKE_CXX_SCAN_FOR_MODULES": "OFF",
-        "BUILD_SHARED_LIBS": "OFF",
-        "CMAKE_POSITION_INDEPENDENT_CODE": "ON"
+        "BUILD_SHARED_LIBS": "OFF"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ This project uses CMake with [CMake Presets](https://cmake.org/cmake/help/latest
     | `msvc-debug` | MSVC (cl) | Debug | ON |
     | `msvc-release` | MSVC (cl) | Release | OFF |
 
+   > [!NOTE]
+   > Release builds enable Link-Time Optimization (LTO) when supported by the compiler,
+   > along with dead code elimination (`/Gy /Gw` on MSVC, `-ffunction-sections -fdata-sections`
+   > with `--gc-sections` on GCC/Clang). MinGW Release builds use `-O2` (overriding CMake's
+   > default `-O3`) for a better code-size/performance tradeoff and are stripped of symbols.
+   > MSVC Debug builds embed CodeView debug info (`/Z7`) for parallel build compatibility;
+   > Release builds omit debug info entirely to minimize binary size.
+
+   <!-- -->
+
    > [!TIP]
    > You can create a `CMakeUserPresets.json` file (git-ignored) to define your own local presets that inherit from the ones above.
 
@@ -241,12 +251,13 @@ This method is ideal for active development and ensures you always have the late
     # Create your mod target
     add_library(MyMod SHARED src/main.cpp)
 
-    # Link against DetourModKit (all dependencies are transitively linked)
+    # Link against DetourModKit (all dependencies are transitively linked).
+    # user32 and xinput1_4 propagate automatically via DetourModKit's INTERFACE linkage.
     target_link_libraries(MyMod PRIVATE DetourModKit)
 
-    # Add system libraries (Windows)
+    # Add any extra system libraries your own mod code needs (Windows)
     if(WIN32)
-        target_link_libraries(MyMod PRIVATE psapi user32 kernel32)
+        target_link_libraries(MyMod PRIVATE psapi kernel32)
     endif()
     ```
 
@@ -285,12 +296,13 @@ This method uses a pre-built and installed version of DetourModKit.
     # Create your mod target
     add_library(MyMod SHARED src/main.cpp)
 
-    # Link against DetourModKit
+    # Link against DetourModKit.
+    # user32 and xinput1_4 propagate automatically via DetourModKit's INTERFACE linkage.
     target_link_libraries(MyMod PRIVATE DetourModKit::DetourModKit)
 
-    # Add system libraries (Windows)
+    # Add any extra system libraries your own mod code needs (Windows)
     if(WIN32)
-        target_link_libraries(MyMod PRIVATE psapi user32 kernel32)
+        target_link_libraries(MyMod PRIVATE psapi kernel32)
     endif()
     ```
 
@@ -303,7 +315,9 @@ This method uses a pre-built and installed version of DetourModKit.
     CXXFLAGS += -I$(DETOURMODKIT_DIR)/include
     LDFLAGS += -L$(DETOURMODKIT_DIR)/lib
     LIBS += -lDetourModKit -lsafetyhook -lZydis -lZycore
-    # Add system libs like: -lpsapi -luser32 -lkernel32 -lshlwapi -static-libgcc -static-libstdc++
+    # Add system libs: -luser32 -lxinput1_4 are required by DetourModKit.
+    # Add -lpsapi -lkernel32 etc. if your own mod code uses them.
+    LIBS += -luser32 -lxinput1_4 -static-libgcc -static-libstdc++
 
     # Example link command:
     # $(CXX) $(YOUR_OBJECTS) -o YourMod.asi -shared $(LDFLAGS) $(LIBS)

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ This project uses CMake with [CMake Presets](https://cmake.org/cmake/help/latest
    > [!NOTE]
    > Release builds enable Link-Time Optimization (LTO) when supported by the compiler,
    > along with dead code elimination (`/Gy /Gw` on MSVC, `-ffunction-sections -fdata-sections`
-   > with `--gc-sections` on GCC/Clang). MinGW Release builds use `-O2` (overriding CMake's
-   > default `-O3`) for a better code-size/performance tradeoff and are stripped of symbols.
+   > with `--gc-sections` on GCC/Clang). `--gc-sections` propagates to consumers via INTERFACE
+   > linkage so unused DetourModKit symbols are stripped at final link time. MinGW Release builds
+   > use `-O2` (overriding CMake's default `-O3`) for a better code-size/performance tradeoff.
    > MSVC Debug builds embed CodeView debug info (`/Z7`) for parallel build compatibility;
    > Release builds omit debug info entirely to minimize binary size.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,7 +67,6 @@ target_link_libraries(DetourModKit_tests
   DetourModKit
   GTest::gtest_main
   psapi
-  user32
 )
 
 # Include directories

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,12 +59,15 @@ add_custom_command(TARGET hook_target_lib POST_BUILD
     $<TARGET_FILE_DIR:DetourModKit_tests>
 )
 
-# Link GoogleTest and DetourModKit
+# Link GoogleTest and DetourModKit.
+# psapi is needed by test_hook_integration.cpp (GetModuleInformation).
+# user32 and xinput1_4 propagate transitively from DetourModKit (INTERFACE).
 target_link_libraries(DetourModKit_tests
   PRIVATE
   DetourModKit
   GTest::gtest_main
   psapi
+  user32
 )
 
 # Include directories


### PR DESCRIPTION
## Summary
- **Fix missing `user32` linkage** — `input.cpp` calls `GetAsyncKeyState`, `GetForegroundWindow`, `GetWindowThreadProcessId` which require user32; previously worked only by accident via transitive loader state
- **Remove unused `psapi`** from library linkage (only used in test code, kept there)
- **Change system libs from PRIVATE to INTERFACE** so consumers of the static library automatically resolve `user32` and `xinput` import libraries
- **Fix cross-toolchain XInput** — MSVC SDK ships `xinput.lib`, MinGW ships `libxinput1_4.a`
- **Move Release flags to target scope** — `/Gy /Gw` (MSVC) and `-ffunction-sections/-fdata-sections` + `--gc-sections -s` (GCC) no longer leak into SafetyHook/Zydis/Zycore subdirectory targets
- **Use generator expressions** for `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` instead of `CMAKE_BUILD_TYPE` string comparison (multi-config safe)
- **Per-target LTO** via `INTERPROCEDURAL_OPTIMIZATION_RELEASE` instead of global `CMAKE_INTERPROCEDURAL_OPTIMIZATION`
- **Override MinGW `-O3` → `-O2`** for better code-size/performance tradeoff
- **Explicit CRT linkage** via `CMAKE_MSVC_RUNTIME_LIBRARY` (default dynamic, overridable)
- **Remove no-op `CMAKE_POSITION_INDEPENDENT_CODE`** (PE/COFF is always position-independent)
- **Remove redundant `-fexceptions`** (GCC enables exceptions by default for C++)

## Verification
- MinGW Debug: 597/597 tests passed
- MSVC Debug: 597/597 tests passed
- MinGW Release: builds clean
- MSVC Release: builds clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Release builds with link-time optimization and dead-code elimination for smaller, faster binaries; improved Release-only optimizations and refined MSVC debug handling.
  * Improved Windows library linkage so required system libs propagate to consuming projects; better cross-platform build flags for non-MSVC toolchains.

* **Documentation**
  * Updated build instructions and examples to describe these optimization, debug, and linkage behavior across toolchains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->