### PR TITLE
fix(logger): consistent log format between sync and async modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,19 +96,19 @@ This project uses CMake with [CMake Presets](https://cmake.org/cmake/help/latest
     | `msvc-debug` | MSVC (cl) | Debug | ON |
     | `msvc-release` | MSVC (cl) | Release | OFF |
 
-    > [!NOTE]
-    > Release builds enable Link-Time Optimization (LTO) when supported by the compiler,
-    > along with dead code elimination (`/Gy /Gw` on MSVC, `-ffunction-sections -fdata-sections`
-    > with `--gc-sections` on GCC/Clang). `--gc-sections` propagates to consumers via INTERFACE
-    > linkage so unused DetourModKit symbols are stripped at final link time. MinGW Release builds
-    > use `-O2` (overriding CMake's default `-O3`) for a better code-size/performance tradeoff.
-    > MSVC Debug builds embed CodeView debug info (`/Z7`) for parallel build compatibility;
-    > Release builds omit debug info entirely to minimize binary size.
+> [!NOTE]
+> Release builds enable Link-Time Optimization (LTO) when supported by the compiler,
+> along with dead code elimination (`/Gy /Gw` on MSVC, `-ffunction-sections -fdata-sections`
+> with `--gc-sections` on GCC/Clang). `--gc-sections` propagates to consumers via INTERFACE
+> linkage so unused DetourModKit symbols are stripped at final link time. MinGW Release builds
+> use `-O2` (overriding CMake's default `-O3`) for a better code-size/performance tradeoff.
+> MSVC Debug builds embed CodeView debug info (`/Z7`) for parallel build compatibility;
+> Release builds omit debug info entirely to minimize binary size.
 
-    ---
+---
 
-    > [!TIP]
-    > You can create a `CMakeUserPresets.json` file (git-ignored) to define your own local presets that inherit from the ones above.
+> [!TIP]
+> You can create a `CMakeUserPresets.json` file (git-ignored) to define your own local presets that inherit from the ones above.
 
    After running the install command, the install directory (`build/install/` for the Makefile wrapper, or whichever `--prefix` you passed to `cmake --install`) will contain:
 

--- a/src/async_logger.cpp
+++ b/src/async_logger.cpp
@@ -425,7 +425,12 @@ namespace DetourModKit
                 localtime_r(&time_t, &tm_buf);
 #endif
 
-                *file_stream_ << "[" << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S") << "] "
+                const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                    now.time_since_epoch()) %
+                                1000;
+                *file_stream_ << "[" << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S")
+                              << "." << std::setfill('0') << std::setw(3) << ms.count()
+                              << std::setfill(' ') << "] "
                               << "[" << std::setw(7) << std::left << log_level_to_string(level) << "] :: "
                               << message << '\n';
                 file_stream_->flush();
@@ -595,7 +600,8 @@ namespace DetourModKit
                             1000;
 
             *file_stream_ << "[" << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S")
-                          << "." << std::setfill('0') << std::setw(3) << ms.count() << "] "
+                          << "." << std::setfill('0') << std::setw(3) << ms.count()
+                          << std::setfill(' ') << "] "
                           << "[" << std::setw(7) << std::left << log_level_to_string(msg.level) << "] :: "
                           << msg.message() << '\n';
         }
@@ -683,7 +689,12 @@ namespace DetourModKit
             localtime_r(&time_t, &tm_buf);
 #endif
 
-            *file_stream_ << "[" << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S") << "] "
+            const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                message.timestamp.time_since_epoch()) %
+                            1000;
+            *file_stream_ << "[" << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S")
+                          << "." << std::setfill('0') << std::setw(3) << ms.count()
+                          << std::setfill(' ') << "] "
                           << "[" << std::setw(7) << std::left << log_level_to_string(message.level) << "] :: "
                           << message.message() << '\n';
             file_stream_->flush();

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -292,7 +292,13 @@ namespace DetourModKit
             {
                 return "TIMESTAMP_FORMAT_ERROR";
             }
-            return std::string(buf, len);
+
+            const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                now.time_since_epoch()) %
+                            1000;
+            char ms_buf[5];
+            std::snprintf(ms_buf, sizeof(ms_buf), ".%03d", static_cast<int>(ms.count()));
+            return std::string(buf, len) + ms_buf;
         }
         catch (const std::exception &e)
         {

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <mutex>
+#include <regex>
 
 #include "DetourModKit/async_logger.hpp"
 
@@ -1524,4 +1525,52 @@ TEST_F(AsyncLoggerTest, FlushWithTimeout_ReturnsTrue_WhenDrained)
     EXPECT_EQ(logger->queue_size(), 0u);
 
     logger->shutdown();
+}
+
+TEST_F(AsyncLoggerTest, LogFormat_MatchesSyncFormat)
+{
+    AsyncLoggerConfig config;
+    config.batch_size = 64;
+    config.flush_interval = std::chrono::milliseconds{10};
+
+    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto log_mutex = std::make_shared<std::mutex>();
+
+    auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
+    static_cast<void>(logger->enqueue(LogLevel::Info, "FORMAT_CHECK_INFO_7f3a"));
+    static_cast<void>(logger->enqueue(LogLevel::Debug, "FORMAT_CHECK_DEBUG_8b2c"));
+    static_cast<void>(logger->enqueue(LogLevel::Warning, "FORMAT_CHECK_WARN_9d4e"));
+    logger->shutdown();
+    file_stream->close();
+
+    std::ifstream in(test_log_file_);
+    std::string content((std::istreambuf_iterator<char>(in)),
+                        std::istreambuf_iterator<char>());
+
+    // Expected format: [YYYY-MM-DD HH:MM:SS.mmm] [LEVEL  ] :: message
+    // Level field is 7 chars wide, left-aligned, space-padded
+    const std::regex line_pattern(
+        R"(\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] \[\w{1,7}\s*\] :: .+)");
+
+    std::istringstream stream(content);
+    std::string line;
+    int matched = 0;
+    while (std::getline(stream, line))
+    {
+        if (line.empty())
+        {
+            continue;
+        }
+        EXPECT_TRUE(std::regex_search(line, line_pattern))
+            << "Async log line does not match expected format: " << line;
+        ++matched;
+    }
+    EXPECT_EQ(matched, 3);
+
+    // Verify level fields use space-padding, not zero-padding
+    EXPECT_NE(content.find("[INFO   ]"), std::string::npos);
+    EXPECT_NE(content.find("[DEBUG  ]"), std::string::npos);
+    EXPECT_NE(content.find("[WARNING]"), std::string::npos);
+    EXPECT_EQ(content.find("[INFO000]"), std::string::npos);
+    EXPECT_EQ(content.find("[DEBUG00]"), std::string::npos);
 }

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -1008,16 +1008,17 @@ TEST_F(LoggerTest, TimestampFormat_StrftimeOutput)
 
     EXPECT_NE(content.find("TIMESTAMP_CHECK_MSG_2k4j"), std::string::npos);
 
-    // Verify timestamp format: [YYYY-MM-DD HH:MM:SS]
+    // Verify timestamp format: [YYYY-MM-DD HH:MM:SS.mmm]
     auto pos = content.find("[20");
     ASSERT_NE(pos, std::string::npos);
     auto end_bracket = content.find(']', pos);
     ASSERT_NE(end_bracket, std::string::npos);
     std::string timestamp = content.substr(pos + 1, end_bracket - pos - 1);
-    ASSERT_GE(timestamp.size(), 19u);
+    ASSERT_GE(timestamp.size(), 23u);
     EXPECT_EQ(timestamp[4], '-');
     EXPECT_EQ(timestamp[7], '-');
     EXPECT_EQ(timestamp[10], ' ');
     EXPECT_EQ(timestamp[13], ':');
     EXPECT_EQ(timestamp[16], ':');
+    EXPECT_EQ(timestamp[19], '.');
 }


### PR DESCRIPTION
## Summary
- Fix `std::setfill('0')` leaking from millisecond formatting into log level field, causing `[INFO000]` instead of `[INFO   ]` in async mode
- Add millisecond precision to sync logger timestamps for consistency with async
- Add format consistency test verifying async output matches sync format

## Files changed
- `src/async_logger.cpp` — reset `setfill(' ')` after ms field in all 3 write paths
- `src/logger.cpp` — append `.mmm` suffix in `get_timestamp()`
- `tests/test_async_logger.cpp` — new `LogFormat_MatchesSyncFormat` test
- `tests/test_logger.cpp` — update timestamp size assertion for ms precision

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Timestamps in all log messages now include millisecond precision, providing enhanced time granularity for debugging and log analysis.

* **Tests**
  * Added new tests to validate log output formatting, ensuring correct timestamp precision, proper alignment of log level indicators, and consistent formatting across different severity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->