### PR TITLE
fix(build): suppress MSVC C4324 warning for intentional alignas padding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ if(MSVC)
     "$<$<CONFIG:Debug>:Embedded>$<$<NOT:$<CONFIG:Debug>>:>")
   set(CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pdb")
 
-# Suppress some common noisy MSVC warnings if necessary:
+# Suppress noisy MSVC warnings:
+  add_compile_options(/wd4324) # structure was padded due to alignment specifier (intentional alignas)
 # add_compile_options(/wd4251) # class 'type' needs to have dll-interface...
 # add_compile_options(/wd4275) # non dll-interface class 'type' used as base...
 else()

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <mutex>
 #include <regex>
+#include <cstdint>
 
 #include "DetourModKit/async_logger.hpp"
 
@@ -492,6 +493,17 @@ TEST(DynamicMPMCQueueTest, CapacityAccessor)
 {
     DynamicMPMCQueue queue(4);
     EXPECT_EQ(queue.capacity(), 4u);
+}
+
+TEST(DynamicMPMCQueueTest, CacheLineAlignment)
+{
+    DynamicMPMCQueue queue(4);
+    auto addr = reinterpret_cast<std::uintptr_t>(&queue);
+
+    // DynamicMPMCQueue contains alignas(64) members; the struct itself
+    // must satisfy that alignment so the atomics land on separate cache lines.
+    EXPECT_EQ(alignof(DynamicMPMCQueue), 64u);
+    EXPECT_EQ(addr % 64u, 0u);
 }
 
 TEST(DynamicMPMCQueueTest, FullAndEmptyQueue)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added cache line alignment verification test for internal queue structure.

* **Chores**
  * Updated MSVC build configuration to suppress alignment-related compiler warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->