### PR TITLE
fix(config): support independent key combos with different modifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,8 @@ PATH="/c/msys64/mingw64/bin:$PATH" ./build/mingw-debug/tests/DetourModKit_tests.
 
 These are called at 60+ fps from game hook callbacks. Never add allocations, locks, or blocking I/O to them:
 
-- `InputPoller::is_binding_active()` — single atomic load
+- `InputPoller::is_binding_active(index)` — single atomic load
+- `InputPoller::is_binding_active(name)` — hash lookup + atomic load per binding (typically 1–3)
 - `HookManager::with_inline_hook()` — shared_lock read
 - `Logger::log()` level check — single atomic load
 - `Logger::log()` async enqueue — atomic shared_ptr load + lock-free queue push

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in g
 
 * **AOB Scanner:** Find array-of-bytes (signatures) in memory with wildcard support and SSE2-accelerated pattern verification (when compiled with SSE2 support) for patterns >= 16 bytes. Supports `|` offset markers for targeting a specific instruction within a wider pattern (e.g., `"48 8B 88 B8 00 00 00 | 48 89 4C 24 68"` sets the offset to byte 7) and nth-occurrence matching (1-based) for patterns that hit multiple locations. Includes RIP-relative instruction resolution for extracting absolute addresses from x86-64 code.
 * **Hook Manager:** A C++ wrapper around [SafetyHook](https://github.com/cursey/safetyhook) for creating and managing inline and mid-function hooks, by direct address or AOB scan.
-* **Configuration System:** Load settings from INI files. Mods register their configuration variables (defined in the mod's code) and the kit handles parsing and value assignment. Supports key combos with modifier keys via `register_key_combo` (format: `modifier+trigger`, e.g., `Ctrl+Shift+F3`). Named keys (`Ctrl`, `F3`, `Mouse1`, `Gamepad_A`), hex VK codes (`0x72`), and mixed formats are all supported. (Powered by [SimpleIni](https://github.com/brofield/simpleini)).
+* **Configuration System:** Load settings from INI files. Mods register their configuration variables (defined in the mod's code) and the kit handles parsing and value assignment. Supports key combos with modifier keys via `register_key_combo` (format: `modifier+trigger`, e.g., `Ctrl+Shift+F3`). Multiple independent combos can be comma-separated (e.g., `F3,Gamepad_LT+Gamepad_B`). Named keys (`Ctrl`, `F3`, `Mouse1`, `Gamepad_A`), hex VK codes (`0x72`), and mixed formats are all supported. (Powered by [SimpleIni](https://github.com/brofield/simpleini)).
 * **Logger:** A flexible singleton logger for outputting messages to a log file. Supports configurable log levels, timestamps, and prefixes. Features **async logging** for high-throughput scenarios and **format string placeholders** for concise log messages.
 * **Async Logger:** A lock-free, bounded queue-based async logger that decouples log message production from file I/O. Designed for minimal latency on the producer side with batched writes on the consumer thread. Features configurable overflow policies (DropNewest/DropOldest/Block/SyncFallback), bounded Block policy with 16 ms default timeout (one frame at 60 fps) to prevent thread starvation, inline buffer optimization for messages of size <= 256 bytes (inclusive), and message size validation with truncation for messages larger than 16 MB (messages > 16 MB are truncated to 16 MB rather than rejected).
 * **Memory Utilities:** Functions for checking memory readability/writability and writing bytes to memory. Includes an optional memory region cache.
@@ -20,9 +20,9 @@ DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in g
 * **Filesystem Utilities:** Basic filesystem operations, notably getting the current module's runtime directory.
 * **Math Utilities:** Provides basic mathematical utility functions (e.g., angle conversions).
 * **Input System:** Hotkey monitoring with a background polling thread.
-  * **Input sources & modes:** Supports keyboard, mouse, and XInput gamepad input via a unified `InputCode` tagged type (`InputSource` + button code). Press (edge-triggered) and hold (level-triggered) input modes with modifier combinations (AND logic for modifiers, OR logic for trigger keys). Gamepad analog triggers (LT/RT) and thumbstick axes are treated as digital buttons with configurable deadzone thresholds. Focus-aware by default — input events are ignored when the process does not own the foreground window.
+  * **Input sources & modes:** Supports keyboard, mouse, and XInput gamepad input via a unified `InputCode` tagged type (`InputSource` + button code). Press (edge-triggered) and hold (level-triggered) input modes with modifier combinations (AND logic for modifiers, OR logic between independent combos). Multiple independent combos can share a single binding name for cross-device hotkeys (e.g., keyboard F3 OR gamepad LT+B). Gamepad analog triggers (LT/RT) and thumbstick axes are treated as digital buttons with configurable deadzone thresholds. Focus-aware by default — input events are ignored when the process does not own the foreground window.
   * **Threading & lifecycle:** Available as an RAII `InputPoller` building block or via the thread-safe `InputManager` singleton for convenience. Two-phase initialization (construct then start) for safe thread launching. `condition_variable_any` with `stop_token` for responsive cooperative shutdown. Exception-safe callback invocation. Automatic hold release on shutdown. DLL-safe when used with `DMK_Shutdown()` before `DLL_PROCESS_DETACH`.
-  * **Performance:** O(1) hash-map-backed `is_binding_active()` query for lock-free cross-thread state reads (e.g., from render hooks at 60+ fps). Lock-free `is_running()` via atomic flag. O(1) reverse name lookup for `input_code_to_name()`.
+  * **Performance:** Hash-map-backed `is_binding_active()` query for lock-free cross-thread state reads (e.g., from render hooks at 60+ fps). Supports multiple bindings per name for multi-combo hotkeys. Lock-free `is_running()` via atomic flag. O(1) reverse name lookup for `input_code_to_name()`.
   * **Gamepad & polling:** XInput is polled once per cycle and skipped entirely when no gamepad bindings are registered. Reconnection attempts are throttled to every 2 seconds when no controller is connected, avoiding the per-cycle overhead of `XInputGetState` on disconnected slots.
   * **Configuration integration:** Loading input codes from INI files (named keys, hex VK codes, or mixed). Named key resolution uses binary search for efficient lookup.
 
@@ -370,8 +370,8 @@ This method uses a pre-built and installed version of DetourModKit.
 struct ModConfiguration {
     bool enable_greeting_hook = true;
     std::string log_level_setting = "INFO";
-    DMKKeyCombo toggle_combo;
-    DMKKeyCombo hold_scroll_combo;
+    DMKKeyComboList toggle_combo;
+    DMKKeyComboList hold_scroll_combo;
 } g_mod_config;
 
 // Example Hook: Target function signature
@@ -417,15 +417,15 @@ void InitializeMyMod() {
         [](const std::string& v) { g_mod_config.log_level_setting = v; }, "INFO");
 
     // Register hotkey bindings from INI (modifier+trigger format)
-    // Named keys: "F3" or "F3,F1" (comma = OR for multiple trigger keys)
-    // With modifiers: "Ctrl+Shift+F3" (plus = AND for modifiers, last segment = triggers)
+    // Comma separates independent combos: "F3,Gamepad_LT+Gamepad_B" (F3 OR LT+B)
+    // Plus separates modifiers from trigger: "Ctrl+Shift+F3" (AND for modifiers, last = trigger)
     // Hex VK codes still work: "0x72", "0x11+0x72"
     // Mouse: "Mouse4", "Ctrl+Mouse1"
     // Gamepad: "Gamepad_A", "Gamepad_LB+Gamepad_A"
     DMKConfig::register_key_combo("Hotkeys", "ToggleKey", "Toggle Keys",
-        [](const DMKKeyCombo& c) { g_mod_config.toggle_combo = c; }, "F3");
+        [](const DMKKeyComboList& c) { g_mod_config.toggle_combo = c; }, "F3");
     DMKConfig::register_key_combo("Hotkeys", "HoldScrollKey", "Hold Scroll Keys",
-        [](const DMKKeyCombo& c) { g_mod_config.hold_scroll_combo = c; }, "");
+        [](const DMKKeyComboList& c) { g_mod_config.hold_scroll_combo = c; }, "");
 
     // Load configuration from INI file
     DMKConfig::load("MyMod.ini");
@@ -503,16 +503,16 @@ void InitializeMyMod() {
     // Register hotkey bindings with the InputManager (after hooks are ready)
     DMKInputManager& input_mgr = DMKInputManager::get_instance();
 
-    if (!g_mod_config.toggle_combo.keys.empty()) {
-        input_mgr.register_press("toggle_view", g_mod_config.toggle_combo.keys,
-            g_mod_config.toggle_combo.modifiers, []() {
+    for (const auto& combo : g_mod_config.toggle_combo) {
+        input_mgr.register_press("toggle_view", combo.keys,
+            combo.modifiers, []() {
                 DMKLogger::get_instance().info("Toggle key pressed!");
             });
     }
 
-    if (!g_mod_config.hold_scroll_combo.keys.empty()) {
-        input_mgr.register_hold("hold_scroll", g_mod_config.hold_scroll_combo.keys,
-            g_mod_config.hold_scroll_combo.modifiers, [](bool held) {
+    for (const auto& combo : g_mod_config.hold_scroll_combo) {
+        input_mgr.register_hold("hold_scroll", combo.keys,
+            combo.modifiers, [](bool held) {
                 DMKLogger::get_instance().info("Hold scroll: {}", held ? "active" : "released");
             });
     }
@@ -565,9 +565,13 @@ LogLevel=INFO
 
 [Hotkeys]
 ; Named keys (recommended)
-ToggleKey=F3,F1              ; F3 or F1 (comma = OR)
+ToggleKey=F3                 ; Single key
 HoldScrollKey=LShift         ; Left Shift
 DebugCombo=Ctrl+Shift+D      ; Ctrl AND Shift AND D (plus = AND for modifiers, last = trigger)
+
+; Multiple independent combos (comma = OR between combos)
+DualInput=F3,Gamepad_LT+Gamepad_B     ; F3 alone OR (hold LT + press B)
+MultiCombo=Ctrl+F3,Ctrl+F4            ; Ctrl+F3 OR Ctrl+F4
 
 ; Mouse buttons
 AimToggle=Mouse4             ; Mouse button 4 (side button)

--- a/include/DetourModKit.hpp
+++ b/include/DetourModKit.hpp
@@ -58,6 +58,7 @@ using DMKInputMode = DetourModKit::InputMode;
 using DMKInputSource = DetourModKit::InputSource;
 using DMKInputCode = DetourModKit::InputCode;
 using DMKKeyCombo = DetourModKit::Config::KeyCombo;
+using DMKKeyComboList = DetourModKit::Config::KeyComboList;
 using DMKInputBinding = DetourModKit::InputBinding;
 #endif // DMK_NO_SHORT_NAMES
 

--- a/include/DetourModKit/config.hpp
+++ b/include/DetourModKit/config.hpp
@@ -29,27 +29,34 @@ namespace DetourModKit
 
         /**
          * @struct KeyCombo
-         * @brief Represents a key combination parsed from an INI value.
+         * @brief Represents a single key combination with trigger keys and modifiers.
          * @details Contains trigger keys (OR logic) and modifier keys (AND logic).
          *          Designed for direct use with InputManager::register_press/register_hold.
          *          Each key is an InputCode identifying both the device source and button.
          *
-         *          INI format: modifiers separated by '+', with the last '+'-delimited
-         *          segment containing trigger key(s) (comma-separated for multiple triggers).
-         *          Tokens can be human-readable names or hex VK codes:
-         *            - "F3"                → keys=[F3], modifiers=[]
-         *            - "Ctrl+F3"           → keys=[F3], modifiers=[Ctrl]
-         *            - "Ctrl+Shift+F3"     → keys=[F3], modifiers=[Ctrl, Shift]
-         *            - "Ctrl+F3,F4"        → keys=[F3, F4], modifiers=[Ctrl]
-         *            - "Mouse4"            → keys=[Mouse4], modifiers=[]
+         *          Within a single combo, modifiers are separated by '+' and the last
+         *          '+'-delimited token is the trigger key. Tokens can be human-readable
+         *          names or hex VK codes:
+         *            - "F3"                   → keys=[F3], modifiers=[]
+         *            - "Ctrl+F3"              → keys=[F3], modifiers=[Ctrl]
+         *            - "Ctrl+Shift+F3"        → keys=[F3], modifiers=[Ctrl, Shift]
+         *            - "Mouse4"               → keys=[Mouse4], modifiers=[]
          *            - "Gamepad_LB+Gamepad_A" → keys=[Gamepad_A], modifiers=[Gamepad_LB]
-         *            - "0x11+0x72"         → keys=[0x72], modifiers=[0x11] (hex fallback)
+         *            - "0x11+0x72"            → keys=[0x72], modifiers=[0x11] (hex fallback)
+         *
+         *          Multiple combos are separated by commas in INI values, parsed into
+         *          a KeyComboList. Each combo is independent (OR logic between combos):
+         *            - "F3,Gamepad_LT+Gamepad_B" → [{keys=[F3]}, {keys=[Gamepad_B], mods=[Gamepad_LT]}]
+         *            - "Ctrl+F3,Ctrl+F4"          → [{keys=[F3], mods=[Ctrl]}, {keys=[F4], mods=[Ctrl]}]
          */
         struct KeyCombo
         {
             std::vector<InputCode> keys;
             std::vector<InputCode> modifiers;
         };
+
+        /// A list of alternative key combinations (OR logic between combos).
+        using KeyComboList = std::vector<KeyCombo>;
 
         /// Registers an integer configuration item.
         void register_int(const std::string &section, const std::string &ini_key, const std::string &log_key_name,
@@ -69,21 +76,19 @@ namespace DetourModKit
 
         /**
          * @brief Registers a key combo configuration item.
-         * @details Parses an INI value as a key combination with optional modifier keys.
-         *          Format: "modifier1+modifier2+trigger_key1,trigger_key2" where tokens
+         * @details Parses an INI value as one or more key combinations. Commas at the
+         *          top level separate independent combos (OR logic). Within each combo,
+         *          '+' separates modifier keys from the trigger key (last token). Tokens
          *          can be human-readable names (e.g., "Ctrl", "F3", "Gamepad_A") or hex
-         *          VK codes (e.g., "0x72"). The '+' separator delimits modifier keys from
-         *          trigger keys, with the last segment being trigger key(s). Commas within
-         *          the last segment provide OR logic for multiple trigger keys. See
-         *          KeyCombo for full parsing semantics.
+         *          VK codes (e.g., "0x72"). See KeyCombo for full parsing semantics.
          * @param section INI section name.
          * @param ini_key INI key name.
          * @param log_key_name Human-readable name shown in log output.
-         * @param setter Callback invoked with the parsed KeyCombo.
+         * @param setter Callback invoked with the parsed KeyComboList.
          * @param default_value_str Default value string in the same format.
          */
         void register_key_combo(const std::string &section, const std::string &ini_key, const std::string &log_key_name,
-                               std::function<void(const KeyCombo &)> setter, const std::string &default_value_str);
+                               std::function<void(const KeyComboList &)> setter, const std::string &default_value_str);
 
         /**
          * @brief Loads all registered configuration settings from the specified INI file.

--- a/include/DetourModKit/input.hpp
+++ b/include/DetourModKit/input.hpp
@@ -202,7 +202,7 @@ namespace DetourModKit
         [[nodiscard]] bool is_process_foreground() const;
 
         std::vector<InputBinding> bindings_;
-        std::unordered_map<std::string, size_t> name_index_;
+        std::unordered_map<std::string, std::vector<size_t>> name_index_;
         std::chrono::milliseconds poll_interval_;
         std::atomic<bool> require_focus_;
         std::atomic<bool> running_{false};

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -115,22 +115,20 @@ namespace
     }
 
     /**
-     * @brief Parses a key combo string into a KeyCombo struct.
-     * @details Format: "modifier1+modifier2+trigger1,trigger2" where each token
-     *          is a named key or hex VK code. The last '+'-delimited segment
-     *          contains trigger key(s) (comma-separated for OR logic). All preceding
-     *          segments are individual modifier keys (AND logic).
-     * @param input The raw string to parse.
+     * @brief Parses a single key combo string into a KeyCombo struct.
+     * @details Format: "modifier1+modifier2+trigger_key" where each token is a
+     *          named key or hex VK code. The last '+'-delimited token is the trigger
+     *          key, all preceding tokens are modifier keys (AND logic). This function
+     *          expects a single combo with no commas; use parse_key_combo_list to
+     *          split comma-separated alternatives first.
+     * @param input The raw string to parse (no commas expected).
      * @return Config::KeyCombo Parsed key combination.
      */
     Config::KeyCombo parse_key_combo(const std::string &input)
     {
         Config::KeyCombo result;
 
-        // Strip trailing comment from the full line
-        const size_t comment_pos = input.find(';');
-        const std::string effective = trim(
-            (comment_pos != std::string::npos) ? input.substr(0, comment_pos) : input);
+        const std::string effective = trim(input);
         if (effective.empty())
         {
             return result;
@@ -156,7 +154,7 @@ namespace
             return result;
         }
 
-        // Last segment contains trigger key(s) (comma-separated for OR logic)
+        // Last segment is the trigger key
         result.keys = parse_input_code_list(segments.back());
 
         // All preceding segments are individual modifier keys
@@ -170,10 +168,55 @@ namespace
     }
 
     /**
-     * @brief Formats a KeyCombo as a human-readable string.
+     * @brief Parses a comma-separated string of key combos into a KeyComboList.
+     * @details Commas at the top level separate independent combos (OR logic between
+     *          combos). Each combo is parsed by parse_key_combo. Handles inline
+     *          semicolon comments, whitespace, and gracefully skips empty/invalid combos.
+     * @param input The raw string to parse.
+     * @return Config::KeyComboList Parsed list of key combinations.
+     */
+    Config::KeyComboList parse_key_combo_list(const std::string &input)
+    {
+        Config::KeyComboList result;
+
+        // Strip trailing comment from the full line
+        const size_t comment_pos = input.find(';');
+        const std::string effective = trim(
+            (comment_pos != std::string::npos) ? input.substr(0, comment_pos) : input);
+        if (effective.empty())
+        {
+            return result;
+        }
+
+        // Split by comma into independent combo strings
+        size_t pos = 0;
+        while (pos < effective.size())
+        {
+            const size_t comma = effective.find(',', pos);
+            const size_t end = (comma != std::string::npos) ? comma : effective.size();
+            const std::string combo_str = trim(effective.substr(pos, end - pos));
+            pos = end + 1;
+
+            if (combo_str.empty())
+            {
+                continue;
+            }
+
+            auto combo = parse_key_combo(combo_str);
+            if (!combo.keys.empty())
+            {
+                result.push_back(std::move(combo));
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @brief Formats a single KeyCombo as a human-readable string.
      * @details Uses named keys where available, falls back to hex for unknown codes.
      * @param combo The key combination to format.
-     * @return std::string Formatted string (e.g., "Ctrl+Shift+F3,F4").
+     * @return std::string Formatted string (e.g., "Ctrl+Shift+F3").
      */
     std::string format_key_combo(const Config::KeyCombo &combo)
     {
@@ -189,6 +232,26 @@ namespace
                 result += ",";
             }
             result += DetourModKit::format_input_code(combo.keys[i]);
+        }
+        return result;
+    }
+
+    /**
+     * @brief Formats a KeyComboList as a human-readable string.
+     * @details Joins individual combos with commas.
+     * @param combos The list of key combinations to format.
+     * @return std::string Formatted string (e.g., "F3,Gamepad_LT+Gamepad_B").
+     */
+    std::string format_key_combo_list(const Config::KeyComboList &combos)
+    {
+        std::string result;
+        for (size_t i = 0; i < combos.size(); ++i)
+        {
+            if (i > 0)
+            {
+                result += ",";
+            }
+            result += format_key_combo(combos[i]);
         }
         return result;
     }
@@ -321,14 +384,14 @@ namespace
         logger.info("Config: {} ({}.{}) = \"{}\"", log_key_name, section, ini_key, current_value);
     }
 
-    // For Config::KeyCombo (key combination with modifiers)
+    // For Config::KeyComboList (list of key combinations)
     template <>
-    void CallbackConfigItem<Config::KeyCombo>::load(CSimpleIniA &ini, [[maybe_unused]] Logger &logger)
+    void CallbackConfigItem<Config::KeyComboList>::load(CSimpleIniA &ini, [[maybe_unused]] Logger &logger)
     {
         const char *ini_value_str = ini.GetValue(section.c_str(), ini_key.c_str(), nullptr);
         if (ini_value_str != nullptr)
         {
-            current_value = parse_key_combo(ini_value_str);
+            current_value = parse_key_combo_list(ini_value_str);
         }
         else
         {
@@ -337,9 +400,9 @@ namespace
     }
 
     template <>
-    void CallbackConfigItem<Config::KeyCombo>::log_current_value(Logger &logger) const
+    void CallbackConfigItem<Config::KeyComboList>::log_current_value(Logger &logger) const
     {
-        logger.info("Config: {} ({}.{}) = {}", log_key_name, section, ini_key, format_key_combo(current_value));
+        logger.info("Config: {} ({}.{}) = {}", log_key_name, section, ini_key, format_key_combo_list(current_value));
     }
 
     // --- Global storage for registered configuration items ---
@@ -442,18 +505,18 @@ void DetourModKit::Config::register_string(const std::string &section, const std
 }
 
 void DetourModKit::Config::register_key_combo(const std::string &section, const std::string &ini_key,
-                                                      const std::string &log_key_name, std::function<void(const KeyCombo &)> setter,
+                                                      const std::string &log_key_name, std::function<void(const KeyComboList &)> setter,
                                                       const std::string &default_value_str)
 {
-    Config::KeyCombo default_combo = parse_key_combo(default_value_str);
+    Config::KeyComboList default_combos = parse_key_combo_list(default_value_str);
 
     if (setter)
     {
-        setter(default_combo);
+        setter(default_combos);
     }
     std::lock_guard<std::mutex> lock(getConfigMutex());
     getRegisteredConfigItems().push_back(
-        std::make_unique<CallbackConfigItem<Config::KeyCombo>>(section, ini_key, log_key_name, std::move(setter), std::move(default_combo)));
+        std::make_unique<CallbackConfigItem<Config::KeyComboList>>(section, ini_key, log_key_name, std::move(setter), std::move(default_combos)));
 }
 
 void DetourModKit::Config::load(const std::string &ini_filename)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -132,7 +132,7 @@ namespace DetourModKit
         {
             if (!bindings_[i].name.empty())
             {
-                name_index_.emplace(bindings_[i].name, i);
+                name_index_[bindings_[i].name].push_back(i);
             }
         }
     }
@@ -197,7 +197,13 @@ namespace DetourModKit
         const auto it = name_index_.find(name);
         if (it != name_index_.end())
         {
-            return active_states_[it->second].load(std::memory_order_relaxed) != 0;
+            for (const size_t idx : it->second)
+            {
+                if (active_states_[idx].load(std::memory_order_relaxed) != 0)
+                {
+                    return true;
+                }
+            }
         }
         return false;
     }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -122,18 +122,18 @@ TEST_F(ConfigTest, KeyCombo_HexFormats)
     ini_file << "TestKeys=0x01, 0X02, 0x03, 0x04\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
+    Config::KeyComboList test_value;
 
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyCombo &c)
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    EXPECT_EQ(test_value.keys.size(), 4u);
-    EXPECT_EQ(test_value.keys[0], keyboard_key(0x01));
-    EXPECT_EQ(test_value.keys[1], keyboard_key(0x02));
-    EXPECT_EQ(test_value.keys[2], keyboard_key(0x03));
-    EXPECT_EQ(test_value.keys[3], keyboard_key(0x04));
+    ASSERT_EQ(test_value.size(), 4u);
+    EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x01));
+    EXPECT_EQ(test_value[1].keys[0], keyboard_key(0x02));
+    EXPECT_EQ(test_value[2].keys[0], keyboard_key(0x03));
+    EXPECT_EQ(test_value[3].keys[0], keyboard_key(0x04));
 }
 
 TEST_F(ConfigTest, KeyCombo_NamedKeys)
@@ -143,17 +143,17 @@ TEST_F(ConfigTest, KeyCombo_NamedKeys)
     ini_file << "TestKeys=F3, F4, A\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
+    Config::KeyComboList test_value;
 
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyCombo &c)
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(test_value.keys.size(), 3u);
-    EXPECT_EQ(test_value.keys[0], keyboard_key(0x72));
-    EXPECT_EQ(test_value.keys[1], keyboard_key(0x73));
-    EXPECT_EQ(test_value.keys[2], keyboard_key(0x41));
+    ASSERT_EQ(test_value.size(), 3u);
+    EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x72));
+    EXPECT_EQ(test_value[1].keys[0], keyboard_key(0x73));
+    EXPECT_EQ(test_value[2].keys[0], keyboard_key(0x41));
 }
 
 TEST_F(ConfigTest, KeyCombo_MouseButton)
@@ -163,15 +163,15 @@ TEST_F(ConfigTest, KeyCombo_MouseButton)
     ini_file << "TestKeys=Mouse4\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
+    Config::KeyComboList test_value;
 
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyCombo &c)
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(test_value.keys.size(), 1u);
-    EXPECT_EQ(test_value.keys[0], mouse_button(0x05));
+    ASSERT_EQ(test_value.size(), 1u);
+    EXPECT_EQ(test_value[0].keys[0], mouse_button(0x05));
 }
 
 TEST_F(ConfigTest, KeyCombo_GamepadButton)
@@ -181,15 +181,15 @@ TEST_F(ConfigTest, KeyCombo_GamepadButton)
     ini_file << "TestKeys=Gamepad_A\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
+    Config::KeyComboList test_value;
 
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyCombo &c)
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(test_value.keys.size(), 1u);
-    EXPECT_EQ(test_value.keys[0], gamepad_button(GamepadCode::A));
+    ASSERT_EQ(test_value.size(), 1u);
+    EXPECT_EQ(test_value[0].keys[0], gamepad_button(GamepadCode::A));
 }
 
 TEST_F(ConfigTest, KeyCombo_GamepadCombo)
@@ -199,17 +199,17 @@ TEST_F(ConfigTest, KeyCombo_GamepadCombo)
     ini_file << "TestKeys=Gamepad_LB+Gamepad_A\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
+    Config::KeyComboList test_value;
 
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyCombo &c)
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(test_value.keys.size(), 1u);
-    EXPECT_EQ(test_value.keys[0], gamepad_button(GamepadCode::A));
-    ASSERT_EQ(test_value.modifiers.size(), 1u);
-    EXPECT_EQ(test_value.modifiers[0], gamepad_button(GamepadCode::LeftBumper));
+    ASSERT_EQ(test_value.size(), 1u);
+    EXPECT_EQ(test_value[0].keys[0], gamepad_button(GamepadCode::A));
+    ASSERT_EQ(test_value[0].modifiers.size(), 1u);
+    EXPECT_EQ(test_value[0].modifiers[0], gamepad_button(GamepadCode::LeftBumper));
 }
 
 TEST_F(ConfigTest, KeyCombo_InvalidHex)
@@ -219,16 +219,16 @@ TEST_F(ConfigTest, KeyCombo_InvalidHex)
     ini_file << "TestKeys=0x10, INVALID, 0xGG, 0x20\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
+    Config::KeyComboList test_value;
 
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyCombo &c)
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    EXPECT_EQ(test_value.keys.size(), 2u);
-    EXPECT_EQ(test_value.keys[0], keyboard_key(0x10));
-    EXPECT_EQ(test_value.keys[1], keyboard_key(0x20));
+    ASSERT_EQ(test_value.size(), 2u);
+    EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x10));
+    EXPECT_EQ(test_value[1].keys[0], keyboard_key(0x20));
 }
 
 TEST_F(ConfigTest, ClearRegisteredItems)
@@ -313,7 +313,7 @@ TEST_F(ConfigTest, MixedConfigTypes)
     float float_val = 0.0f;
     bool bool_val = false;
     std::string string_val;
-    Config::KeyCombo keys_val;
+    Config::KeyComboList keys_val;
 
     Config::register_int("Section1", "IntVal", "int_val", [&int_val](int v)
                          { int_val = v; }, 0);
@@ -323,7 +323,7 @@ TEST_F(ConfigTest, MixedConfigTypes)
                           { bool_val = v; }, false);
     Config::register_string("Section2", "StringVal", "string_val", [&string_val](const std::string &v)
                             { string_val = v; }, "");
-    Config::register_key_combo("Section2", "Keys", "keys_val", [&keys_val](const Config::KeyCombo &c)
+    Config::register_key_combo("Section2", "Keys", "keys_val", [&keys_val](const Config::KeyComboList &c)
                                { keys_val = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
@@ -332,7 +332,7 @@ TEST_F(ConfigTest, MixedConfigTypes)
     EXPECT_NEAR(float_val, 3.14f, 0.01f);
     EXPECT_TRUE(bool_val);
     EXPECT_EQ(string_val, "hello");
-    EXPECT_EQ(keys_val.keys.size(), 2u);
+    ASSERT_EQ(keys_val.size(), 2u);
 }
 
 TEST_F(ConfigTest, BoolVariations)
@@ -396,16 +396,16 @@ TEST_F(ConfigTest, KeyCombo_CommentsAndSpaces)
     ini_file << "Keys=  0x10  ,  0x20  ; this is a comment\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
+    Config::KeyComboList test_value;
 
-    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyCombo &c)
+    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    EXPECT_EQ(test_value.keys.size(), 2u);
-    EXPECT_EQ(test_value.keys[0], keyboard_key(0x10));
-    EXPECT_EQ(test_value.keys[1], keyboard_key(0x20));
+    ASSERT_EQ(test_value.size(), 2u);
+    EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x10));
+    EXPECT_EQ(test_value[1].keys[0], keyboard_key(0x20));
 }
 
 TEST_F(ConfigTest, KeyCombo_JustPrefix)
@@ -415,15 +415,15 @@ TEST_F(ConfigTest, KeyCombo_JustPrefix)
     ini_file << "Keys=0x, 0x10\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
+    Config::KeyComboList test_value;
 
-    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyCombo &c)
+    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    EXPECT_EQ(test_value.keys.size(), 1u);
-    EXPECT_EQ(test_value.keys[0], keyboard_key(0x10));
+    ASSERT_EQ(test_value.size(), 1u);
+    EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x10));
 }
 
 TEST_F(ConfigTest, MultipleRegistrationsSameType)
@@ -452,7 +452,7 @@ TEST_F(ConfigTest, LogAll_AllTypes)
     float f_val = 0.0f;
     bool b_val = false;
     std::string s_val;
-    Config::KeyCombo k_val;
+    Config::KeyComboList k_val;
 
     Config::register_float("Sec", "F", "f_val", [&f_val](float v)
                            { f_val = v; }, 1.5f);
@@ -460,7 +460,7 @@ TEST_F(ConfigTest, LogAll_AllTypes)
                           { b_val = v; }, true);
     Config::register_string("Sec", "S", "s_val", [&s_val](const std::string &v)
                             { s_val = v; }, "hello");
-    Config::register_key_combo("Sec", "K", "k_val", [&k_val](const Config::KeyCombo &c)
+    Config::register_key_combo("Sec", "K", "k_val", [&k_val](const Config::KeyComboList &c)
                                { k_val = c; }, "0x41");
 
     Config::load(test_ini_file_.string());
@@ -470,7 +470,7 @@ TEST_F(ConfigTest, LogAll_AllTypes)
     EXPECT_NEAR(f_val, 1.5f, 0.01f);
     EXPECT_TRUE(b_val);
     EXPECT_EQ(s_val, "hello");
-    EXPECT_EQ(k_val.keys.size(), 1u);
+    ASSERT_EQ(k_val.size(), 1u);
 }
 
 TEST_F(ConfigTest, KeyCombo_InlineTokenComment)
@@ -480,15 +480,15 @@ TEST_F(ConfigTest, KeyCombo_InlineTokenComment)
     ini_file << "Keys=0x10, 0x20 ; inline comment at end of line\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
-    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyCombo &c)
+    Config::KeyComboList test_value;
+    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    EXPECT_EQ(test_value.keys.size(), 2u);
-    EXPECT_EQ(test_value.keys[0], keyboard_key(0x10));
-    EXPECT_EQ(test_value.keys[1], keyboard_key(0x20));
+    ASSERT_EQ(test_value.size(), 2u);
+    EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x10));
+    EXPECT_EQ(test_value[1].keys[0], keyboard_key(0x20));
 }
 
 TEST_F(ConfigTest, KeyCombo_EmptyTokenFromConsecutiveCommas)
@@ -498,15 +498,15 @@ TEST_F(ConfigTest, KeyCombo_EmptyTokenFromConsecutiveCommas)
     ini_file << "Keys=0x10,,0x20\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
-    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyCombo &c)
+    Config::KeyComboList test_value;
+    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    EXPECT_EQ(test_value.keys.size(), 2u);
-    EXPECT_EQ(test_value.keys[0], keyboard_key(0x10));
-    EXPECT_EQ(test_value.keys[1], keyboard_key(0x20));
+    ASSERT_EQ(test_value.size(), 2u);
+    EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x10));
+    EXPECT_EQ(test_value[1].keys[0], keyboard_key(0x20));
 }
 
 TEST_F(ConfigTest, KeyCombo_OverflowValue)
@@ -516,43 +516,43 @@ TEST_F(ConfigTest, KeyCombo_OverflowValue)
     ini_file << "Keys=FFFFFFFFFFFFFFFFFFFFFFFF, 0x41\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
-    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyCombo &c)
+    Config::KeyComboList test_value;
+    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    EXPECT_EQ(test_value.keys.size(), 1u);
-    EXPECT_EQ(test_value.keys[0], keyboard_key(0x41));
+    ASSERT_EQ(test_value.size(), 1u);
+    EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x41));
 }
 
 TEST_F(ConfigTest, KeyCombo_DefaultEmptyToken)
 {
-    Config::KeyCombo val;
-    Config::register_key_combo("S", "K1", "k1", [&val](const Config::KeyCombo &c)
+    Config::KeyComboList val;
+    Config::register_key_combo("S", "K1", "k1", [&val](const Config::KeyComboList &c)
                                { val = c; }, "0x41,,0x42");
     Config::load(test_ini_file_.string());
-    EXPECT_EQ(val.keys.size(), 2u);
+    ASSERT_EQ(val.size(), 2u);
 }
 
 TEST_F(ConfigTest, KeyCombo_DefaultBarePrefix)
 {
-    Config::KeyCombo val;
-    Config::register_key_combo("S", "K2", "k2", [&val](const Config::KeyCombo &c)
+    Config::KeyComboList val;
+    Config::register_key_combo("S", "K2", "k2", [&val](const Config::KeyComboList &c)
                                { val = c; }, "0x, 0x42");
     Config::load(test_ini_file_.string());
-    EXPECT_EQ(val.keys.size(), 1u);
-    EXPECT_EQ(val.keys[0], keyboard_key(0x42));
+    ASSERT_EQ(val.size(), 1u);
+    EXPECT_EQ(val[0].keys[0], keyboard_key(0x42));
 }
 
 TEST_F(ConfigTest, KeyCombo_DefaultOverflow)
 {
-    Config::KeyCombo val;
-    Config::register_key_combo("S", "K3", "k3", [&val](const Config::KeyCombo &c)
+    Config::KeyComboList val;
+    Config::register_key_combo("S", "K3", "k3", [&val](const Config::KeyComboList &c)
                                { val = c; }, "FFFFFFFFFFFFFFFFFFFFFFFF, 0x43");
     Config::load(test_ini_file_.string());
-    EXPECT_EQ(val.keys.size(), 1u);
-    EXPECT_EQ(val.keys[0], keyboard_key(0x43));
+    ASSERT_EQ(val.size(), 1u);
+    EXPECT_EQ(val[0].keys[0], keyboard_key(0x43));
 }
 
 TEST_F(ConfigTest, KeyCombo_ValueExceedingIntMax)
@@ -562,24 +562,24 @@ TEST_F(ConfigTest, KeyCombo_ValueExceedingIntMax)
     ini_file << "Keys=0x80000000, 0x41\n";
     ini_file.close();
 
-    Config::KeyCombo test_value;
-    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyCombo &c)
+    Config::KeyComboList test_value;
+    Config::register_key_combo("TestSection", "Keys", "keys", [&test_value](const Config::KeyComboList &c)
                                { test_value = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    EXPECT_EQ(test_value.keys.size(), 1u);
-    EXPECT_EQ(test_value.keys[0], keyboard_key(0x41));
+    ASSERT_EQ(test_value.size(), 1u);
+    EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x41));
 }
 
 TEST_F(ConfigTest, KeyCombo_DefaultValueExceedingIntMax)
 {
-    Config::KeyCombo val;
-    Config::register_key_combo("S", "K4", "k4", [&val](const Config::KeyCombo &c)
+    Config::KeyComboList val;
+    Config::register_key_combo("S", "K4", "k4", [&val](const Config::KeyComboList &c)
                                { val = c; }, "0x80000000, 0x44");
     Config::load(test_ini_file_.string());
-    EXPECT_EQ(val.keys.size(), 1u);
-    EXPECT_EQ(val.keys[0], keyboard_key(0x44));
+    ASSERT_EQ(val.size(), 1u);
+    EXPECT_EQ(val[0].keys[0], keyboard_key(0x44));
 }
 
 TEST_F(ConfigTest, DuplicateKeyRegistration)
@@ -721,105 +721,105 @@ TEST_F(ConfigTest, RegisterString_DefaultValueNotMovedFrom)
 
 TEST_F(ConfigTest, RegisterKeyCombo_SingleKey)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "0x72");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    EXPECT_TRUE(combo.modifiers.empty());
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    EXPECT_TRUE(combo[0].modifiers.empty());
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_NamedSingleKey)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "F3");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    EXPECT_TRUE(combo.modifiers.empty());
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    EXPECT_TRUE(combo[0].modifiers.empty());
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_SingleModifier)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "0x11+0x72");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    ASSERT_EQ(combo.modifiers.size(), 1u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combo[0].modifiers.size(), 1u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_NamedModifier)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "Ctrl+F3");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    ASSERT_EQ(combo.modifiers.size(), 1u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combo[0].modifiers.size(), 1u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_MultipleModifiers)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "Ctrl+Shift+F3");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    ASSERT_EQ(combo.modifiers.size(), 2u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
-    EXPECT_EQ(combo.modifiers[1], keyboard_key(0x10));
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combo[0].modifiers.size(), 2u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
+    EXPECT_EQ(combo[0].modifiers[1], keyboard_key(0x10));
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_MultipleTriggerKeys)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "Ctrl+F3,F4");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 2u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    EXPECT_EQ(combo.keys[1], keyboard_key(0x73));
-    ASSERT_EQ(combo.modifiers.size(), 1u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
+    ASSERT_EQ(combo.size(), 2u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combo[0].modifiers.size(), 1u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
+    EXPECT_EQ(combo[1].keys[0], keyboard_key(0x73));
+    EXPECT_TRUE(combo[1].modifiers.empty());
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_Empty)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    EXPECT_TRUE(combo.keys.empty());
-    EXPECT_TRUE(combo.modifiers.empty());
+    EXPECT_TRUE(combo.empty());
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_FromFile)
@@ -829,18 +829,18 @@ TEST_F(ConfigTest, RegisterKeyCombo_FromFile)
     ini_file << "Toggle=Ctrl+Shift+F3 ; Ctrl+Shift+F3\n";
     ini_file.close();
 
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "0x41");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    ASSERT_EQ(combo.modifiers.size(), 2u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
-    EXPECT_EQ(combo.modifiers[1], keyboard_key(0x10));
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combo[0].modifiers.size(), 2u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
+    EXPECT_EQ(combo[0].modifiers[1], keyboard_key(0x10));
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_FromFileNoModifiers)
@@ -850,16 +850,16 @@ TEST_F(ConfigTest, RegisterKeyCombo_FromFileNoModifiers)
     ini_file << "Toggle=F3\n";
     ini_file.close();
 
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    EXPECT_TRUE(combo.modifiers.empty());
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    EXPECT_TRUE(combo[0].modifiers.empty());
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_FromFileMultipleTriggers)
@@ -869,71 +869,73 @@ TEST_F(ConfigTest, RegisterKeyCombo_FromFileMultipleTriggers)
     ini_file << "Toggle=Ctrl+F3,F4,F5\n";
     ini_file.close();
 
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 3u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    EXPECT_EQ(combo.keys[1], keyboard_key(0x73));
-    EXPECT_EQ(combo.keys[2], keyboard_key(0x74));
-    ASSERT_EQ(combo.modifiers.size(), 1u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
+    ASSERT_EQ(combo.size(), 3u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combo[0].modifiers.size(), 1u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
+    EXPECT_EQ(combo[1].keys[0], keyboard_key(0x73));
+    EXPECT_TRUE(combo[1].modifiers.empty());
+    EXPECT_EQ(combo[2].keys[0], keyboard_key(0x74));
+    EXPECT_TRUE(combo[2].modifiers.empty());
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_InvalidModifierSkipped)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "0xGG+Ctrl+F3");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    ASSERT_EQ(combo.modifiers.size(), 1u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combo[0].modifiers.size(), 1u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_WhitespaceAroundPlus)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "  Ctrl  +  Shift  +  F3  ");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    ASSERT_EQ(combo.modifiers.size(), 2u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
-    EXPECT_EQ(combo.modifiers[1], keyboard_key(0x10));
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combo[0].modifiers.size(), 2u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
+    EXPECT_EQ(combo[0].modifiers[1], keyboard_key(0x10));
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_DefaultValueApplied)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "Ctrl+F3");
 
     // Before load(), the setter should have been called with the parsed default
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], keyboard_key(0x72));
-    ASSERT_EQ(combo.modifiers.size(), 1u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combo[0].modifiers.size(), 1u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_LogAll)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "Ctrl+F3");
 
     Config::load(test_ini_file_.string());
@@ -943,42 +945,43 @@ TEST_F(ConfigTest, RegisterKeyCombo_LogAll)
 
 TEST_F(ConfigTest, RegisterKeyCombo_GamepadDefault)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "GP", "gp", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "GP", "gp", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "Gamepad_LB+Gamepad_A,Gamepad_B");
 
-    ASSERT_EQ(combo.keys.size(), 2u);
-    EXPECT_EQ(combo.keys[0], gamepad_button(GamepadCode::A));
-    EXPECT_EQ(combo.keys[1], gamepad_button(GamepadCode::B));
-    ASSERT_EQ(combo.modifiers.size(), 1u);
-    EXPECT_EQ(combo.modifiers[0], gamepad_button(GamepadCode::LeftBumper));
+    ASSERT_EQ(combo.size(), 2u);
+    EXPECT_EQ(combo[0].keys[0], gamepad_button(GamepadCode::A));
+    ASSERT_EQ(combo[0].modifiers.size(), 1u);
+    EXPECT_EQ(combo[0].modifiers[0], gamepad_button(GamepadCode::LeftBumper));
+    EXPECT_EQ(combo[1].keys[0], gamepad_button(GamepadCode::B));
+    EXPECT_TRUE(combo[1].modifiers.empty());
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_MouseDefault)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "MS", "ms", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "MS", "ms", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "Ctrl+Mouse4");
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], mouse_button(0x05));
-    ASSERT_EQ(combo.modifiers.size(), 1u);
-    EXPECT_EQ(combo.modifiers[0], keyboard_key(0x11));
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], mouse_button(0x05));
+    ASSERT_EQ(combo[0].modifiers.size(), 1u);
+    EXPECT_EQ(combo[0].modifiers[0], keyboard_key(0x11));
 }
 
 TEST_F(ConfigTest, RegisterKeyCombo_ThumbstickDefault)
 {
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "LS", "ls", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "LS", "ls", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "Gamepad_LB+Gamepad_LSUp");
 
-    ASSERT_EQ(combo.keys.size(), 1u);
-    EXPECT_EQ(combo.keys[0], gamepad_button(GamepadCode::LeftStickUp));
-    ASSERT_EQ(combo.modifiers.size(), 1u);
-    EXPECT_EQ(combo.modifiers[0], gamepad_button(GamepadCode::LeftBumper));
+    ASSERT_EQ(combo.size(), 1u);
+    EXPECT_EQ(combo[0].keys[0], gamepad_button(GamepadCode::LeftStickUp));
+    ASSERT_EQ(combo[0].modifiers.size(), 1u);
+    EXPECT_EQ(combo[0].modifiers[0], gamepad_button(GamepadCode::LeftBumper));
 }
 
 TEST_F(ConfigTest, KeyCombo_ThumbstickFromFile)
@@ -988,14 +991,73 @@ TEST_F(ConfigTest, KeyCombo_ThumbstickFromFile)
     ini_file << "StickCombo=Gamepad_RSLeft,Gamepad_RSRight\n";
     ini_file.close();
 
-    Config::KeyCombo combo;
+    Config::KeyComboList combo;
 
-    Config::register_key_combo("Hotkeys", "StickCombo", "stick", [&combo](const Config::KeyCombo &c)
+    Config::register_key_combo("Hotkeys", "StickCombo", "stick", [&combo](const Config::KeyComboList &c)
                                { combo = c; }, "");
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    ASSERT_EQ(combo.keys.size(), 2u);
-    EXPECT_EQ(combo.keys[0], gamepad_button(GamepadCode::RightStickLeft));
-    EXPECT_EQ(combo.keys[1], gamepad_button(GamepadCode::RightStickRight));
+    ASSERT_EQ(combo.size(), 2u);
+    EXPECT_EQ(combo[0].keys[0], gamepad_button(GamepadCode::RightStickLeft));
+    EXPECT_EQ(combo[1].keys[0], gamepad_button(GamepadCode::RightStickRight));
+}
+
+TEST_F(ConfigTest, KeyComboList_IndependentCombos)
+{
+    std::ofstream ini_file(test_ini_file_);
+    ini_file << "[Hotkeys]\n";
+    ini_file << "Toggle=F3,Gamepad_LT+Gamepad_B\n";
+    ini_file.close();
+
+    Config::KeyComboList combos;
+
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combos](const Config::KeyComboList &c)
+                               { combos = c; }, "");
+
+    EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
+
+    ASSERT_EQ(combos.size(), 2u);
+    ASSERT_EQ(combos[0].keys.size(), 1u);
+    EXPECT_EQ(combos[0].keys[0], keyboard_key(0x72));
+    EXPECT_TRUE(combos[0].modifiers.empty());
+    ASSERT_EQ(combos[1].keys.size(), 1u);
+    EXPECT_EQ(combos[1].keys[0], gamepad_button(GamepadCode::B));
+    ASSERT_EQ(combos[1].modifiers.size(), 1u);
+    EXPECT_EQ(combos[1].modifiers[0], gamepad_button(GamepadCode::LeftTrigger));
+}
+
+TEST_F(ConfigTest, KeyComboList_IndependentCombosDefault)
+{
+    Config::KeyComboList combos;
+
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&combos](const Config::KeyComboList &c)
+                               { combos = c; }, "F3,Gamepad_LT+Gamepad_B");
+
+    ASSERT_EQ(combos.size(), 2u);
+    ASSERT_EQ(combos[0].keys.size(), 1u);
+    EXPECT_EQ(combos[0].keys[0], keyboard_key(0x72));
+    EXPECT_TRUE(combos[0].modifiers.empty());
+    ASSERT_EQ(combos[1].keys.size(), 1u);
+    EXPECT_EQ(combos[1].keys[0], gamepad_button(GamepadCode::B));
+    ASSERT_EQ(combos[1].modifiers.size(), 1u);
+    EXPECT_EQ(combos[1].modifiers[0], gamepad_button(GamepadCode::LeftTrigger));
+}
+
+TEST_F(ConfigTest, KeyComboList_MixedDeviceCombos)
+{
+    Config::KeyComboList combos;
+
+    Config::register_key_combo("Hotkeys", "Action", "action", [&combos](const Config::KeyComboList &c)
+                               { combos = c; }, "Ctrl+F3,Mouse4,Gamepad_LB+Gamepad_A");
+
+    ASSERT_EQ(combos.size(), 3u);
+    EXPECT_EQ(combos[0].keys[0], keyboard_key(0x72));
+    ASSERT_EQ(combos[0].modifiers.size(), 1u);
+    EXPECT_EQ(combos[0].modifiers[0], keyboard_key(0x11));
+    EXPECT_EQ(combos[1].keys[0], mouse_button(0x05));
+    EXPECT_TRUE(combos[1].modifiers.empty());
+    EXPECT_EQ(combos[2].keys[0], gamepad_button(GamepadCode::A));
+    ASSERT_EQ(combos[2].modifiers.size(), 1u);
+    EXPECT_EQ(combos[2].modifiers[0], gamepad_button(GamepadCode::LeftBumper));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hotkey combo configuration now supports multiple independent key combinations separated by commas, enabling flexible alternative input bindings.

* **Documentation**
  * Updated configuration examples and syntax guidance for multi-combo support.
  * Enhanced performance guidance for input binding lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->