### PR TITLE
feat(input): add KeyComboList overloads to InputManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in g
   * **Threading & lifecycle:** Available as an RAII `InputPoller` building block or via the thread-safe `InputManager` singleton for convenience. Two-phase initialization (construct then start) for safe thread launching. `condition_variable_any` with `stop_token` for responsive cooperative shutdown. Exception-safe callback invocation. Automatic hold release on shutdown. DLL-safe when used with `DMK_Shutdown()` before `DLL_PROCESS_DETACH`.
   * **Performance:** Hash-map-backed `is_binding_active()` query for lock-free cross-thread state reads (e.g., from render hooks at 60+ fps). Supports multiple bindings per name for multi-combo hotkeys. Lock-free `is_running()` via atomic flag. O(1) reverse name lookup for `input_code_to_name()`.
   * **Gamepad & polling:** XInput is polled once per cycle and skipped entirely when no gamepad bindings are registered. Reconnection attempts are throttled to every 2 seconds when no controller is connected, avoiding the per-cycle overhead of `XInputGetState` on disconnected slots.
-  * **Configuration integration:** Loading input codes from INI files (named keys, hex VK codes, or mixed). Named key resolution uses binary search for efficient lookup.
+  * **Configuration integration:** Loading input codes from INI files (named keys, hex VK codes, or mixed). Named key resolution uses binary search for efficient lookup. `register_press` and `register_hold` accept `KeyComboList` directly for zero-boilerplate binding of config-parsed key combos.
 
 ## Testing
 
@@ -500,22 +500,18 @@ void InitializeMyMod() {
         logger.warning("Target address is 0 or not found. Hook not created.");
     }
 
-    // Register hotkey bindings with the InputManager (after hooks are ready)
+    // Register hotkey bindings with the InputManager (after hooks are ready).
+    // register_press/register_hold accept a KeyComboList directly — one binding
+    // is created per combo, all sharing the same name for OR-logic queries.
     DMKInputManager& input_mgr = DMKInputManager::get_instance();
 
-    for (const auto& combo : g_mod_config.toggle_combo) {
-        input_mgr.register_press("toggle_view", combo.keys,
-            combo.modifiers, []() {
-                DMKLogger::get_instance().info("Toggle key pressed!");
-            });
-    }
+    input_mgr.register_press("toggle_view", g_mod_config.toggle_combo, []() {
+        DMKLogger::get_instance().info("Toggle key pressed!");
+    });
 
-    for (const auto& combo : g_mod_config.hold_scroll_combo) {
-        input_mgr.register_hold("hold_scroll", combo.keys,
-            combo.modifiers, [](bool held) {
-                DMKLogger::get_instance().info("Hold scroll: {}", held ? "active" : "released");
-            });
-    }
+    input_mgr.register_hold("hold_scroll", g_mod_config.hold_scroll_combo, [](bool held) {
+        DMKLogger::get_instance().info("Hold scroll: {}", held ? "active" : "released");
+    });
 
     // Start the input polling thread (focus-aware by default)
     input_mgr.start();

--- a/include/DetourModKit/input.hpp
+++ b/include/DetourModKit/input.hpp
@@ -2,6 +2,7 @@
 #define INPUT_HPP
 
 #include "DetourModKit/input_codes.hpp"
+#include "DetourModKit/config.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -272,6 +273,18 @@ namespace DetourModKit
                             std::function<void()> callback);
 
         /**
+         * @brief Registers press-mode bindings from a KeyComboList.
+         * @details Registers one binding per combo in the list. All bindings share
+         *          the same name, enabling OR-logic via is_binding_active().
+         *          Must be called before start(). Ignored if the poller is already running.
+         * @param name Shared binding name for all combos.
+         * @param combos List of key combinations (each combo is registered independently).
+         * @param callback Function to invoke on key press.
+         */
+        void register_press(const std::string &name, const Config::KeyComboList &combos,
+                            std::function<void()> callback);
+
+        /**
          * @brief Registers a hold-mode binding.
          * @details The callback fires with true when any input in the list is pressed,
          *          and false when all are released. Must be called before start().
@@ -295,6 +308,18 @@ namespace DetourModKit
          */
         void register_hold(const std::string &name, const std::vector<InputCode> &keys,
                            const std::vector<InputCode> &modifiers,
+                           std::function<void(bool)> callback);
+
+        /**
+         * @brief Registers hold-mode bindings from a KeyComboList.
+         * @details Registers one binding per combo in the list. All bindings share
+         *          the same name, enabling OR-logic via is_binding_active().
+         *          Must be called before start(). Ignored if the poller is already running.
+         * @param name Shared binding name for all combos.
+         * @param combos List of key combinations (each combo is registered independently).
+         * @param callback Function invoked with the hold state (true = held, false = released).
+         */
+        void register_hold(const std::string &name, const Config::KeyComboList &combos,
                            std::function<void(bool)> callback);
 
         /**

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "DetourModKit/input.hpp"
+#include "DetourModKit/config.hpp"
 #include "DetourModKit/logger.hpp"
 
 #include <windows.h>
@@ -465,6 +466,24 @@ namespace DetourModKit
         binding.mode = InputMode::Hold;
         binding.on_state_change = std::move(callback);
         pending_bindings_.push_back(std::move(binding));
+    }
+
+    void InputManager::register_press(const std::string &name, const Config::KeyComboList &combos,
+                                      std::function<void()> callback)
+    {
+        for (const auto &combo : combos)
+        {
+            register_press(name, combo.keys, combo.modifiers, callback);
+        }
+    }
+
+    void InputManager::register_hold(const std::string &name, const Config::KeyComboList &combos,
+                                     std::function<void(bool)> callback)
+    {
+        for (const auto &combo : combos)
+        {
+            register_hold(name, combo.keys, combo.modifiers, callback);
+        }
     }
 
     void InputManager::set_require_focus(bool require_focus)

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "DetourModKit/input.hpp"
+#include "DetourModKit/config.hpp"
 
 using namespace DetourModKit;
 using DetourModKit::keyboard_key;
@@ -1038,6 +1039,124 @@ TEST_F(InputManagerTest, MixedKeyboardAndGamepadBindings)
 
     mgr.start();
     EXPECT_TRUE(mgr.is_running());
+
+    mgr.shutdown();
+}
+
+// --- InputManager: KeyComboList overloads ---
+
+TEST_F(InputManagerTest, RegisterPressFromKeyComboList)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    Config::KeyComboList combos = {
+        {.keys = {keyboard_key(0x72)}, .modifiers = {}},
+        {.keys = {gamepad_button(GamepadCode::A)}, .modifiers = {gamepad_button(GamepadCode::LeftBumper)}}};
+
+    mgr.register_press("toggle", combos, []() {});
+
+    EXPECT_EQ(mgr.binding_count(), 2u);
+}
+
+TEST_F(InputManagerTest, RegisterHoldFromKeyComboList)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    Config::KeyComboList combos = {
+        {.keys = {keyboard_key(0x10)}, .modifiers = {}},
+        {.keys = {gamepad_button(GamepadCode::LeftTrigger)}, .modifiers = {}}};
+
+    mgr.register_hold("hold_action", combos, [](bool) {});
+
+    EXPECT_EQ(mgr.binding_count(), 2u);
+}
+
+TEST_F(InputManagerTest, RegisterPressFromEmptyKeyComboList)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    Config::KeyComboList combos;
+
+    mgr.register_press("empty", combos, []() {});
+
+    EXPECT_EQ(mgr.binding_count(), 0u);
+}
+
+TEST_F(InputManagerTest, RegisterHoldFromEmptyKeyComboList)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    Config::KeyComboList combos;
+
+    mgr.register_hold("empty", combos, [](bool) {});
+
+    EXPECT_EQ(mgr.binding_count(), 0u);
+}
+
+TEST_F(InputManagerTest, RegisterPressFromSingleCombo)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    Config::KeyComboList combos = {
+        {.keys = {keyboard_key(0x72)}, .modifiers = {keyboard_key(0x11)}}};
+
+    mgr.register_press("single", combos, []() {});
+
+    EXPECT_EQ(mgr.binding_count(), 1u);
+}
+
+TEST_F(InputManagerTest, KeyComboListBindingsShareName)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    Config::KeyComboList combos = {
+        {.keys = {keyboard_key(0x72)}, .modifiers = {}},
+        {.keys = {keyboard_key(0x73)}, .modifiers = {}}};
+
+    mgr.register_press("shared_name", combos, []() {});
+    mgr.start();
+
+    EXPECT_TRUE(mgr.is_running());
+    EXPECT_EQ(mgr.binding_count(), 2u);
+
+    // is_binding_active queries by shared name (OR logic across combos)
+    EXPECT_FALSE(mgr.is_binding_active("shared_name"));
+
+    mgr.shutdown();
+}
+
+TEST_F(InputManagerTest, KeyComboListMixedWithIndividualBindings)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    mgr.register_press("individual", {keyboard_key(0x41)}, []() {});
+
+    Config::KeyComboList combos = {
+        {.keys = {keyboard_key(0x72)}, .modifiers = {}},
+        {.keys = {keyboard_key(0x73)}, .modifiers = {}}};
+
+    mgr.register_hold("combo_hold", combos, [](bool) {});
+
+    EXPECT_EQ(mgr.binding_count(), 3u);
+}
+
+TEST_F(InputManagerTest, KeyComboListIgnoredWhileRunning)
+{
+    InputManager &mgr = InputManager::get_instance();
+
+    mgr.register_press("before", {keyboard_key(0x41)}, []() {});
+    mgr.start();
+
+    EXPECT_EQ(mgr.binding_count(), 1u);
+
+    Config::KeyComboList combos = {
+        {.keys = {keyboard_key(0x72)}, .modifiers = {}}};
+
+    mgr.register_press("after", combos, []() {});
+    EXPECT_EQ(mgr.binding_count(), 1u);
+
+    mgr.register_hold("after_hold", combos, [](bool) {});
+    EXPECT_EQ(mgr.binding_count(), 1u);
 
     mgr.shutdown();
 }


### PR DESCRIPTION
## Summary

- Add `register_press` and `register_hold` overloads that accept `Config::KeyComboList` directly, eliminating boilerplate when bridging config-parsed key combos to `InputManager`
- All combos in the list share the same binding name, enabling OR-logic via `is_binding_active()`
- Add 8 new unit tests covering empty lists, single/multi-combo, shared name queries, mixed usage, and ignored-while-running behavior
- Update README code example and feature description to reflect the new API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new `register_press` and `register_hold` API overloads that accept multiple key combinations in a single call, simplifying binding registration without requiring per-combo iteration loops.

* **Documentation**
  * Updated configuration examples and feature documentation to demonstrate the streamlined key binding registration using the new `KeyComboList`-direct registration capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->