### PR TITLE
fix(logger): use Win32 shared-access file handles for concurrent log file access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ include/DetourModKit/    # Public headers — one per module
   hook_manager.hpp       # SafetyHook wrapper (inline + mid hooks)
   async_logger.hpp       # Lock-free MPMC queue logger
   logger.hpp             # Synchronous singleton logger
+  win_file_stream.hpp    # Win32 shared-access file stream (CreateFile backend)
   config.hpp             # INI configuration with callback setters
   input.hpp              # Input polling (keyboard/mouse/XInput)
   input_codes.hpp        # Unified InputCode type and named key tables

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in g
 * **AOB Scanner:** Find array-of-bytes (signatures) in memory with wildcard support and SSE2-accelerated pattern verification (when compiled with SSE2 support) for patterns >= 16 bytes. Supports `|` offset markers for targeting a specific instruction within a wider pattern (e.g., `"48 8B 88 B8 00 00 00 | 48 89 4C 24 68"` sets the offset to byte 7) and nth-occurrence matching (1-based) for patterns that hit multiple locations. Includes RIP-relative instruction resolution for extracting absolute addresses from x86-64 code.
 * **Hook Manager:** A C++ wrapper around [SafetyHook](https://github.com/cursey/safetyhook) for creating and managing inline and mid-function hooks, by direct address or AOB scan.
 * **Configuration System:** Load settings from INI files. Mods register their configuration variables (defined in the mod's code) and the kit handles parsing and value assignment. Supports key combos with modifier keys via `register_key_combo` (format: `modifier+trigger`, e.g., `Ctrl+Shift+F3`). Multiple independent combos can be comma-separated (e.g., `F3,Gamepad_LT+Gamepad_B`). Named keys (`Ctrl`, `F3`, `Mouse1`, `Gamepad_A`), hex VK codes (`0x72`), and mixed formats are all supported. (Powered by [SimpleIni](https://github.com/brofield/simpleini)).
-* **Logger:** A flexible singleton logger for outputting messages to a log file. Supports configurable log levels, timestamps, and prefixes. Features **async logging** for high-throughput scenarios and **format string placeholders** for concise log messages.
+* **Logger:** A flexible singleton logger for outputting messages to a log file. Supports configurable log levels, timestamps, and prefixes. Features **async logging** for high-throughput scenarios, **format string placeholders** for concise log messages, and **concurrent file access** via Win32 shared-access file handles (log files can be read by external tools while logging is active).
 * **Async Logger:** A lock-free, bounded queue-based async logger that decouples log message production from file I/O. Designed for minimal latency on the producer side with batched writes on the consumer thread. Features configurable overflow policies (DropNewest/DropOldest/Block/SyncFallback), bounded Block policy with 16 ms default timeout (one frame at 60 fps) to prevent thread starvation, inline buffer optimization for messages of size <= 256 bytes (inclusive), and message size validation with truncation for messages larger than 16 MB (messages > 16 MB are truncated to 16 MB rather than rejected).
 * **Memory Utilities:** Functions for checking memory readability/writability and writing bytes to memory. Includes an optional memory region cache.
 * **String Utilities:** Whitespace trimming for string cleanup.
@@ -127,6 +127,7 @@ This project uses CMake with [CMake Presets](https://cmake.org/cmake/help/latest
     │   │   ├── input.hpp             <-- Input/hotkey system
     │   │   ├── input_codes.hpp       <-- Unified input codes (keyboard/mouse/gamepad)
     │   │   ├── logger.hpp            <-- Synchronous logger
+    │   │   ├── win_file_stream.hpp   <-- Win32 shared-access file stream
     │   │   └── ...
     │   ├── DetourModKit.hpp          <-- Main DetourModKit include
     │   ├── DirectXMath/              <-- DirectXMath headers

--- a/include/DetourModKit/async_logger.hpp
+++ b/include/DetourModKit/async_logger.hpp
@@ -268,7 +268,7 @@ namespace DetourModKit
      * @details Uses a lock-free queue to accept log messages from multiple threads
      *          and a dedicated writer thread to perform batched file writes.
      *          This significantly reduces latency on the producer side.
-     * @note Uses shared_ptr<ofstream> to safely handle Logger reconfiguration during runtime.
+     * @note Uses shared_ptr<WinFileStream> to safely handle Logger reconfiguration during runtime.
      */
     class AsyncLogger
     {
@@ -280,7 +280,7 @@ namespace DetourModKit
          * @param log_mutex Shared pointer to the mutex protecting the file stream.
          */
         explicit AsyncLogger(const AsyncLoggerConfig &config,
-                             std::shared_ptr<std::ofstream> file_stream,
+                             std::shared_ptr<WinFileStream> file_stream,
                              std::shared_ptr<std::mutex> log_mutex);
 
         ~AsyncLogger() noexcept;
@@ -341,7 +341,7 @@ namespace DetourModKit
         DynamicMPMCQueue queue_;
         AsyncLoggerConfig config_;
 
-        std::shared_ptr<std::ofstream> file_stream_;
+        std::shared_ptr<WinFileStream> file_stream_;
         std::shared_ptr<std::mutex> log_mutex_;
 
         std::jthread writer_thread_;

--- a/include/DetourModKit/logger.hpp
+++ b/include/DetourModKit/logger.hpp
@@ -3,12 +3,13 @@
 
 #include <string>
 #include <string_view>
-#include <fstream>
 #include <mutex>
 #include <memory>
 #include <chrono>
 #include <format>
 #include <atomic>
+
+#include "DetourModKit/win_file_stream.hpp"
 
 namespace DetourModKit
 {
@@ -270,7 +271,7 @@ namespace DetourModKit
         std::string log_file_name_;
         std::string timestamp_format_;
 
-        std::shared_ptr<std::ofstream> log_file_stream_ptr_;
+        std::shared_ptr<WinFileStream> log_file_stream_ptr_;
         std::shared_ptr<std::mutex> log_mutex_ptr_;
         std::atomic<LogLevel> current_log_level_{LogLevel::Info};
         std::atomic<bool> shutdown_called_{false};

--- a/include/DetourModKit/win_file_stream.hpp
+++ b/include/DetourModKit/win_file_stream.hpp
@@ -1,0 +1,77 @@
+#ifndef WIN_FILE_STREAM_HPP
+#define WIN_FILE_STREAM_HPP
+
+#include <array>
+#include <ios>
+#include <ostream>
+#include <string>
+
+namespace DetourModKit
+{
+    /**
+     * @class WinFileStreamBuf
+     * @brief Custom stream buffer using Win32 CreateFile with shared access flags.
+     * @details Opens files with FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+     *          allowing external processes to read log files while they are being written.
+     *          Uses an internal buffer to minimize WriteFile syscalls.
+     */
+    class WinFileStreamBuf : public std::streambuf
+    {
+    public:
+        static constexpr size_t BUFFER_SIZE = 8192;
+
+        WinFileStreamBuf() noexcept;
+        ~WinFileStreamBuf() noexcept override;
+
+        WinFileStreamBuf(const WinFileStreamBuf &) = delete;
+        WinFileStreamBuf &operator=(const WinFileStreamBuf &) = delete;
+        WinFileStreamBuf(WinFileStreamBuf &&) = delete;
+        WinFileStreamBuf &operator=(WinFileStreamBuf &&) = delete;
+
+        bool open(const std::string &path, std::ios_base::openmode mode);
+        [[nodiscard]] bool is_open() const noexcept;
+        void close();
+
+    protected:
+        int_type overflow(int_type ch) override;
+        int sync() override;
+        std::streamsize xsputn(const char *s, std::streamsize count) override;
+
+    private:
+        bool flush_buffer();
+
+        void *handle_; // Win32 HANDLE
+        std::array<char, BUFFER_SIZE> buffer_;
+    };
+
+    /**
+     * @class WinFileStream
+     * @brief Output stream backed by Win32 file handles with shared access.
+     * @details Drop-in replacement for std::ofstream that guarantees concurrent
+     *          read access from external processes on Windows. Uses WinFileStreamBuf
+     *          for buffered I/O through the standard streambuf interface.
+     */
+    class WinFileStream : public std::ostream
+    {
+    public:
+        WinFileStream();
+        explicit WinFileStream(const std::string &path,
+                               std::ios_base::openmode mode = std::ios_base::out);
+        ~WinFileStream() noexcept override;
+
+        WinFileStream(const WinFileStream &) = delete;
+        WinFileStream &operator=(const WinFileStream &) = delete;
+        WinFileStream(WinFileStream &&) = delete;
+        WinFileStream &operator=(WinFileStream &&) = delete;
+
+        void open(const std::string &path, std::ios_base::openmode mode = std::ios_base::out);
+        [[nodiscard]] bool is_open() const noexcept;
+        void close();
+
+    private:
+        WinFileStreamBuf buf_;
+    };
+
+} // namespace DetourModKit
+
+#endif // WIN_FILE_STREAM_HPP

--- a/src/async_logger.cpp
+++ b/src/async_logger.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -377,7 +376,7 @@ namespace DetourModKit
     }
 
     AsyncLogger::AsyncLogger(const AsyncLoggerConfig &config,
-                             std::shared_ptr<std::ofstream> file_stream,
+                             std::shared_ptr<WinFileStream> file_stream,
                              std::shared_ptr<std::mutex> log_mutex)
         : queue_(config.queue_capacity),
           config_(config),

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <stdexcept>
 #include <array>
-#include <map>
 
 namespace DetourModKit
 {
@@ -128,7 +127,7 @@ namespace DetourModKit
     }
 
     Logger::Logger()
-        : log_file_stream_ptr_(std::make_shared<std::ofstream>()),
+        : log_file_stream_ptr_(std::make_shared<WinFileStream>()),
           log_mutex_ptr_(std::make_shared<std::mutex>())
     {
         {

--- a/src/win_file_stream.cpp
+++ b/src/win_file_stream.cpp
@@ -1,0 +1,196 @@
+#include "DetourModKit/win_file_stream.hpp"
+
+#include <windows.h>
+#include <algorithm>
+#include <cstring>
+
+namespace DetourModKit
+{
+    // --- WinFileStreamBuf ---
+
+    WinFileStreamBuf::WinFileStreamBuf() noexcept
+        : handle_(INVALID_HANDLE_VALUE)
+    {
+        setp(buffer_.data(), buffer_.data() + BUFFER_SIZE);
+    }
+
+    WinFileStreamBuf::~WinFileStreamBuf() noexcept
+    {
+        close();
+    }
+
+    bool WinFileStreamBuf::open(const std::string &path, std::ios_base::openmode mode)
+    {
+        if (is_open())
+        {
+            close();
+        }
+
+        DWORD creation = CREATE_ALWAYS;
+        if (mode & std::ios_base::app)
+        {
+            creation = OPEN_ALWAYS;
+        }
+
+        handle_ = CreateFileA(
+            path.c_str(),
+            GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            nullptr,
+            creation,
+            FILE_ATTRIBUTE_NORMAL,
+            nullptr);
+
+        if (handle_ == INVALID_HANDLE_VALUE)
+        {
+            return false;
+        }
+
+        if (mode & std::ios_base::app)
+        {
+            if (SetFilePointer(static_cast<HANDLE>(handle_), 0, nullptr, FILE_END) ==
+                INVALID_SET_FILE_POINTER && GetLastError() != NO_ERROR)
+            {
+                CloseHandle(static_cast<HANDLE>(handle_));
+                handle_ = INVALID_HANDLE_VALUE;
+                return false;
+            }
+        }
+
+        setp(buffer_.data(), buffer_.data() + BUFFER_SIZE);
+        return true;
+    }
+
+    bool WinFileStreamBuf::is_open() const noexcept
+    {
+        return handle_ != INVALID_HANDLE_VALUE;
+    }
+
+    void WinFileStreamBuf::close()
+    {
+        if (!is_open())
+        {
+            return;
+        }
+
+        flush_buffer();
+        CloseHandle(static_cast<HANDLE>(handle_));
+        handle_ = INVALID_HANDLE_VALUE;
+        setp(nullptr, nullptr);
+    }
+
+    WinFileStreamBuf::int_type WinFileStreamBuf::overflow(int_type ch)
+    {
+        if (!is_open())
+        {
+            return traits_type::eof();
+        }
+
+        if (!flush_buffer())
+        {
+            return traits_type::eof();
+        }
+
+        if (!traits_type::eq_int_type(ch, traits_type::eof()))
+        {
+            *pptr() = traits_type::to_char_type(ch);
+            pbump(1);
+        }
+
+        return traits_type::not_eof(ch);
+    }
+
+    int WinFileStreamBuf::sync()
+    {
+        if (!is_open())
+        {
+            return -1;
+        }
+
+        return flush_buffer() ? 0 : -1;
+    }
+
+    std::streamsize WinFileStreamBuf::xsputn(const char *s, std::streamsize count)
+    {
+        if (!is_open() || count <= 0)
+        {
+            return 0;
+        }
+
+        std::streamsize written = 0;
+
+        while (written < count)
+        {
+            const auto available = static_cast<std::streamsize>(epptr() - pptr());
+            const auto to_copy = std::min(count - written, available);
+
+            if (to_copy > 0)
+            {
+                std::memcpy(pptr(), s + written, static_cast<size_t>(to_copy));
+                pbump(static_cast<int>(to_copy));
+                written += to_copy;
+            }
+
+            if (pptr() == epptr())
+            {
+                if (!flush_buffer())
+                {
+                    break;
+                }
+            }
+        }
+
+        return written;
+    }
+
+    bool WinFileStreamBuf::flush_buffer()
+    {
+        const auto count = static_cast<DWORD>(pptr() - pbase());
+        if (count == 0)
+        {
+            return true;
+        }
+
+        DWORD bytes_written = 0;
+        const BOOL result = WriteFile(
+            static_cast<HANDLE>(handle_), pbase(), count, &bytes_written, nullptr);
+        setp(buffer_.data(), buffer_.data() + BUFFER_SIZE);
+
+        return result != 0 && bytes_written == count;
+    }
+
+    // --- WinFileStream ---
+
+    WinFileStream::WinFileStream()
+        : std::ostream(&buf_)
+    {
+    }
+
+    WinFileStream::WinFileStream(const std::string &path, std::ios_base::openmode mode)
+        : std::ostream(&buf_)
+    {
+        open(path, mode);
+    }
+
+    WinFileStream::~WinFileStream() noexcept = default;
+
+    void WinFileStream::open(const std::string &path, std::ios_base::openmode mode)
+    {
+        clear();
+        if (!buf_.open(path, mode))
+        {
+            setstate(std::ios_base::failbit);
+        }
+    }
+
+    bool WinFileStream::is_open() const noexcept
+    {
+        return buf_.is_open();
+    }
+
+    void WinFileStream::close()
+    {
+        buf_.close();
+    }
+
+} // namespace DetourModKit

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -62,7 +62,7 @@ TEST_F(AsyncLoggerTest, BasicCreation)
     config.batch_size = 10;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -77,7 +77,7 @@ TEST_F(AsyncLoggerTest, StartStop)
     config.batch_size = 10;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -95,7 +95,7 @@ TEST_F(AsyncLoggerTest, Enqueue)
     config.batch_size = 10;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -130,7 +130,7 @@ TEST_F(AsyncLoggerTest, Enqueue_ReturnsTrue_OnSuccess)
     config.batch_size = 10;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -150,7 +150,7 @@ TEST_F(AsyncLoggerTest, Enqueue_ReturnsFalse_WhenDropped)
     config.overflow_policy = OverflowPolicy::DropNewest;
     config.flush_interval = std::chrono::milliseconds{5000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -177,7 +177,7 @@ TEST_F(AsyncLoggerTest, Enqueue_BlockPolicy_BasicFunctionality)
     config.block_timeout_ms = std::chrono::milliseconds{100};
     config.flush_interval = std::chrono::milliseconds{100};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -194,7 +194,7 @@ TEST_F(AsyncLoggerTest, Flush)
     config.batch_size = 100;
     config.flush_interval = std::chrono::milliseconds{1000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -214,7 +214,7 @@ TEST_F(AsyncLoggerTest, MultiThreadedLogging)
     config.batch_size = 100;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -251,7 +251,7 @@ TEST_F(AsyncLoggerTest, EmptyMessage)
     config.batch_size = 10;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -271,7 +271,7 @@ TEST_F(AsyncLoggerTest, LongMessage)
     config.batch_size = 10;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -289,7 +289,7 @@ TEST_F(AsyncLoggerTest, LongMessage)
 TEST_F(AsyncLoggerTest, DoubleShutdown)
 {
     AsyncLoggerConfig config;
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -302,7 +302,7 @@ TEST_F(AsyncLoggerTest, DoubleShutdown)
 TEST_F(AsyncLoggerTest, IsRunningAfterShutdown)
 {
     AsyncLoggerConfig config;
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -320,7 +320,7 @@ TEST_F(AsyncLoggerTest, EnqueueAfterShutdown_SyncWrite)
     config.batch_size = 10;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -336,7 +336,7 @@ TEST_F(AsyncLoggerTest, EnqueueAfterShutdown_SyncWrite)
 TEST_F(AsyncLoggerTest, Flush_WhenNotRunning)
 {
     AsyncLoggerConfig config;
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -355,7 +355,7 @@ TEST_F(AsyncLoggerTest, OverflowPolicy_DropNewest)
     config.overflow_policy = OverflowPolicy::DropNewest;
     config.flush_interval = std::chrono::milliseconds{5000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -378,7 +378,7 @@ TEST_F(AsyncLoggerTest, OverflowPolicy_DropOldest_Full)
     config.overflow_policy = OverflowPolicy::DropOldest;
     config.flush_interval = std::chrono::milliseconds{5000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -401,7 +401,7 @@ TEST_F(AsyncLoggerTest, OverflowPolicy_SyncFallback)
     config.overflow_policy = OverflowPolicy::SyncFallback;
     config.flush_interval = std::chrono::milliseconds{5000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -425,7 +425,7 @@ TEST_F(AsyncLoggerTest, OverflowPolicy_Block)
     config.block_timeout_ms = std::chrono::milliseconds{200};
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -445,7 +445,7 @@ TEST(AsyncLoggerConfigTest, InvalidConfig_Throws)
     AsyncLoggerConfig config;
     config.queue_capacity = 0;
 
-    auto file_stream = std::make_shared<std::ofstream>();
+    auto file_stream = std::make_shared<WinFileStream>();
     auto log_mutex = std::make_shared<std::mutex>();
 
     EXPECT_THROW(AsyncLogger(config, file_stream, log_mutex), std::invalid_argument);
@@ -462,7 +462,7 @@ TEST(AsyncLoggerConfigTest, NullFileStream_Throws)
 TEST(AsyncLoggerConfigTest, NullMutex_Throws)
 {
     AsyncLoggerConfig config;
-    auto file_stream = std::make_shared<std::ofstream>();
+    auto file_stream = std::make_shared<WinFileStream>();
 
     EXPECT_THROW(AsyncLogger(config, file_stream, nullptr), std::invalid_argument);
 }
@@ -616,7 +616,7 @@ TEST_F(AsyncLoggerTest, MessageContentVerification)
     config.batch_size = 10;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -633,7 +633,7 @@ TEST_F(AsyncLoggerTest, MessageContentVerification)
 TEST_F(AsyncLoggerTest, DestructorFlushGuarantee)
 {
     {
-        auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+        auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
         auto log_mutex = std::make_shared<std::mutex>();
         AsyncLoggerConfig config;
         config.batch_size = 10;
@@ -658,7 +658,7 @@ TEST_F(AsyncLoggerTest, BatchBoundaryBehavior)
     config.batch_size = kBatchSize;
     config.flush_interval = std::chrono::milliseconds{50};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -684,7 +684,7 @@ TEST_F(AsyncLoggerTest, ConcurrentFlushAndEnqueue)
     config.batch_size = 16;
     config.flush_interval = std::chrono::milliseconds{20};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -845,7 +845,7 @@ TEST_F(AsyncLoggerTest, FlushGuarantee_AllMessagesWritten)
     config.batch_size = 4;
     config.flush_interval = std::chrono::milliseconds{1000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -936,7 +936,7 @@ TEST_F(AsyncLoggerTest, FlushWithTimeout_Success)
     config.batch_size = 4;
     config.flush_interval = std::chrono::milliseconds{10000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -955,7 +955,7 @@ TEST_F(AsyncLoggerTest, FlushWithTimeout_Success)
 TEST_F(AsyncLoggerTest, FlushWithTimeout_WhenNotRunning)
 {
     AsyncLoggerConfig config;
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -974,7 +974,7 @@ TEST_F(AsyncLoggerTest, DroppedCount_Increment)
     config.overflow_policy = OverflowPolicy::DropNewest;
     config.flush_interval = std::chrono::milliseconds{10000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -1000,7 +1000,7 @@ TEST_F(AsyncLoggerTest, DroppedCount_DropOldest)
     config.overflow_policy = OverflowPolicy::DropOldest;
     config.flush_interval = std::chrono::milliseconds{10000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -1023,7 +1023,7 @@ TEST_F(AsyncLoggerTest, DroppedCount_Reset)
     config.overflow_policy = OverflowPolicy::DropNewest;
     config.flush_interval = std::chrono::milliseconds{10000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -1052,7 +1052,7 @@ TEST_F(AsyncLoggerTest, DroppedCount_DropNewest)
     config.overflow_policy = OverflowPolicy::DropNewest;
     config.flush_interval = std::chrono::milliseconds{10000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -1077,7 +1077,7 @@ TEST_F(AsyncLoggerTest, QueueSize_Accuracy)
     config.batch_size = 4;
     config.flush_interval = std::chrono::milliseconds{1000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -1101,7 +1101,7 @@ TEST_F(AsyncLoggerTest, Shutdown_DrainsAllPending)
     config.batch_size = 4;
     config.flush_interval = std::chrono::milliseconds{10000};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -1189,7 +1189,7 @@ TEST_F(AsyncLoggerTest, DropOldest_NoCounterUnderflow)
     config.batch_size = 2;
     config.overflow_policy = OverflowPolicy::DropOldest;
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_.string());
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     AsyncLogger logger(config, file_stream, log_mutex);
@@ -1220,7 +1220,7 @@ TEST_F(AsyncLoggerTest, SyncFallback_WritesWhenQueueFull)
     config.batch_size = 1;
     config.overflow_policy = OverflowPolicy::SyncFallback;
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_.string());
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     AsyncLogger logger(config, file_stream, log_mutex);
@@ -1249,7 +1249,7 @@ TEST_F(AsyncLoggerTest, EnqueueAfterShutdown_WritesSync)
     config.queue_capacity = 64;
     config.batch_size = 10;
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_.string());
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     AsyncLogger logger(config, file_stream, log_mutex);
@@ -1274,7 +1274,7 @@ TEST_F(AsyncLoggerTest, MultiThread_EnqueueStress)
     config.batch_size = 32;
     config.overflow_policy = OverflowPolicy::DropNewest;
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_.string());
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     AsyncLogger logger(config, file_stream, log_mutex);
@@ -1523,7 +1523,7 @@ TEST_F(AsyncLoggerTest, FlushWithTimeout_ReturnsTrue_WhenDrained)
     config.batch_size = 64;
     config.flush_interval = std::chrono::milliseconds{10};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
@@ -1545,7 +1545,7 @@ TEST_F(AsyncLoggerTest, LogFormat_MatchesSyncFormat)
     config.batch_size = 64;
     config.flush_interval = std::chrono::milliseconds{10};
 
-    auto file_stream = std::make_shared<std::ofstream>(test_log_file_);
+    auto file_stream = std::make_shared<WinFileStream>(test_log_file_.string());
     auto log_mutex = std::make_shared<std::mutex>();
 
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -1022,3 +1022,205 @@ TEST_F(LoggerTest, TimestampFormat_StrftimeOutput)
     EXPECT_EQ(timestamp[16], ':');
     EXPECT_EQ(timestamp[19], '.');
 }
+
+TEST_F(LoggerTest, ConcurrentFileAccess_ReadWhileLogging)
+{
+    Logger &logger = Logger::get_instance();
+    logger.set_log_level(LogLevel::Trace);
+
+    const int pre_open_count = 10;
+    const int during_open_count = 20;
+    const int post_close_count = 10;
+
+    for (int i = 0; i < pre_open_count; ++i)
+    {
+        logger.info("PRE_OPEN_{}", i);
+    }
+    logger.flush();
+
+    // Simulate an external process opening the log file for reading
+    HANDLE external_handle = CreateFileA(
+        test_log_file_.string().c_str(),
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+    ASSERT_NE(external_handle, INVALID_HANDLE_VALUE)
+        << "Failed to open log file externally: " << GetLastError();
+
+    for (int i = 0; i < during_open_count; ++i)
+    {
+        logger.info("DURING_OPEN_{}", i);
+    }
+    logger.flush();
+
+    CloseHandle(external_handle);
+
+    for (int i = 0; i < post_close_count; ++i)
+    {
+        logger.info("POST_CLOSE_{}", i);
+    }
+    logger.flush();
+
+    std::ifstream ifs(test_log_file_);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+
+    for (int i = 0; i < pre_open_count; ++i)
+    {
+        EXPECT_NE(content.find("PRE_OPEN_" + std::to_string(i)), std::string::npos)
+            << "Missing PRE_OPEN_" << i;
+    }
+    for (int i = 0; i < during_open_count; ++i)
+    {
+        EXPECT_NE(content.find("DURING_OPEN_" + std::to_string(i)), std::string::npos)
+            << "Missing DURING_OPEN_" << i;
+    }
+    for (int i = 0; i < post_close_count; ++i)
+    {
+        EXPECT_NE(content.find("POST_CLOSE_" + std::to_string(i)), std::string::npos)
+            << "Missing POST_CLOSE_" << i;
+    }
+}
+
+TEST_F(LoggerTest, ConcurrentFileAccess_ExclusiveReadWhileLogging)
+{
+    Logger &logger = Logger::get_instance();
+    logger.set_log_level(LogLevel::Trace);
+
+    logger.info("BEFORE_EXCLUSIVE_OPEN");
+    logger.flush();
+
+    // Open with no sharing flags (simulates an editor that locks the file)
+    HANDLE exclusive_handle = CreateFileA(
+        test_log_file_.string().c_str(),
+        GENERIC_READ,
+        0, // No sharing — exclusive lock
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+
+    // This open may or may not succeed depending on OS sharing enforcement.
+    // The key assertion is that logging continues to work regardless.
+    const int msg_count = 10;
+    for (int i = 0; i < msg_count; ++i)
+    {
+        EXPECT_NO_THROW(logger.info("EXCLUSIVE_TEST_{}", i));
+    }
+    logger.flush();
+
+    if (exclusive_handle != INVALID_HANDLE_VALUE)
+    {
+        CloseHandle(exclusive_handle);
+    }
+
+    // Re-read and verify messages written before the exclusive open
+    std::ifstream ifs(test_log_file_);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+
+    EXPECT_NE(content.find("BEFORE_EXCLUSIVE_OPEN"), std::string::npos);
+}
+
+TEST_F(LoggerTest, ConcurrentFileAccess_RepeatedOpenClose)
+{
+    Logger &logger = Logger::get_instance();
+    logger.set_log_level(LogLevel::Trace);
+
+    const int iterations = 5;
+    const int msgs_per_iter = 5;
+
+    for (int iter = 0; iter < iterations; ++iter)
+    {
+        for (int i = 0; i < msgs_per_iter; ++i)
+        {
+            logger.info("ITER{}_{}", iter, i);
+        }
+        logger.flush();
+
+        HANDLE h = CreateFileA(
+            test_log_file_.string().c_str(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            nullptr,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            nullptr);
+
+        if (h != INVALID_HANDLE_VALUE)
+        {
+            CloseHandle(h);
+        }
+    }
+
+    logger.flush();
+
+    std::ifstream ifs(test_log_file_);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+
+    for (int iter = 0; iter < iterations; ++iter)
+    {
+        for (int i = 0; i < msgs_per_iter; ++i)
+        {
+            EXPECT_NE(content.find("ITER" + std::to_string(iter) + "_" + std::to_string(i)), std::string::npos)
+                << "Missing ITER" << iter << "_" << i;
+        }
+    }
+}
+
+TEST_F(LoggerTest, ConcurrentFileAccess_AsyncModeReadWhileLogging)
+{
+    Logger &logger = Logger::get_instance();
+    logger.set_log_level(LogLevel::Trace);
+
+    logger.enable_async_mode();
+    ASSERT_TRUE(logger.is_async_mode_enabled());
+
+    const int pre_open_count = 10;
+    const int during_open_count = 20;
+
+    for (int i = 0; i < pre_open_count; ++i)
+    {
+        logger.info("ASYNC_PRE_{}", i);
+    }
+    logger.flush();
+
+    HANDLE external_handle = CreateFileA(
+        test_log_file_.string().c_str(),
+        GENERIC_READ,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr);
+    ASSERT_NE(external_handle, INVALID_HANDLE_VALUE);
+
+    for (int i = 0; i < during_open_count; ++i)
+    {
+        logger.info("ASYNC_DURING_{}", i);
+    }
+    logger.flush();
+
+    CloseHandle(external_handle);
+
+    logger.disable_async_mode();
+
+    std::ifstream ifs(test_log_file_);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+
+    for (int i = 0; i < pre_open_count; ++i)
+    {
+        EXPECT_NE(content.find("ASYNC_PRE_" + std::to_string(i)), std::string::npos)
+            << "Missing ASYNC_PRE_" << i;
+    }
+    for (int i = 0; i < during_open_count; ++i)
+    {
+        EXPECT_NE(content.find("ASYNC_DURING_" + std::to_string(i)), std::string::npos)
+            << "Missing ASYNC_DURING_" << i;
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `std::ofstream` with a custom `WinFileStream` backed by Win32 `CreateFile` using `FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE`
- Fixes log stream breaking permanently when external processes (text editors, tail tools) open the log file during active logging
- Add 4 concurrent file access tests covering sync mode, async mode, exclusive locks, and repeated open/close cycles

## Details
The root cause was that `std::ofstream` on Windows opens files without explicit sharing flags. When an external process opens the log file, the write can fail and set the stream's `failbit` — which is never cleared, permanently breaking the logger for the rest of the process.

`WinFileStream` uses an 8 KB buffered `std::streambuf` with `WriteFile` for I/O, providing the same `std::ostream` interface with zero-overhead sharing.

## Test plan
- [x] All 621 tests pass on MinGW (0 warnings)
- [x] All 621 tests pass on MSVC (0 new warnings)
- [x] New `ConcurrentFileAccess_ReadWhileLogging` — logs before, during, and after external file open, verifies all messages present
- [x] New `ConcurrentFileAccess_ExclusiveReadWhileLogging` — logging continues even when file is opened with no sharing flags
- [x] New `ConcurrentFileAccess_RepeatedOpenClose` — repeated external open/close cycles don't disrupt logging
- [x] New `ConcurrentFileAccess_AsyncModeReadWhileLogging` — same concurrent access test under async mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logger now supports concurrent file access on Windows so external tools can read logs while writing.
  * A new Windows-backed file stream is provided for file-based logging.

* **Documentation**
  * Project docs and README updated to reflect concurrent access and the new public header.

* **Tests**
  * Added unit tests validating log-file accessibility during active logging (sync and async).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->