### PR TITLE
fix(hook_manager,config): resolve hot-reload state persistence issues

### DIFF
--- a/docs/hot-reload-guide.md
+++ b/docs/hot-reload-guide.md
@@ -995,3 +995,13 @@ A: Yes — this is actually the safest time to reload, since fewer game systems 
 
 **Q: What about C++ exceptions thrown during Init()?**
 A: If `Init()` throws, the loader catches nothing (C functions shouldn't throw across DLL boundaries). Use `try/catch` inside `Init()` and return `false` on failure. The loader will log the error and leave the logic DLL unloaded until the next reload attempt.
+
+---
+
+## Hot-Reload Safety Guarantees
+
+DetourModKit's core systems are designed to be safe across DLL reload cycles:
+
+**HookManager:** `shutdown()` removes all hooks and resets its internal state, allowing subsequent `create_*_hook()` calls to succeed. The same applies to `remove_all_hooks()`. Both methods leave the singleton in a clean, reusable state for the next `Init()` cycle. There is no need to call both — either one prepares the HookManager for reuse.
+
+**Config:** `register_*()` functions use replace-on-duplicate semantics. If a new DLL registers a config item with the same section and INI key as an existing entry, the old registration is replaced rather than appended. This prevents doubled registrations across reload cycles without requiring an explicit `clear_registered_items()` call. Calling `clear_registered_items()` before re-registration is still supported but no longer required.

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -311,7 +311,9 @@ namespace DetourModKit
          * @brief Explicitly shuts down the HookManager, removing all hooks without logging.
          * @details This method is safe to call during shutdown when Logger may be destroyed.
          *          It removes all hooks without attempting to log, preventing use-after-free.
-         *          After calling shutdown(), the destructor becomes a no-op.
+         *          The shutdown flag is reset after hooks are cleared, allowing subsequent
+         *          hook creation for hot-reload scenarios. The destructor becomes a no-op
+         *          only while the flag is set during the shutdown operation itself.
          */
         void shutdown();
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -427,6 +427,22 @@ namespace
         return s_registered_items;
     }
 
+    /// Replaces an existing item with the same section+key, or appends if none found.
+    /// Caller must hold getConfigMutex().
+    void replace_or_append(std::unique_ptr<ConfigItemBase> item)
+    {
+        auto &items = getRegisteredConfigItems();
+        for (auto &existing : items)
+        {
+            if (existing->section == item->section && existing->ini_key == item->ini_key)
+            {
+                existing = std::move(item);
+                return;
+            }
+        }
+        items.push_back(std::move(item));
+    }
+
     /**
      * @brief Determines the full absolute path for the INI configuration file.
      */
@@ -469,7 +485,7 @@ void DetourModKit::Config::register_int(const std::string &section, const std::s
         setter(default_value);
     }
     std::lock_guard<std::mutex> lock(getConfigMutex());
-    getRegisteredConfigItems().push_back(
+    replace_or_append(
         std::make_unique<CallbackConfigItem<int>>(section, ini_key, log_key_name, std::move(setter), default_value));
 }
 
@@ -482,7 +498,7 @@ void DetourModKit::Config::register_float(const std::string &section, const std:
         setter(default_value);
     }
     std::lock_guard<std::mutex> lock(getConfigMutex());
-    getRegisteredConfigItems().push_back(
+    replace_or_append(
         std::make_unique<CallbackConfigItem<float>>(section, ini_key, log_key_name, std::move(setter), default_value));
 }
 
@@ -495,7 +511,7 @@ void DetourModKit::Config::register_bool(const std::string &section, const std::
         setter(default_value);
     }
     std::lock_guard<std::mutex> lock(getConfigMutex());
-    getRegisteredConfigItems().push_back(
+    replace_or_append(
         std::make_unique<CallbackConfigItem<bool>>(section, ini_key, log_key_name, std::move(setter), default_value));
 }
 
@@ -508,7 +524,7 @@ void DetourModKit::Config::register_string(const std::string &section, const std
         setter(default_value);
     }
     std::lock_guard<std::mutex> lock(getConfigMutex());
-    getRegisteredConfigItems().push_back(
+    replace_or_append(
         std::make_unique<CallbackConfigItem<std::string>>(section, ini_key, log_key_name, std::move(setter), std::move(default_value)));
 }
 
@@ -523,7 +539,7 @@ void DetourModKit::Config::register_key_combo(const std::string &section, const 
         setter(default_combos);
     }
     std::lock_guard<std::mutex> lock(getConfigMutex());
-    getRegisteredConfigItems().push_back(
+    replace_or_append(
         std::make_unique<CallbackConfigItem<Config::KeyComboList>>(section, ini_key, log_key_name, std::move(setter), std::move(default_combos)));
 }
 

--- a/src/hook_manager.cpp
+++ b/src/hook_manager.cpp
@@ -63,6 +63,8 @@ void HookManager::shutdown()
         hook->disable();
     }
     m_hooks.clear();
+
+    m_shutdown_called.store(false, std::memory_order_release);
 }
 
 std::string HookManager::error_to_string(const safetyhook::InlineHook::Error &err) const

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -582,7 +582,7 @@ TEST_F(ConfigTest, KeyCombo_DefaultValueExceedingIntMax)
     EXPECT_EQ(val[0].keys[0], keyboard_key(0x44));
 }
 
-TEST_F(ConfigTest, DuplicateKeyRegistration)
+TEST_F(ConfigTest, DuplicateKeyRegistration_ReplacesExisting)
 {
     std::ofstream ini_file(test_ini_file_);
     ini_file << "[TestSection]\n";
@@ -599,10 +599,9 @@ TEST_F(ConfigTest, DuplicateKeyRegistration)
 
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
-    // The implementation appends each registration independently to the item
-    // list. Both callbacks are invoked during load(), so both variables receive
-    // the value read from the INI file.
-    EXPECT_EQ(first_val, 77);
+    // Re-registration with the same section+key replaces the previous entry.
+    // Only the second (latest) callback receives the loaded value.
+    EXPECT_EQ(first_val, 10);
     EXPECT_EQ(second_val, 77);
 }
 
@@ -1084,4 +1083,77 @@ TEST_F(ConfigTest, LogAll_EmptyKeyComboList)
     Config::register_key_combo("Sec", "K", "empty_combo", nullptr, "");
 
     EXPECT_NO_THROW(Config::log_all());
+}
+
+TEST_F(ConfigTest, ReRegistration_ReplacesCallback)
+{
+    std::ofstream ini_file(test_ini_file_);
+    ini_file << "[TestSection]\n";
+    ini_file << "TestInt=50\n";
+    ini_file.close();
+
+    int old_val = 0;
+    int new_val = 0;
+
+    Config::register_int("TestSection", "TestInt", "old", [&old_val](int v)
+                         { old_val = v; }, 10);
+
+    // Simulate hot-reload: re-register the same section+key with a new callback.
+    Config::register_int("TestSection", "TestInt", "new", [&new_val](int v)
+                         { new_val = v; }, 20);
+
+    Config::load(test_ini_file_.string());
+
+    // The old callback is replaced — only the new callback receives the loaded value.
+    EXPECT_EQ(old_val, 10);
+    EXPECT_EQ(new_val, 50);
+}
+
+TEST_F(ConfigTest, ReRegistration_PreservesOtherKeys)
+{
+    std::ofstream ini_file(test_ini_file_);
+    ini_file << "[Sec]\n";
+    ini_file << "A=1\n";
+    ini_file << "B=2\n";
+    ini_file.close();
+
+    int a_val = 0, b_val = 0, a_val_new = 0;
+
+    Config::register_int("Sec", "A", "a", [&a_val](int v)
+                         { a_val = v; }, 0);
+    Config::register_int("Sec", "B", "b", [&b_val](int v)
+                         { b_val = v; }, 0);
+
+    // Re-register only key A.
+    Config::register_int("Sec", "A", "a_new", [&a_val_new](int v)
+                         { a_val_new = v; }, 0);
+
+    Config::load(test_ini_file_.string());
+
+    EXPECT_EQ(a_val, 0);
+    EXPECT_EQ(a_val_new, 1);
+    EXPECT_EQ(b_val, 2);
+}
+
+TEST_F(ConfigTest, ReRegistration_DifferentSectionsSameKey)
+{
+    std::ofstream ini_file(test_ini_file_);
+    ini_file << "[Sec1]\n";
+    ini_file << "Key=10\n";
+    ini_file << "[Sec2]\n";
+    ini_file << "Key=20\n";
+    ini_file.close();
+
+    int val1 = 0, val2 = 0;
+
+    Config::register_int("Sec1", "Key", "k1", [&val1](int v)
+                         { val1 = v; }, 0);
+    Config::register_int("Sec2", "Key", "k2", [&val2](int v)
+                         { val2 = v; }, 0);
+
+    Config::load(test_ini_file_.string());
+
+    // Same key name but different sections — both should be kept independently.
+    EXPECT_EQ(val1, 10);
+    EXPECT_EQ(val2, 20);
 }

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -757,6 +757,72 @@ TEST_F(HookManagerTest, WithMidHook_NotFound)
     EXPECT_FALSE(result.has_value());
 }
 
+TEST_F(HookManagerTest, HotReload_InlineHookAfterShutdown)
+{
+    void *tramp = nullptr;
+
+    auto r1 = hook_manager_->create_inline_hook(
+        "PreShutdownHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(r1.has_value());
+
+    hook_manager_->shutdown();
+    EXPECT_TRUE(hook_manager_->get_hook_ids().empty());
+
+    tramp = nullptr;
+    auto r2 = hook_manager_->create_inline_hook(
+        "PostShutdownHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(r2.has_value()) << "Hook creation must succeed after shutdown (hot-reload)";
+    EXPECT_NE(tramp, nullptr);
+}
+
+TEST_F(HookManagerTest, HotReload_MidHookAfterShutdown)
+{
+    auto detour_fn = [](safetyhook::Context &) {};
+
+    auto r1 = hook_manager_->create_mid_hook(
+        "PreShutdownMid",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        detour_fn);
+    ASSERT_TRUE(r1.has_value());
+
+    hook_manager_->shutdown();
+
+    auto r2 = hook_manager_->create_mid_hook(
+        "PostShutdownMid",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        detour_fn);
+    ASSERT_TRUE(r2.has_value()) << "Mid hook creation must succeed after shutdown (hot-reload)";
+}
+
+TEST_F(HookManagerTest, ShutdownThenRemoveAll_Succeeds)
+{
+    void *tramp = nullptr;
+
+    auto r1 = hook_manager_->create_inline_hook(
+        "ShutRemAll",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(r1.has_value());
+
+    hook_manager_->shutdown();
+    hook_manager_->remove_all_hooks();
+
+    tramp = nullptr;
+    auto r2 = hook_manager_->create_inline_hook(
+        "AfterShutRemAll",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(r2.has_value());
+}
+
 TEST_F(HookManagerTest, WithInlineHook_WrongType)
 {
     auto detour_fn = [](safetyhook::Context &) {};
@@ -1379,36 +1445,6 @@ TEST_F(HookManagerTest, MidHook_GetDestination_Noexcept)
 
     EXPECT_TRUE(hook_result.has_value());
     EXPECT_TRUE(*hook_result);
-}
-
-TEST_F(HookManagerTest, CreateInlineHook_AfterShutdown_ReturnsShutdownInProgress)
-{
-    hook_manager_->shutdown();
-
-    void *tramp = nullptr;
-    auto result = hook_manager_->create_inline_hook(
-        "PostShutdownHook",
-        reinterpret_cast<uintptr_t>(&real_hook_target_add),
-        reinterpret_cast<void *>(&real_hook_detour_add),
-        &tramp);
-
-    ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error(), HookError::ShutdownInProgress);
-    EXPECT_EQ(tramp, nullptr);
-}
-
-TEST_F(HookManagerTest, CreateMidHook_AfterShutdown_ReturnsShutdownInProgress)
-{
-    hook_manager_->shutdown();
-
-    auto detour_fn = [](safetyhook::Context &) {};
-    auto result = hook_manager_->create_mid_hook(
-        "PostShutdownMidHook",
-        reinterpret_cast<uintptr_t>(&real_hook_target_add),
-        detour_fn);
-
-    ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error(), HookError::ShutdownInProgress);
 }
 
 TEST_F(HookManagerTest, CreateInlineHook_TrampolineNotSetOnFailure)


### PR DESCRIPTION
## Summary

- `HookManager::shutdown()` now resets the shutdown flag after clearing hooks, allowing hook creation in subsequent reload cycles
- `Config::register_*()` now replaces existing entries with the same section+key instead of appending

## Test plan

- [x] Full test suite passes (630/630)
- [x] Manual: hot-reload logic DLL, confirm hooks re-create and config count stays correct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration registration now replaces duplicate entries by section+key instead of accumulating.
  * Hook manager supports hot-reload: hooks can be removed and recreated after shutdown.

* **Documentation**
  * Added "Hot-Reload Safety Guarantees" outlining runtime behavior and config deduplication semantics.

* **Tests**
  * Updated and added tests to verify re-registration behavior and hot-reload hook recreation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->