### PR TITLE
fix: harden memory safety, thread safety, and build strictness

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -76,6 +76,7 @@ jobs:
         shell: powershell
 
       - name: Run Tests
+        timeout-minutes: 5
         run: |
           & ".\build\mingw-debug\tests\DetourModKit_tests.exe" --gtest_output=xml:test-results.xml
           if ($LASTEXITCODE -ne 0) { throw "Tests failed with exit code $LASTEXITCODE" }

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -60,7 +60,7 @@ jobs:
         shell: bash
 
       - name: Configure (Debug + Tests + Coverage)
-        run: cmake --preset mingw-debug -DDMK_ENABLE_COVERAGE=ON
+        run: cmake --preset mingw-debug -DDMK_ENABLE_COVERAGE=ON -DDMK_WARNINGS_AS_ERRORS=ON
         shell: bash
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,13 @@ if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
 endif()
 
 # --- Compiler Flags ---
+option(DMK_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
+
 if(MSVC)
-  # /W4 for high warning level.
-  # Add /WX to treat warnings as errors in CI or for strict builds if desired.
   add_compile_options(/W4)
+  if(DMK_WARNINGS_AS_ERRORS)
+    add_compile_options(/WX)
+  endif()
 
   # Security hardening: ASLR, DEP, and Control Flow Guard
   add_link_options(/DYNAMICBASE /NXCOMPAT /GUARD:CF)
@@ -42,6 +45,9 @@ if(MSVC)
 else()
   # GCC/Clang specific flags
   add_compile_options(-Wall -Wextra -Wpedantic)
+  if(DMK_WARNINGS_AS_ERRORS)
+    add_compile_options(-Werror)
+  endif()
 
   # Security hardening: ASLR and DEP (NX) for MinGW targets
   add_link_options(-Wl,--dynamicbase -Wl,--nxcompat)

--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ ctest --preset msvc-debug
 > taskkill /F /IM cl.exe 2>nul || echo No cl.exe processes found
 > ```
 
+### Warnings as Errors
+
+To treat compiler warnings as errors (enabled by default in CI):
+
+```bash
+cmake --preset mingw-debug -DDMK_WARNINGS_AS_ERRORS=ON
+cmake --build --preset mingw-debug --parallel
+```
+
 ### Enabling Sanitizers
 
 To enable AddressSanitizer and UndefinedBehaviorSanitizer (requires GCC/Clang):

--- a/include/DetourModKit/async_logger.hpp
+++ b/include/DetourModKit/async_logger.hpp
@@ -65,6 +65,8 @@ namespace DetourModKit
             std::string str;
             PoolSlot *next_free{nullptr};
         };
+        static_assert(offsetof(PoolSlot, str) == 0,
+                      "PoolSlot::str must be the first member for pointer arithmetic in deallocate()");
 
         struct Block
         {
@@ -197,31 +199,17 @@ namespace DetourModKit
 
             Slot(const Slot &) = delete;
             Slot &operator=(const Slot &) = delete;
-
-            // Move operations are safe because:
-            // 1. Only the single writer thread calls try_pop (consumer)
-            // 2. try_push only moves INTO empty slots (enqueue_pos slots)
-            // 3. No concurrent moves can occur on the same slot
-            Slot(Slot &&other) noexcept
-                : sequence(other.sequence.load(std::memory_order_relaxed)), data(std::move(other.data))
-            {
-            }
-
-            Slot &operator=(Slot &&other) noexcept
-            {
-                if (this != &other)
-                {
-                    sequence.store(other.sequence.load(std::memory_order_relaxed), std::memory_order_relaxed);
-                    data = std::move(other.data);
-                }
-                return *this;
-            }
+            Slot(Slot &&) = delete;
+            Slot &operator=(Slot &&) = delete;
         };
 
-        // Read-only after construction
-        size_t capacity_;
-        size_t mask_;
-        std::vector<Slot> buffer_;
+        // Immutable after construction — never resized.
+        const size_t capacity_;
+        const size_t mask_;
+
+        // Allocated once in the constructor; the unique_ptr ensures immutability
+        // (no accidental resize) while maintaining contiguous cache-friendly layout.
+        std::unique_ptr<Slot[]> buffer_;
 
         // Cache-line aligned to prevent false sharing between producers and consumers.
         alignas(64) std::atomic<size_t> enqueue_pos_{0};

--- a/include/DetourModKit/async_logger.hpp
+++ b/include/DetourModKit/async_logger.hpp
@@ -65,8 +65,15 @@ namespace DetourModKit
             std::string str;
             PoolSlot *next_free{nullptr};
         };
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
         static_assert(offsetof(PoolSlot, str) == 0,
                       "PoolSlot::str must be the first member for pointer arithmetic in deallocate()");
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
         struct Block
         {
@@ -236,7 +243,7 @@ namespace DetourModKit
 
         [[nodiscard]] constexpr bool validate() const noexcept
         {
-            if (queue_capacity == 0 || (queue_capacity & (queue_capacity - 1)) != 0)
+            if (queue_capacity < 2 || (queue_capacity & (queue_capacity - 1)) != 0)
                 return false;
             if (batch_size == 0)
                 return false;

--- a/include/DetourModKit/async_logger.hpp
+++ b/include/DetourModKit/async_logger.hpp
@@ -259,9 +259,9 @@ namespace DetourModKit
         }
     };
 
-    // Compile-time validation: Default queue capacity must be power of 2
-    static_assert((DEFAULT_QUEUE_CAPACITY & (DEFAULT_QUEUE_CAPACITY - 1)) == 0,
-                  "DEFAULT_QUEUE_CAPACITY must be a power of 2");
+    // Compile-time validation: Default queue capacity must be a power of 2 and >= 2
+    static_assert(DEFAULT_QUEUE_CAPACITY >= 2 && (DEFAULT_QUEUE_CAPACITY & (DEFAULT_QUEUE_CAPACITY - 1)) == 0,
+                  "DEFAULT_QUEUE_CAPACITY must be a power of 2 and at least 2");
 
     /**
      * @class AsyncLogger

--- a/include/DetourModKit/async_logger.hpp
+++ b/include/DetourModKit/async_logger.hpp
@@ -145,7 +145,7 @@ namespace DetourModKit
     public:
         /**
          * @brief Constructs a queue with the specified capacity.
-         * @param capacity The maximum number of elements (must be power of 2).
+         * @param capacity The maximum number of elements (must be power of 2 and >= 2).
          */
         explicit DynamicMPMCQueue(size_t capacity);
 
@@ -202,6 +202,10 @@ namespace DetourModKit
             Slot(Slot &&) = delete;
             Slot &operator=(Slot &&) = delete;
         };
+
+        /// Validates capacity before member initialization to prevent
+        /// allocation of an invalid-sized buffer in the initializer list.
+        static size_t validated_capacity(size_t capacity);
 
         // Immutable after construction — never resized.
         const size_t capacity_;

--- a/include/DetourModKit/input.hpp
+++ b/include/DetourModKit/input.hpp
@@ -402,8 +402,8 @@ namespace DetourModKit
 
         mutable std::mutex mutex_;
         std::vector<InputBinding> pending_bindings_;
-        std::unique_ptr<InputPoller> poller_;
-        std::atomic<InputPoller *> active_poller_{nullptr};
+        std::shared_ptr<InputPoller> poller_;
+        std::atomic<std::shared_ptr<InputPoller>> active_poller_{};
         std::atomic<bool> running_{false};
         bool require_focus_ = true;
         int gamepad_index_ = 0;

--- a/src/async_logger.cpp
+++ b/src/async_logger.cpp
@@ -166,7 +166,10 @@ namespace DetourModKit
 
         // Not a pool allocation — heap delete under lock is safe and brief.
         delete ptr;
-        heap_fallback_count_.fetch_sub(1, std::memory_order_relaxed);
+        if (heap_fallback_count_.load(std::memory_order_relaxed) > 0)
+        {
+            heap_fallback_count_.fetch_sub(1, std::memory_order_relaxed);
+        }
     }
 
     void StringPool::return_slot_locked(PoolSlot *slot, Block *block) noexcept
@@ -230,6 +233,7 @@ namespace DetourModKit
             std::memcpy(buffer.data(), other.buffer.data(), length);
         }
         other.overflow = nullptr;
+        other.length = 0;
     }
 
     LogMessage &LogMessage::operator=(LogMessage &&other) noexcept
@@ -247,6 +251,7 @@ namespace DetourModKit
                 std::memcpy(buffer.data(), other.buffer.data(), length);
             }
             other.overflow = nullptr;
+            other.length = 0;
         }
         return *this;
     }
@@ -280,16 +285,15 @@ namespace DetourModKit
     }
 
     DynamicMPMCQueue::DynamicMPMCQueue(size_t capacity)
-        : capacity_(capacity), mask_(capacity - 1)
+        : capacity_(capacity), mask_(capacity - 1),
+          buffer_(std::make_unique<Slot[]>(capacity))
     {
         if ((capacity & (capacity - 1)) != 0 || capacity < 2)
         {
             throw std::invalid_argument("DynamicMPMCQueue capacity must be a power of 2 and at least 2");
         }
 
-        buffer_.resize(capacity);
-
-        for (size_t i = 0; i < capacity; ++i)
+        for (size_t i = 0; i < capacity_; ++i)
         {
             buffer_[i].sequence.store(i, std::memory_order_relaxed);
         }
@@ -636,6 +640,7 @@ namespace DetourModKit
             LogMessage oldest;
             if (queue_.try_pop(oldest))
             {
+                // Count the evicted oldest message as dropped
                 dropped_messages_.fetch_add(1, std::memory_order_relaxed);
                 if (queue_.try_push(message))
                 {
@@ -646,6 +651,8 @@ namespace DetourModKit
                 // Pop succeeded but push failed: net -1
                 pending_messages_.fetch_sub(1, std::memory_order_acq_rel);
             }
+            // Count the new message as dropped (separate from the evicted oldest above).
+            // dropped_messages_ counts individual lost messages, not overflow events.
             dropped_messages_.fetch_add(1, std::memory_order_relaxed);
             return false;
         }

--- a/src/async_logger.cpp
+++ b/src/async_logger.cpp
@@ -284,15 +284,19 @@ namespace DetourModKit
         length = 0;
     }
 
-    DynamicMPMCQueue::DynamicMPMCQueue(size_t capacity)
-        : capacity_(capacity), mask_(capacity - 1),
-          buffer_(std::make_unique<Slot[]>(capacity))
+    size_t DynamicMPMCQueue::validated_capacity(size_t capacity)
     {
         if ((capacity & (capacity - 1)) != 0 || capacity < 2)
         {
             throw std::invalid_argument("DynamicMPMCQueue capacity must be a power of 2 and at least 2");
         }
+        return capacity;
+    }
 
+    DynamicMPMCQueue::DynamicMPMCQueue(size_t capacity)
+        : capacity_(validated_capacity(capacity)), mask_(capacity_ - 1),
+          buffer_(std::make_unique<Slot[]>(capacity_))
+    {
         for (size_t i = 0; i < capacity_; ++i)
         {
             buffer_[i].sequence.store(i, std::memory_order_relaxed);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -481,9 +481,11 @@ void DetourModKit::Config::register_int(const std::string &section, const std::s
                                                const std::string &log_key_name, std::function<void(int)> setter,
                                                int default_value)
 {
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<int>>(section, ini_key, log_key_name, setter, default_value));
+    {
+        std::lock_guard<std::mutex> lock(getConfigMutex());
+        replace_or_append(
+            std::make_unique<CallbackConfigItem<int>>(section, ini_key, log_key_name, setter, default_value));
+    }
     if (setter)
     {
         setter(default_value);
@@ -494,9 +496,11 @@ void DetourModKit::Config::register_float(const std::string &section, const std:
                                                  const std::string &log_key_name, std::function<void(float)> setter,
                                                  float default_value)
 {
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<float>>(section, ini_key, log_key_name, setter, default_value));
+    {
+        std::lock_guard<std::mutex> lock(getConfigMutex());
+        replace_or_append(
+            std::make_unique<CallbackConfigItem<float>>(section, ini_key, log_key_name, setter, default_value));
+    }
     if (setter)
     {
         setter(default_value);
@@ -507,9 +511,11 @@ void DetourModKit::Config::register_bool(const std::string &section, const std::
                                                 const std::string &log_key_name, std::function<void(bool)> setter,
                                                 bool default_value)
 {
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<bool>>(section, ini_key, log_key_name, setter, default_value));
+    {
+        std::lock_guard<std::mutex> lock(getConfigMutex());
+        replace_or_append(
+            std::make_unique<CallbackConfigItem<bool>>(section, ini_key, log_key_name, setter, default_value));
+    }
     if (setter)
     {
         setter(default_value);
@@ -520,9 +526,11 @@ void DetourModKit::Config::register_string(const std::string &section, const std
                                                   const std::string &log_key_name, std::function<void(const std::string &)> setter,
                                                   std::string default_value)
 {
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<std::string>>(section, ini_key, log_key_name, setter, default_value));
+    {
+        std::lock_guard<std::mutex> lock(getConfigMutex());
+        replace_or_append(
+            std::make_unique<CallbackConfigItem<std::string>>(section, ini_key, log_key_name, setter, default_value));
+    }
     if (setter)
     {
         setter(default_value);
@@ -535,9 +543,11 @@ void DetourModKit::Config::register_key_combo(const std::string &section, const 
 {
     Config::KeyComboList default_combos = parse_key_combo_list(default_value_str);
 
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<Config::KeyComboList>>(section, ini_key, log_key_name, setter, default_combos));
+    {
+        std::lock_guard<std::mutex> lock(getConfigMutex());
+        replace_or_append(
+            std::make_unique<CallbackConfigItem<Config::KeyComboList>>(section, ini_key, log_key_name, setter, default_combos));
+    }
     if (setter)
     {
         setter(default_combos);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -481,52 +481,52 @@ void DetourModKit::Config::register_int(const std::string &section, const std::s
                                                const std::string &log_key_name, std::function<void(int)> setter,
                                                int default_value)
 {
+    std::lock_guard<std::mutex> lock(getConfigMutex());
+    replace_or_append(
+        std::make_unique<CallbackConfigItem<int>>(section, ini_key, log_key_name, setter, default_value));
     if (setter)
     {
         setter(default_value);
     }
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<int>>(section, ini_key, log_key_name, std::move(setter), default_value));
 }
 
 void DetourModKit::Config::register_float(const std::string &section, const std::string &ini_key,
                                                  const std::string &log_key_name, std::function<void(float)> setter,
                                                  float default_value)
 {
+    std::lock_guard<std::mutex> lock(getConfigMutex());
+    replace_or_append(
+        std::make_unique<CallbackConfigItem<float>>(section, ini_key, log_key_name, setter, default_value));
     if (setter)
     {
         setter(default_value);
     }
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<float>>(section, ini_key, log_key_name, std::move(setter), default_value));
 }
 
 void DetourModKit::Config::register_bool(const std::string &section, const std::string &ini_key,
                                                 const std::string &log_key_name, std::function<void(bool)> setter,
                                                 bool default_value)
 {
+    std::lock_guard<std::mutex> lock(getConfigMutex());
+    replace_or_append(
+        std::make_unique<CallbackConfigItem<bool>>(section, ini_key, log_key_name, setter, default_value));
     if (setter)
     {
         setter(default_value);
     }
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<bool>>(section, ini_key, log_key_name, std::move(setter), default_value));
 }
 
 void DetourModKit::Config::register_string(const std::string &section, const std::string &ini_key,
                                                   const std::string &log_key_name, std::function<void(const std::string &)> setter,
                                                   std::string default_value)
 {
+    std::lock_guard<std::mutex> lock(getConfigMutex());
+    replace_or_append(
+        std::make_unique<CallbackConfigItem<std::string>>(section, ini_key, log_key_name, setter, default_value));
     if (setter)
     {
         setter(default_value);
     }
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<std::string>>(section, ini_key, log_key_name, std::move(setter), std::move(default_value)));
 }
 
 void DetourModKit::Config::register_key_combo(const std::string &section, const std::string &ini_key,
@@ -535,13 +535,13 @@ void DetourModKit::Config::register_key_combo(const std::string &section, const 
 {
     Config::KeyComboList default_combos = parse_key_combo_list(default_value_str);
 
+    std::lock_guard<std::mutex> lock(getConfigMutex());
+    replace_or_append(
+        std::make_unique<CallbackConfigItem<Config::KeyComboList>>(section, ini_key, log_key_name, setter, default_combos));
     if (setter)
     {
         setter(default_combos);
     }
-    std::lock_guard<std::mutex> lock(getConfigMutex());
-    replace_or_append(
-        std::make_unique<CallbackConfigItem<Config::KeyComboList>>(section, ini_key, log_key_name, std::move(setter), std::move(default_combos)));
 }
 
 void DetourModKit::Config::load(const std::string &ini_filename)

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -7,10 +7,10 @@
  */
 
 #include "DetourModKit/filesystem.hpp"
-#include "DetourModKit/logger.hpp"
 
 #include <windows.h>
 #include <filesystem>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 
@@ -20,14 +20,18 @@ namespace
 {
     /**
      * @brief Resolves the directory of the currently executing module.
+     *
      * @details Called exactly once; the result is cached by the caller.
+     * Diagnostics are written to stderr rather than Logger because this
+     * function executes during Logger construction (via generate_log_file_path),
+     * and calling Logger::get_instance() here would deadlock on the magic-static
+     * guard that is already held by the in-progress Logger singleton init.
      */
     std::string resolve_module_directory()
     {
         HMODULE h_self_module = nullptr;
         wchar_t module_path_buffer[MAX_PATH] = {0};
         std::string result_directory_path;
-        Logger &logger = Logger::get_instance();
 
         try
         {
@@ -54,16 +58,16 @@ namespace
 
             const std::filesystem::path module_full_path(module_path_buffer);
             result_directory_path = module_full_path.parent_path().string();
-
-            logger.debug("get_runtime_directory: Successfully determined module directory: {}", result_directory_path);
         }
         catch (const std::filesystem::filesystem_error &fs_err)
         {
-            logger.warning("get_runtime_directory: Filesystem error: {}. Attempting to fall back to current working directory.", fs_err.what());
+            std::cerr << "[DMK Filesystem WARNING] Filesystem error: " << fs_err.what()
+                      << ". Attempting to fall back to current working directory." << '\n';
         }
         catch (const std::exception &e)
         {
-            logger.warning("get_runtime_directory: Failed to determine module directory: {}. Attempting to fall back to current working directory.", e.what());
+            std::cerr << "[DMK Filesystem WARNING] Failed to determine module directory: " << e.what()
+                      << ". Attempting to fall back to current working directory." << '\n';
         }
 
         if (result_directory_path.empty())
@@ -72,14 +76,15 @@ namespace
             if (GetCurrentDirectoryW(MAX_PATH, current_dir_buffer) > 0)
             {
                 result_directory_path = std::filesystem::path(current_dir_buffer).string();
-                logger.warning("get_runtime_directory: Using current working directory as fallback: {}", result_directory_path);
+                std::cerr << "[DMK Filesystem WARNING] Using current working directory as fallback: "
+                          << result_directory_path << '\n';
             }
             else
             {
                 const DWORD last_error = GetLastError();
-                // If even GetCurrentDirectoryW fails, use "." as a last resort.
                 result_directory_path = ".";
-                logger.error("get_runtime_directory: Failed to get current working directory. Using relative path anchor '.'. Error: {}", last_error);
+                std::cerr << "[DMK Filesystem ERROR] Failed to get current working directory."
+                          << " Using relative path anchor '.'. Error: " << last_error << '\n';
             }
         }
         return result_directory_path;

--- a/src/hook_manager.cpp
+++ b/src/hook_manager.cpp
@@ -57,14 +57,19 @@ void HookManager::shutdown()
     if (!m_shutdown_called.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
         return;
 
-    std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
-    for (auto &[name, hook] : m_hooks)
     {
-        hook->disable();
-    }
-    m_hooks.clear();
+        std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+        for (auto &[name, hook] : m_hooks)
+        {
+            hook->disable();
+        }
+        m_hooks.clear();
 
-    m_shutdown_called.store(false, std::memory_order_release);
+        // Reset under the lock so concurrent create_*_hook calls cannot
+        // observe the flag as true (rejected) and then immediately see it
+        // as false (accepted) before the map is fully cleared.
+        m_shutdown_called.store(false, std::memory_order_release);
+    }
 }
 
 std::string HookManager::error_to_string(const safetyhook::InlineHook::Error &err) const

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -619,12 +619,12 @@ namespace DetourModKit
                          input_mode_to_string(binding.mode), binding.name, binding.keys.size());
         }
 
-        poller_ = std::make_unique<InputPoller>(std::move(pending_bindings_), poll_interval,
+        poller_ = std::make_shared<InputPoller>(std::move(pending_bindings_), poll_interval,
                                                 require_focus_, gamepad_index_, trigger_threshold_,
                                                 stick_threshold_);
         pending_bindings_.clear();
         poller_->start();
-        active_poller_.store(poller_.get(), std::memory_order_release);
+        active_poller_.store(poller_, std::memory_order_release);
         running_.store(true, std::memory_order_release);
     }
 
@@ -645,7 +645,7 @@ namespace DetourModKit
 
     bool InputManager::is_binding_active(const std::string &name) const noexcept
     {
-        InputPoller *p = active_poller_.load(std::memory_order_acquire);
+        auto p = active_poller_.load(std::memory_order_acquire);
         if (p)
         {
             return p->is_binding_active(name);
@@ -655,12 +655,12 @@ namespace DetourModKit
 
     void InputManager::shutdown() noexcept
     {
-        std::unique_ptr<InputPoller> local_poller;
+        std::shared_ptr<InputPoller> local_poller;
 
         {
             std::lock_guard lock(mutex_);
-            // Clear atomic pointer before destroying the poller to ensure
-            // is_binding_active() never accesses a destroyed object.
+            // Clear atomic shared_ptr before releasing the poller to ensure
+            // concurrent is_binding_active() callers hold a valid shared_ptr.
             active_poller_.store(nullptr, std::memory_order_release);
             running_.store(false, std::memory_order_release);
             local_poller = std::move(poller_);

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,8 +1,8 @@
 #include "DetourModKit/logger.hpp"
 #include "DetourModKit/async_logger.hpp"
+#include "DetourModKit/filesystem.hpp"
 #include "DetourModKit/format.hpp"
 
-#include <windows.h>
 #include <algorithm>
 #include <ctime>
 #include <filesystem>
@@ -324,33 +324,17 @@ namespace DetourModKit
             return log_file_name_;
         }
 
-        std::string determined_module_dir;
-        HMODULE h_current_module = NULL;
-        char module_full_path_buffer[MAX_PATH] = {0};
-
         try
         {
-            if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                                    reinterpret_cast<LPCSTR>(&Logger::get_instance),
-                                    &h_current_module) ||
-                h_current_module == NULL)
+            std::string module_dir = Filesystem::get_runtime_directory();
+            if (module_dir.empty() || module_dir == ".")
             {
-                throw std::runtime_error("GetModuleHandleExA failed for logger's module. Error: " + std::to_string(GetLastError()));
+                std::cerr << "[" << log_prefix_ << " Logger PATH_WARNING] "
+                          << "Could not determine module directory. Using relative path: " << log_file_name_ << '\n';
+                return log_file_name_;
             }
 
-            const DWORD path_len = GetModuleFileNameA(h_current_module, module_full_path_buffer, MAX_PATH);
-            if (path_len == 0)
-            {
-                throw std::runtime_error("GetModuleFileNameA failed for logger's module path. Error: " + std::to_string(GetLastError()));
-            }
-            if (path_len == MAX_PATH && GetLastError() == ERROR_INSUFFICIENT_BUFFER)
-            {
-                throw std::runtime_error("GetModuleHandleEx buffer too small for logger's module path.");
-            }
-
-            std::filesystem::path actual_module_path(module_full_path_buffer);
-            determined_module_dir = actual_module_path.parent_path().string();
-            const std::filesystem::path final_log_path = std::filesystem::path(determined_module_dir) / log_file_name_;
+            const std::filesystem::path final_log_path = std::filesystem::path(module_dir) / log_file_name_;
             return final_log_path.lexically_normal().string();
         }
         catch (const std::exception &e)

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -187,7 +187,11 @@ namespace MemoryUtilsCacheInternal
         ActiveReaderGuard &operator=(const ActiveReaderGuard &) = delete;
     };
 
-    // Background cleanup thread
+    // Background cleanup thread.
+    // Uses std::thread (not jthread) because these are namespace-scope statics:
+    // jthread's auto-join destructor would run after s_cleanupCv/s_cleanupMutex
+    // are destroyed (reverse declaration order), causing UB. Manual join in
+    // shutdown_cache() avoids this. DMK_Shutdown() guarantees proper teardown.
     std::atomic<bool> s_cleanupThreadRunning{false};
     std::thread s_cleanupThread;
     std::mutex s_cleanupMutex;

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -494,8 +494,10 @@ TEST(DynamicMPMCQueueTest, ValidCapacity)
 
 TEST(DynamicMPMCQueueTest, CapacityAccessor)
 {
-    DynamicMPMCQueue queue(4);
-    EXPECT_EQ(queue.capacity(), 4u);
+    DynamicMPMCQueue queue(64);
+    EXPECT_EQ(queue.capacity(), 64u);
+    EXPECT_TRUE(queue.empty());
+    EXPECT_EQ(queue.size(), 0u);
 }
 
 TEST(DynamicMPMCQueueTest, CacheLineAlignment)
@@ -529,9 +531,25 @@ TEST(DynamicMPMCQueueTest, FullAndEmptyQueue)
 
     LogMessage popped;
     EXPECT_TRUE(queue.try_pop(popped));
+    EXPECT_EQ(popped.message(), "msg1");
     EXPECT_TRUE(queue.try_pop(popped));
+    EXPECT_EQ(popped.message(), "msg2");
 
     EXPECT_FALSE(queue.try_pop(popped));
+    EXPECT_TRUE(queue.empty());
+
+    // Wraparound: push/pop again after draining to exercise head/tail wrap
+    LogMessage wrap1(LogLevel::Debug, "wrap1");
+    LogMessage wrap2(LogLevel::Debug, "wrap2");
+    EXPECT_TRUE(queue.try_push(wrap1));
+    EXPECT_TRUE(queue.try_push(wrap2));
+    EXPECT_EQ(queue.size(), 2u);
+
+    LogMessage wrap_out;
+    EXPECT_TRUE(queue.try_pop(wrap_out));
+    EXPECT_EQ(wrap_out.message(), "wrap1");
+    EXPECT_TRUE(queue.try_pop(wrap_out));
+    EXPECT_EQ(wrap_out.message(), "wrap2");
     EXPECT_TRUE(queue.empty());
 }
 
@@ -1627,38 +1645,3 @@ TEST(LogMessageMoveTest, MovedFromMessageReturnsEmpty)
     EXPECT_TRUE(src.message().empty());
 }
 
-// --- DynamicMPMCQueue with unique_ptr buffer ---
-
-TEST(DynamicMPMCQueueTest, CapacityIsImmutable)
-{
-    DynamicMPMCQueue queue(64);
-    EXPECT_EQ(queue.capacity(), 64);
-    EXPECT_TRUE(queue.empty());
-    EXPECT_EQ(queue.size(), 0);
-}
-
-TEST(DynamicMPMCQueueTest, PushPopRoundTrip)
-{
-    DynamicMPMCQueue queue(16);
-    LogMessage msg(LogLevel::Info, "roundtrip");
-    ASSERT_TRUE(queue.try_push(msg));
-    EXPECT_EQ(queue.size(), 1);
-
-    LogMessage out;
-    ASSERT_TRUE(queue.try_pop(out));
-    EXPECT_EQ(out.message(), "roundtrip");
-    EXPECT_TRUE(queue.empty());
-}
-
-TEST(DynamicMPMCQueueTest, FullQueueRejectsPush)
-{
-    DynamicMPMCQueue queue(2);
-
-    LogMessage m1(LogLevel::Info, "a");
-    LogMessage m2(LogLevel::Info, "b");
-    LogMessage m3(LogLevel::Info, "c");
-
-    ASSERT_TRUE(queue.try_push(m1));
-    ASSERT_TRUE(queue.try_push(m2));
-    EXPECT_FALSE(queue.try_push(m3));
-}

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -1589,3 +1589,76 @@ TEST_F(AsyncLoggerTest, LogFormat_MatchesSyncFormat)
     EXPECT_EQ(content.find("[INFO000]"), std::string::npos);
     EXPECT_EQ(content.find("[DEBUG00]"), std::string::npos);
 }
+
+// --- LogMessage move semantics ---
+
+TEST(LogMessageMoveTest, MoveConstructorZerosSourceLength)
+{
+    LogMessage src(LogLevel::Info, "hello");
+    ASSERT_EQ(src.length, 5);
+    ASSERT_TRUE(src.is_valid());
+
+    LogMessage dst(std::move(src));
+
+    EXPECT_EQ(dst.length, 5);
+    EXPECT_EQ(dst.message(), "hello");
+    EXPECT_EQ(src.length, 0);
+    EXPECT_EQ(src.overflow, nullptr);
+}
+
+TEST(LogMessageMoveTest, MoveAssignmentZerosSourceLength)
+{
+    LogMessage src(LogLevel::Info, "world");
+    LogMessage dst;
+
+    dst = std::move(src);
+
+    EXPECT_EQ(dst.length, 5);
+    EXPECT_EQ(dst.message(), "world");
+    EXPECT_EQ(src.length, 0);
+    EXPECT_EQ(src.overflow, nullptr);
+}
+
+TEST(LogMessageMoveTest, MovedFromMessageReturnsEmpty)
+{
+    LogMessage src(LogLevel::Debug, "test message");
+    LogMessage dst(std::move(src));
+
+    EXPECT_TRUE(src.message().empty());
+}
+
+// --- DynamicMPMCQueue with unique_ptr buffer ---
+
+TEST(DynamicMPMCQueueTest, CapacityIsImmutable)
+{
+    DynamicMPMCQueue queue(64);
+    EXPECT_EQ(queue.capacity(), 64);
+    EXPECT_TRUE(queue.empty());
+    EXPECT_EQ(queue.size(), 0);
+}
+
+TEST(DynamicMPMCQueueTest, PushPopRoundTrip)
+{
+    DynamicMPMCQueue queue(16);
+    LogMessage msg(LogLevel::Info, "roundtrip");
+    ASSERT_TRUE(queue.try_push(msg));
+    EXPECT_EQ(queue.size(), 1);
+
+    LogMessage out;
+    ASSERT_TRUE(queue.try_pop(out));
+    EXPECT_EQ(out.message(), "roundtrip");
+    EXPECT_TRUE(queue.empty());
+}
+
+TEST(DynamicMPMCQueueTest, FullQueueRejectsPush)
+{
+    DynamicMPMCQueue queue(2);
+
+    LogMessage m1(LogLevel::Info, "a");
+    LogMessage m2(LogLevel::Info, "b");
+    LogMessage m3(LogLevel::Info, "c");
+
+    ASSERT_TRUE(queue.try_push(m1));
+    ASSERT_TRUE(queue.try_push(m2));
+    EXPECT_FALSE(queue.try_push(m3));
+}

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -607,6 +607,10 @@ TEST(AsyncLoggerConfigTest, Validate_AllReturnValues)
     zero_cap.queue_capacity = 0;
     EXPECT_FALSE(zero_cap.validate());
 
+    AsyncLoggerConfig cap_one;
+    cap_one.queue_capacity = 1;
+    EXPECT_FALSE(cap_one.validate());
+
     AsyncLoggerConfig bad_cap;
     bad_cap.queue_capacity = 100;
     EXPECT_FALSE(bad_cap.validate());

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -1460,3 +1460,22 @@ TEST_F(HookManagerTest, CreateInlineHook_TrampolineNotSetOnFailure)
     // Trampoline should remain unchanged on early validation failure
     EXPECT_EQ(tramp, reinterpret_cast<void *>(0xDEADBEEF));
 }
+
+TEST_F(HookManagerTest, ShutdownResetsFlag)
+{
+    // After shutdown(), the manager accepts new hook creation requests
+    // (returns validation errors, not ShutdownInProgress)
+    hook_manager_->shutdown();
+
+    // Verify by checking that a subsequent call doesn't return ShutdownInProgress.
+    // Use nullptr detour to trigger InvalidDetourFunction rather than ShutdownInProgress.
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "PostShutdownHook",
+        0x1000,
+        nullptr,
+        &tramp);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), HookError::InvalidDetourFunction);
+}

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -1464,15 +1464,15 @@ TEST_F(HookManagerTest, CreateInlineHook_TrampolineNotSetOnFailure)
 TEST_F(HookManagerTest, ShutdownResetsFlag)
 {
     // After shutdown(), the manager accepts new hook creation requests
-    // (returns validation errors, not ShutdownInProgress)
+    // (returns validation errors, not ShutdownInProgress).
+    // Use a real target address so the test depends on the shutdown flag
+    // rather than the validation ordering of target_address == 0.
     hook_manager_->shutdown();
 
-    // Verify by checking that a subsequent call doesn't return ShutdownInProgress.
-    // Use nullptr detour to trigger InvalidDetourFunction rather than ShutdownInProgress.
     void *tramp = nullptr;
     auto result = hook_manager_->create_inline_hook(
         "PostShutdownHook",
-        0x1000,
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
         nullptr,
         &tramp);
 


### PR DESCRIPTION
## Summary

- Fix InputManager TOCTOU use-after-free by replacing `atomic<InputPoller*>` with `atomic<shared_ptr<InputPoller>>`
- Fix logger path corruption on non-ASCII paths by using Wide APIs via `Filesystem::get_runtime_directory()`
- Enforce MPMC queue buffer immutability with `unique_ptr<Slot[]>` and `const` capacity/mask
- Add `static_assert` for StringPool `PoolSlot::str` layout assumption in `deallocate()`
- Fix LogMessage move semantics: zero source `length` to prevent stale reads
- Guard `heap_fallback_count_` against unsigned underflow
- Move HookManager `m_shutdown_called` reset inside exclusive lock scope
- Move config `register_*` setter callbacks under mutex to prevent registration race
- Add `DMK_WARNINGS_AS_ERRORS` CMake option (`-Werror`/`/WX`), enabled in CI
- Document why memory cache cleanup thread uses `std::thread` (static destruction order)
- Add 7 new tests for move semantics, MPMC queue immutability, and shutdown flag reset

## Test plan

- [x] Build clean with `-DDMK_WARNINGS_AS_ERRORS=ON` (zero warnings)
- [x] New tests pass: `LogMessageMoveTest.*`, `DynamicMPMCQueueTest.*`, `HookManagerTest.ShutdownResetsFlag`
- [x] Full test suite passes (exit 0)
- [x] No hot-path performance impact (all fixes target setup/teardown paths)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to treat compiler warnings as errors for stricter builds.

* **Bug Fixes**
  * Improved cross-platform log path resolution and safer filesystem diagnostics.
  * More robust logger queue/overflow accounting and prevention of counter underflow.
  * Safer input poller lifetime handling and more reliable shutdown sequencing for hooks.

* **Documentation**
  * Added instructions for enabling warnings-as-errors in build presets.

* **Tests**
  * Expanded tests for logger move semantics, queue behavior, and shutdown logic.

* **Chores**
  * CI: enforced 5-minute timeout on Windows test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->