### PR TITLE
perf(hook_manager): value semantics, transparent hash, API cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,10 +127,10 @@ CMakePresets.json        # Build presets (mingw-debug/release, msvc-debug/releas
 ### Example -- good hook callback pattern
 
 ```cpp
-hook_manager.with_inline_hook("camera_update", [](const safetyhook::InlineHook &hook) {
+hook_manager.with_inline_hook("camera_update", [](InlineHook &hook) {
     // shared_lock held -- safe to read hook state
     // Do NOT call create_hook/remove_hook from here (deadlock)
-    auto original = hook.original<CameraUpdateFn>();
+    auto original = hook.get_original<CameraUpdateFn>();
     original(camera_ptr);
 });
 ```

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -24,6 +24,16 @@
 namespace DetourModKit
 {
     /**
+     * @brief Transparent hash functor for heterogeneous lookup in string-keyed maps.
+     * @details Allows std::string_view lookups without constructing a temporary std::string.
+     */
+    struct TransparentStringHash
+    {
+        using is_transparent = void;
+        size_t operator()(std::string_view sv) const noexcept { return std::hash<std::string_view>{}(sv); }
+    };
+
+    /**
      * @enum HookType
      * @brief Enumeration of supported hook types, corresponding to SafetyHook capabilities.
      */
@@ -42,9 +52,7 @@ namespace DetourModKit
         Active,
         Disabled,
         Enabling,
-        Disabling,
-        Failed,
-        Removed
+        Disabling
     };
 
     /**
@@ -70,8 +78,6 @@ namespace DetourModKit
     struct HookConfig
     {
         bool auto_enable = true;
-        safetyhook::InlineHook::Flags inline_flags = static_cast<safetyhook::InlineHook::Flags>(0);
-        safetyhook::MidHook::Flags mid_flags = static_cast<safetyhook::MidHook::Flags>(0);
     };
 
     /**
@@ -159,10 +165,6 @@ namespace DetourModKit
                 return "Enabling";
             case HookStatus::Disabling:
                 return "Disabling";
-            case HookStatus::Failed:
-                return "Failed";
-            case HookStatus::Removed:
-                return "Removed";
             default:
                 return "Unknown";
             }
@@ -218,7 +220,7 @@ namespace DetourModKit
     {
     public:
         InlineHook(std::string name, uintptr_t target_address,
-                   std::unique_ptr<safetyhook::InlineHook> hook_obj,
+                   safetyhook::InlineHook hook_obj,
                    HookStatus initial_status)
             : Hook(std::move(name), HookType::Inline, target_address, initial_status),
               m_safetyhook_impl(std::move(hook_obj)) {}
@@ -231,24 +233,24 @@ namespace DetourModKit
         template <typename T>
         T get_original() const noexcept
         {
-            return m_safetyhook_impl ? m_safetyhook_impl->original<T>() : nullptr;
+            return m_safetyhook_impl ? m_safetyhook_impl.original<T>() : nullptr;
         }
 
     protected:
-        bool is_impl_valid() const noexcept override { return m_safetyhook_impl != nullptr; }
+        bool is_impl_valid() const noexcept override { return static_cast<bool>(m_safetyhook_impl); }
         bool do_enable() override
         {
-            auto result = m_safetyhook_impl->enable();
+            auto result = m_safetyhook_impl.enable();
             return result.has_value();
         }
         bool do_disable() override
         {
-            auto result = m_safetyhook_impl->disable();
+            auto result = m_safetyhook_impl.disable();
             return result.has_value();
         }
 
     private:
-        std::unique_ptr<safetyhook::InlineHook> m_safetyhook_impl;
+        safetyhook::InlineHook m_safetyhook_impl;
     };
 
     /**
@@ -259,7 +261,7 @@ namespace DetourModKit
     {
     public:
         MidHook(std::string name, uintptr_t target_address,
-                std::unique_ptr<safetyhook::MidHook> hook_obj,
+                safetyhook::MidHook hook_obj,
                 HookStatus initial_status)
             : Hook(std::move(name), HookType::Mid, target_address, initial_status),
               m_safetyhook_impl(std::move(hook_obj)) {}
@@ -270,24 +272,24 @@ namespace DetourModKit
          */
         safetyhook::MidHookFn get_destination() const noexcept
         {
-            return m_safetyhook_impl ? m_safetyhook_impl->destination() : nullptr;
+            return m_safetyhook_impl ? m_safetyhook_impl.destination() : nullptr;
         }
 
     protected:
-        bool is_impl_valid() const noexcept override { return m_safetyhook_impl != nullptr; }
+        bool is_impl_valid() const noexcept override { return static_cast<bool>(m_safetyhook_impl); }
         bool do_enable() override
         {
-            auto result = m_safetyhook_impl->enable();
+            auto result = m_safetyhook_impl.enable();
             return result.has_value();
         }
         bool do_disable() override
         {
-            auto result = m_safetyhook_impl->disable();
+            auto result = m_safetyhook_impl.disable();
             return result.has_value();
         }
 
     private:
-        std::unique_ptr<safetyhook::MidHook> m_safetyhook_impl;
+        safetyhook::MidHook m_safetyhook_impl;
     };
 
     /**
@@ -468,13 +470,40 @@ namespace DetourModKit
             }
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
             ReentrancyGuard guard(get_reentrancy_guard());
-            const std::string key{hook_id};
-            auto it = m_hooks.find(key);
+            auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
                 return std::invoke(std::forward<F>(fn), static_cast<InlineHook &>(*it->second));
             }
             return std::nullopt;
+        }
+
+        /**
+         * @brief Safely accesses an InlineHook by its ID for a void-returning callback.
+         * @details Same locking and reentrancy semantics as the value-returning overload.
+         * @param hook_id The name of the inline hook.
+         * @param fn The void-returning callback to invoke with the hook reference.
+         * @return true if the hook was found and the callback was invoked, false otherwise.
+         */
+        template <typename F>
+            requires std::invocable<F, InlineHook &> &&
+                     std::is_void_v<std::invoke_result_t<F, InlineHook &>>
+        [[nodiscard]] bool with_inline_hook(std::string_view hook_id, F &&fn)
+        {
+            if (get_reentrancy_guard() > 0)
+            {
+                m_logger.error("HookManager: Reentrant callback detected in with_inline_hook('{}')! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.", hook_id);
+                return false;
+            }
+            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
+            ReentrancyGuard guard(get_reentrancy_guard());
+            auto it = m_hooks.find(hook_id);
+            if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
+            {
+                std::invoke(std::forward<F>(fn), static_cast<InlineHook &>(*it->second));
+                return true;
+            }
+            return false;
         }
 
         /**
@@ -510,8 +539,7 @@ namespace DetourModKit
                 return std::nullopt;
             }
             ReentrancyGuard guard(get_reentrancy_guard());
-            const std::string key{hook_id};
-            auto it = m_hooks.find(key);
+            auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Inline)
             {
                 return std::invoke(std::forward<F>(fn), static_cast<InlineHook &>(*it->second));
@@ -546,13 +574,40 @@ namespace DetourModKit
             }
             std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
             ReentrancyGuard guard(get_reentrancy_guard());
-            const std::string key{hook_id};
-            auto it = m_hooks.find(key);
+            auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
                 return std::invoke(std::forward<F>(fn), static_cast<MidHook &>(*it->second));
             }
             return std::nullopt;
+        }
+
+        /**
+         * @brief Safely accesses a MidHook by its ID for a void-returning callback.
+         * @details Same locking and reentrancy semantics as the value-returning overload.
+         * @param hook_id The name of the mid hook.
+         * @param fn The void-returning callback to invoke with the hook reference.
+         * @return true if the hook was found and the callback was invoked, false otherwise.
+         */
+        template <typename F>
+            requires std::invocable<F, MidHook &> &&
+                     std::is_void_v<std::invoke_result_t<F, MidHook &>>
+        [[nodiscard]] bool with_mid_hook(std::string_view hook_id, F &&fn)
+        {
+            if (get_reentrancy_guard() > 0)
+            {
+                m_logger.error("HookManager: Reentrant callback detected in with_mid_hook('{}')! Callback holding m_hooks_mutex must not call HookManager methods that acquire a unique_lock (remove_hook, enable_hook, disable_hook, create_*_hook). Perform mutations outside the callback or use an asynchronous operation.", hook_id);
+                return false;
+            }
+            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
+            ReentrancyGuard guard(get_reentrancy_guard());
+            auto it = m_hooks.find(hook_id);
+            if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
+            {
+                std::invoke(std::forward<F>(fn), static_cast<MidHook &>(*it->second));
+                return true;
+            }
+            return false;
         }
 
         /**
@@ -588,8 +643,7 @@ namespace DetourModKit
                 return std::nullopt;
             }
             ReentrancyGuard guard(get_reentrancy_guard());
-            const std::string key{hook_id};
-            auto it = m_hooks.find(key);
+            auto it = m_hooks.find(hook_id);
             if (it != m_hooks.end() && it->second->get_type() == HookType::Mid)
             {
                 return std::invoke(std::forward<F>(fn), static_cast<MidHook &>(*it->second));
@@ -601,7 +655,7 @@ namespace DetourModKit
         explicit HookManager(Logger &logger = Logger::get_instance());
 
         mutable std::shared_mutex m_hooks_mutex;
-        std::unordered_map<std::string, std::unique_ptr<Hook>> m_hooks;
+        std::unordered_map<std::string, std::unique_ptr<Hook>, TransparentStringHash, std::equal_to<>> m_hooks;
         Logger &m_logger;
         std::shared_ptr<safetyhook::Allocator> m_allocator;
         std::atomic<bool> m_shutdown_called{false};
@@ -626,8 +680,10 @@ namespace DetourModKit
         std::string error_to_string(const safetyhook::InlineHook::Error &err) const;
         std::string error_to_string(const safetyhook::MidHook::Error &err) const;
 
-        // Non-locking variant - caller must already hold m_hooks_mutex
-        bool hook_id_exists_locked(std::string_view hook_id) const;
+        bool hook_id_exists_locked(std::string_view hook_id) const
+        {
+            return m_hooks.find(hook_id) != m_hooks.end();
+        }
     };
 } // namespace DetourModKit
 

--- a/src/hook_manager.cpp
+++ b/src/hook_manager.cpp
@@ -122,13 +122,6 @@ std::string HookManager::error_to_string(const safetyhook::MidHook::Error &err) 
     }
 }
 
-// Non-locking internal helpers - caller must hold m_hooks_mutex
-bool HookManager::hook_id_exists_locked(std::string_view hook_id) const
-{
-    const std::string key{hook_id};
-    return m_hooks.find(key) != m_hooks.end();
-}
-
 std::expected<std::string, HookError> HookManager::create_inline_hook(
     std::string_view name,
     uintptr_t target_address,
@@ -175,12 +168,9 @@ std::expected<std::string, HookError> HookManager::create_inline_hook(
 
         try
         {
-            safetyhook::InlineHook::Flags sh_flags = config.inline_flags;
-            if (!config.auto_enable)
-            {
-                sh_flags = static_cast<safetyhook::InlineHook::Flags>(
-                    static_cast<uint32_t>(sh_flags) | static_cast<uint32_t>(safetyhook::InlineHook::StartDisabled));
-            }
+            auto sh_flags = config.auto_enable
+                                ? safetyhook::InlineHook::Default
+                                : safetyhook::InlineHook::StartDisabled;
 
             auto hook_creation_result = safetyhook::InlineHook::create(
                 m_allocator,
@@ -196,10 +186,10 @@ std::expected<std::string, HookError> HookManager::create_inline_hook(
                           LogLevel::Error}}};
             }
 
-            auto sh_inline_hook_ptr = std::make_unique<safetyhook::InlineHook>(std::move(hook_creation_result.value()));
-            void *trampoline = sh_inline_hook_ptr->original<void *>();
+            auto sh_inline_hook = std::move(hook_creation_result.value());
+            void *trampoline = sh_inline_hook.original<void *>();
 
-            HookStatus initial_status = sh_inline_hook_ptr->enabled() ? HookStatus::Active : HookStatus::Disabled;
+            HookStatus initial_status = sh_inline_hook.enabled() ? HookStatus::Active : HookStatus::Disabled;
 
             // Pre-build log entries before committing to m_hooks so that
             // allocation failures in std::format cannot leave a ghost hook.
@@ -217,7 +207,7 @@ std::expected<std::string, HookError> HookManager::create_inline_hook(
             }
 
             std::string name_str{name};
-            auto managed_hook = std::make_unique<InlineHook>(name_str, target_address, std::move(sh_inline_hook_ptr), initial_status);
+            auto managed_hook = std::make_unique<InlineHook>(name_str, target_address, std::move(sh_inline_hook), initial_status);
             m_hooks.emplace(name_str, std::move(managed_hook));
             *original_trampoline = trampoline;
 
@@ -322,12 +312,9 @@ std::expected<std::string, HookError> HookManager::create_mid_hook(
 
         try
         {
-            safetyhook::MidHook::Flags sh_flags = config.mid_flags;
-            if (!config.auto_enable)
-            {
-                sh_flags = static_cast<safetyhook::MidHook::Flags>(
-                    static_cast<uint32_t>(sh_flags) | static_cast<uint32_t>(safetyhook::MidHook::StartDisabled));
-            }
+            auto sh_flags = config.auto_enable
+                                ? safetyhook::MidHook::Default
+                                : safetyhook::MidHook::StartDisabled;
 
             auto hook_creation_result = safetyhook::MidHook::create(
                 m_allocator,
@@ -343,9 +330,9 @@ std::expected<std::string, HookError> HookManager::create_mid_hook(
                           LogLevel::Error}}};
             }
 
-            auto sh_mid_hook_ptr = std::make_unique<safetyhook::MidHook>(std::move(hook_creation_result.value()));
+            auto sh_mid_hook = std::move(hook_creation_result.value());
 
-            HookStatus initial_status = sh_mid_hook_ptr->enabled() ? HookStatus::Active : HookStatus::Disabled;
+            HookStatus initial_status = sh_mid_hook.enabled() ? HookStatus::Active : HookStatus::Disabled;
 
             // Pre-build log entries before committing to m_hooks so that
             // allocation failures in std::format cannot leave a ghost hook.
@@ -363,7 +350,7 @@ std::expected<std::string, HookError> HookManager::create_mid_hook(
             }
 
             std::string name_str{name};
-            auto managed_hook = std::make_unique<MidHook>(name_str, target_address, std::move(sh_mid_hook_ptr), initial_status);
+            auto managed_hook = std::make_unique<MidHook>(name_str, target_address, std::move(sh_mid_hook), initial_status);
             m_hooks.emplace(name_str, std::move(managed_hook));
 
             return {std::move(name_str), std::move(logs)};
@@ -426,8 +413,7 @@ std::expected<std::string, HookError> HookManager::create_mid_hook_aob(
 bool HookManager::remove_hook(std::string_view hook_id)
 {
     std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
-    const std::string key{hook_id};
-    auto it = m_hooks.find(key);
+    auto it = m_hooks.find(hook_id);
     if (it != m_hooks.end())
     {
         std::string name_of_removed_hook = it->second->get_name();
@@ -464,8 +450,7 @@ void HookManager::remove_all_hooks()
 bool HookManager::enable_hook(std::string_view hook_id)
 {
     std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-    const std::string key{hook_id};
-    auto it = m_hooks.find(key);
+    auto it = m_hooks.find(hook_id);
     if (it == m_hooks.end())
     {
         m_logger.warning("HookManager: Hook ID '{}' not found for enable operation.", hook_id);
@@ -500,8 +485,7 @@ bool HookManager::enable_hook(std::string_view hook_id)
 bool HookManager::disable_hook(std::string_view hook_id)
 {
     std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-    const std::string key{hook_id};
-    auto it = m_hooks.find(key);
+    auto it = m_hooks.find(hook_id);
     if (it == m_hooks.end())
     {
         m_logger.warning("HookManager: Hook ID '{}' not found for disable operation.", hook_id);
@@ -536,8 +520,7 @@ bool HookManager::disable_hook(std::string_view hook_id)
 std::optional<HookStatus> HookManager::get_hook_status(std::string_view hook_id) const
 {
     std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
-    const std::string key{hook_id};
-    auto it = m_hooks.find(key);
+    auto it = m_hooks.find(hook_id);
     if (it != m_hooks.end())
     {
         return it->second->get_status();
@@ -551,8 +534,6 @@ std::unordered_map<HookStatus, size_t> HookManager::get_hook_counts() const
     std::unordered_map<HookStatus, size_t> counts;
     counts[HookStatus::Active] = 0;
     counts[HookStatus::Disabled] = 0;
-    counts[HookStatus::Failed] = 0;
-    counts[HookStatus::Removed] = 0;
     for (const auto &[name, hook_ptr] : m_hooks)
     {
         counts[hook_ptr->get_status()]++;

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -295,15 +295,6 @@ TEST(HookErrorStringTest, ErrorToString_All)
     EXPECT_EQ(Hook::error_to_string(HookError::UnknownError), "Unknown error");
 }
 
-TEST_F(HookManagerTest, HookConfig_AutoEnable)
-{
-    HookConfig config;
-    EXPECT_TRUE(config.auto_enable);
-
-    config.auto_enable = false;
-    EXPECT_FALSE(config.auto_enable);
-}
-
 TEST_F(HookManagerTest, GetHookCounts_Empty)
 {
     auto counts = hook_manager_->get_hook_counts();

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -44,14 +44,10 @@ TEST_F(HookManagerTest, HookStatus)
     HookStatus status2 = HookStatus::Disabled;
     HookStatus status3 = HookStatus::Enabling;
     HookStatus status4 = HookStatus::Disabling;
-    HookStatus status5 = HookStatus::Failed;
-    HookStatus status6 = HookStatus::Removed;
 
     EXPECT_NE(status1, status2);
     EXPECT_NE(status2, status3);
     EXPECT_NE(status3, status4);
-    EXPECT_NE(status4, status5);
-    EXPECT_NE(status5, status6);
 }
 
 TEST_F(HookManagerTest, HookType)
@@ -160,8 +156,8 @@ TEST_F(HookManagerTest, GetHookIds_WithFilter)
     auto disabled_ids = hook_manager_->get_hook_ids(HookStatus::Disabled);
     EXPECT_TRUE(disabled_ids.empty());
 
-    auto failed_ids = hook_manager_->get_hook_ids(HookStatus::Failed);
-    EXPECT_TRUE(failed_ids.empty());
+    auto enabling_ids = hook_manager_->get_hook_ids(HookStatus::Enabling);
+    EXPECT_TRUE(enabling_ids.empty());
 }
 
 TEST_F(HookManagerTest, RemoveAllHooks)
@@ -299,18 +295,13 @@ TEST(HookErrorStringTest, ErrorToString_All)
     EXPECT_EQ(Hook::error_to_string(HookError::UnknownError), "Unknown error");
 }
 
-TEST_F(HookManagerTest, HookConfig_Flags)
+TEST_F(HookManagerTest, HookConfig_AutoEnable)
 {
     HookConfig config;
+    EXPECT_TRUE(config.auto_enable);
+
     config.auto_enable = false;
-
     EXPECT_FALSE(config.auto_enable);
-
-    config.inline_flags = static_cast<safetyhook::InlineHook::Flags>(0);
-    config.mid_flags = static_cast<safetyhook::MidHook::Flags>(0);
-
-    (void)config.inline_flags;
-    (void)config.mid_flags;
 }
 
 TEST_F(HookManagerTest, GetHookCounts_Empty)
@@ -319,8 +310,6 @@ TEST_F(HookManagerTest, GetHookCounts_Empty)
 
     EXPECT_EQ(counts[HookStatus::Active], 0u);
     EXPECT_EQ(counts[HookStatus::Disabled], 0u);
-    EXPECT_EQ(counts[HookStatus::Failed], 0u);
-    EXPECT_EQ(counts[HookStatus::Removed], 0u);
 }
 
 TEST_F(HookManagerTest, Shutdown_Multiple)
@@ -862,8 +851,6 @@ TEST_F(HookManagerTest, StatusToString_AllValues)
     EXPECT_EQ(Hook::status_to_string(HookStatus::Disabled), "Disabled");
     EXPECT_EQ(Hook::status_to_string(HookStatus::Enabling), "Enabling");
     EXPECT_EQ(Hook::status_to_string(HookStatus::Disabling), "Disabling");
-    EXPECT_EQ(Hook::status_to_string(HookStatus::Failed), "Failed");
-    EXPECT_EQ(Hook::status_to_string(HookStatus::Removed), "Removed");
     EXPECT_EQ(Hook::status_to_string(static_cast<HookStatus>(999)), "Unknown");
 }
 
@@ -897,7 +884,7 @@ TEST_F(HookManagerTest, GetHookStatus_NotFound)
 
 TEST_F(HookManagerTest, GetHookIds_FilteredEmpty)
 {
-    auto ids = hook_manager_->get_hook_ids(HookStatus::Failed);
+    auto ids = hook_manager_->get_hook_ids(HookStatus::Disabled);
     EXPECT_TRUE(ids.empty());
 }
 
@@ -1478,4 +1465,77 @@ TEST_F(HookManagerTest, ShutdownResetsFlag)
 
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), HookError::InvalidDetourFunction);
+}
+
+TEST_F(HookManagerTest, WithInlineHook_VoidCallback)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "VoidInlineCB",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    bool callback_executed = false;
+    bool found = hook_manager_->with_inline_hook(
+        "VoidInlineCB",
+        [&callback_executed](InlineHook &hook)
+        {
+            callback_executed = true;
+            EXPECT_EQ(hook.get_type(), HookType::Inline);
+        });
+
+    EXPECT_TRUE(found);
+    EXPECT_TRUE(callback_executed);
+}
+
+TEST_F(HookManagerTest, WithInlineHook_VoidCallback_NotFound)
+{
+    bool callback_executed = false;
+    bool found = hook_manager_->with_inline_hook(
+        "NonExistentVoidCB",
+        [&callback_executed]([[maybe_unused]] InlineHook &hook)
+        {
+            callback_executed = true;
+        });
+
+    EXPECT_FALSE(found);
+    EXPECT_FALSE(callback_executed);
+}
+
+TEST_F(HookManagerTest, WithMidHook_VoidCallback)
+{
+    auto detour_fn = [](safetyhook::Context &) {};
+    auto result = hook_manager_->create_mid_hook(
+        "VoidMidCB",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        detour_fn);
+    ASSERT_TRUE(result.has_value());
+
+    bool callback_executed = false;
+    bool found = hook_manager_->with_mid_hook(
+        "VoidMidCB",
+        [&callback_executed](MidHook &hook)
+        {
+            callback_executed = true;
+            EXPECT_EQ(hook.get_type(), HookType::Mid);
+        });
+
+    EXPECT_TRUE(found);
+    EXPECT_TRUE(callback_executed);
+}
+
+TEST_F(HookManagerTest, WithMidHook_VoidCallback_NotFound)
+{
+    bool callback_executed = false;
+    bool found = hook_manager_->with_mid_hook(
+        "NonExistentVoidMidCB",
+        [&callback_executed]([[maybe_unused]] MidHook &hook)
+        {
+            callback_executed = true;
+        });
+
+    EXPECT_FALSE(found);
+    EXPECT_FALSE(callback_executed);
 }


### PR DESCRIPTION
## Summary

- Store SafetyHook objects directly instead of `unique_ptr`, eliminating one heap allocation per hook and one pointer indirection on every `get_original()` / `enable()` / `disable()` call
- Use `TransparentStringHash` with `std::equal_to<>` for heterogeneous map lookup, eliminating a temporary `std::string` allocation on every `find` / `enable_hook` / `disable_hook` / `with_*_hook` call
- Remove dead `HookStatus::Failed` and `HookStatus::Removed` states (declared but never assigned by any code path)
- Remove `HookConfig::inline_flags` / `mid_flags` fields that leaked SafetyHook implementation types into the public API (`auto_enable` already handles `StartDisabled`)
- Add void-returning `with_inline_hook` / `with_mid_hook` callback overloads (returns `bool` found/not-found instead of requiring a dummy return value)
- Fix AGENTS.md hook callback example to use correct DMK wrapper types

## Test plan

- [x] All 689 tests pass on MinGW debug
- [x] All 689 tests pass on MSVC debug
- [x] 4 new tests for void-returning callback overloads
- [x] Updated existing tests for removed enum states and config fields


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for void-returning hook callbacks with enhanced callback handling and reentrancy detection.

* **Documentation**
  * Updated inline hook usage example to reflect the updated callback parameter mutability and accessor naming.

* **Refactor**
  * Simplified hook configuration and status model; streamlined hook lookup and internal ownership semantics for better performance.

* **Tests**
  * Updated tests to remove obsolete statuses and added coverage for void-returning hook callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->