### PR TITLE
feat(hook_manager): add VMT hook support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ make clean        # Remove all build directories
 ```text
 include/DetourModKit/    # Public headers -- one per module
   scanner.hpp            # AOB pattern scanning with SSE2
-  hook_manager.hpp       # SafetyHook wrapper (inline + mid hooks)
+  hook_manager.hpp       # SafetyHook wrapper (inline, mid, and VMT hooks)
   async_logger.hpp       # Lock-free MPMC queue logger
   logger.hpp             # Synchronous singleton logger
   win_file_stream.hpp    # Win32 shared-access file stream (CreateFile backend)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ hook_manager.with_inline_hook("camera_update", [](InlineHook &hook) {
 - **One test file per module:** `tests/test_<module>.cpp` mirrors `src/<module>.cpp`.
 - **Integration tests:** `tests/test_hook_integration.cpp` tests cross-module hooking against `tests/fixtures/hook_target_lib.cpp` (built as a DLL). The DLL exports `extern "C"` functions with volatile magic constants for stable AOB patterns.
 - **Test fixture pattern:** Each suite uses a `::testing::Test` subclass with `SetUp()`/`TearDown()` for temp file cleanup. Temp file paths must include the process ID (`_getpid()`) and a counter to avoid collisions when CTest runs tests in parallel as separate processes.
+- **VMT hook test lifetime:** GoogleTest destroys test-body locals *before* calling `TearDown()`. VMT tests must explicitly call `remove_all_vmt_hooks()` (or `remove_vmt_hook`) before target objects go out of scope. Do not rely on `TearDown()` for VMT cleanup when the hooked object is a test-body local.
 - **Coverage gate:** 80% minimum line coverage enforced in CI. All PRs must pass.
 - **Concurrency tests:** Use `std::atomic<bool> stop` flag pattern with multiple threads. See `AsyncMode_ConcurrentLogAndDisable` in `test_logger.cpp` for the reference pattern.
 - **Build flag:** Tests are enabled with `DMK_BUILD_TESTS=ON` (on by default in debug presets).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in g
 ## Features
 
 * **AOB Scanner:** Find array-of-bytes (signatures) in memory with wildcard support and SSE2-accelerated pattern verification (when compiled with SSE2 support) for patterns >= 16 bytes. Supports `|` offset markers for targeting a specific instruction within a wider pattern (e.g., `"48 8B 88 B8 00 00 00 | 48 89 4C 24 68"` sets the offset to byte 7) and nth-occurrence matching (1-based) for patterns that hit multiple locations. Includes RIP-relative instruction resolution for extracting absolute addresses from x86-64 code (returns `std::expected` with typed `RipResolveError` for actionable diagnostics on failure). Provides `scan_executable_regions()` for scanning all committed executable pages in the process -- useful for games with packed or protected binaries that unpack code into anonymous memory outside any loaded module.
-* **Hook Manager:** A C++ wrapper around [SafetyHook](https://github.com/cursey/safetyhook) for creating and managing inline and mid-function hooks, by direct address or AOB scan.
+* **Hook Manager:** A C++ wrapper around [SafetyHook](https://github.com/cursey/safetyhook) for creating and managing inline hooks, mid-function hooks, and VMT (virtual method table) hooks. Inline and mid hooks target functions by direct address or AOB scan. VMT hooks clone an object's vtable and replace individual method slots by index, enabling per-object interception of virtual calls (e.g., D3D device methods, game AI interfaces). Supports applying a single hooked vtable to multiple objects and safe callback-based access to hooked methods via `with_vmt_method()`.
 * **Configuration System:** Load settings from INI files. Mods register their configuration variables (defined in the mod's code) and the kit handles parsing and value assignment. Supports key combos with modifier keys via `register_key_combo` (format: `modifier+trigger`, e.g., `Ctrl+Shift+F3`). Multiple independent combos can be comma-separated (e.g., `F3,Gamepad_LT+Gamepad_B`). Named keys (`Ctrl`, `F3`, `Mouse1`, `Gamepad_A`), hex VK codes (`0x72`), and mixed formats are all supported. (Powered by [SimpleIni](https://github.com/brofield/simpleini)).
 * **Logger:** A flexible singleton logger for outputting messages to a log file. Supports configurable log levels, timestamps, and prefixes. Features **async logging** for high-throughput scenarios, **format string placeholders** for concise log messages, **concurrent file access** via Win32 shared-access file handles (log files can be read by external tools while logging is active), and `is_enabled(LogLevel)` for gating expensive trace-only work.
 * **Async Logger:** A lock-free, bounded queue-based async logger that decouples log message production from file I/O. Designed for minimal latency on the producer side with batched writes on the consumer thread. Features configurable overflow policies (DropNewest/DropOldest/Block/SyncFallback), bounded Block policy with 16 ms default timeout (one frame at 60 fps) to prevent thread starvation, inline buffer optimization for messages of size <= 512 bytes (inclusive), and message size validation with truncation for messages larger than 16 MB (messages > 16 MB are truncated to 16 MB rather than rejected).
@@ -55,6 +55,12 @@ This project uses CMake with [CMake Presets](https://cmake.org/cmake/help/latest
 
     ```bash
     git submodule update --init --recursive
+    ```
+
+    To update submodules to the latest upstream version (when not pinned to a specific commit):
+
+    ```bash
+    git submodule update --init --recursive --remote
     ```
 
 2. **Build & Package for Distribution:**

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <cassert>
 #include <utility>
+#include <format>
 
 #include "safetyhook.hpp"
 #include "DetourModKit/logger.hpp"
@@ -40,7 +41,8 @@ namespace DetourModKit
     enum class HookType
     {
         Inline,
-        Mid
+        Mid,
+        Vmt
     };
 
     /**
@@ -68,6 +70,9 @@ namespace DetourModKit
         HookAlreadyExists,
         ShutdownInProgress,
         SafetyHookError,
+        InvalidObject,
+        VmtHookNotFound,
+        MethodAlreadyHooked,
         UnknownError
     };
 
@@ -186,6 +191,12 @@ namespace DetourModKit
                 return "Hook already exists";
             case HookError::SafetyHookError:
                 return "SafetyHook error";
+            case HookError::InvalidObject:
+                return "Invalid object pointer";
+            case HookError::VmtHookNotFound:
+                return "VMT hook not found";
+            case HookError::MethodAlreadyHooked:
+                return "VMT method already hooked";
             case HookError::UnknownError:
                 return "Unknown error";
             default:
@@ -293,8 +304,64 @@ namespace DetourModKit
     };
 
     /**
+     * @class VmtHookEntry
+     * @brief Manages a VMT hook for a single object class, wrapping SafetyHook's VmtHook.
+     * @details Owns the cloned vtable and tracks individual method hooks by vtable index.
+     *          VMT hooks operate at the object level by replacing the vptr with a cloned
+     *          vtable. Individual methods are hooked by index within the cloned table.
+     *          Does not support enable/disable toggling (SafetyHook VmHook limitation).
+     */
+    class VmtHookEntry
+    {
+    public:
+        VmtHookEntry(std::string name, safetyhook::VmtHook vmt_hook)
+            : m_name(std::move(name)), m_vmt_hook(std::move(vmt_hook)) {}
+
+        const std::string &get_name() const noexcept { return m_name; }
+
+        safetyhook::VmtHook &vmt_hook() noexcept { return m_vmt_hook; }
+        const safetyhook::VmtHook &vmt_hook() const noexcept { return m_vmt_hook; }
+
+        bool has_method_hook(size_t index) const { return m_method_hooks.find(index) != m_method_hooks.end(); }
+
+        safetyhook::VmHook *get_method_hook(size_t index)
+        {
+            auto it = m_method_hooks.find(index);
+            return it != m_method_hooks.end() ? &it->second : nullptr;
+        }
+
+        const safetyhook::VmHook *get_method_hook(size_t index) const
+        {
+            auto it = m_method_hooks.find(index);
+            return it != m_method_hooks.end() ? &it->second : nullptr;
+        }
+
+        void add_method_hook(size_t index, safetyhook::VmHook hook)
+        {
+            m_method_hooks.emplace(index, std::move(hook));
+        }
+
+        bool remove_method_hook(size_t index)
+        {
+            return m_method_hooks.erase(index) > 0;
+        }
+
+        size_t method_hook_count() const noexcept { return m_method_hooks.size(); }
+
+        VmtHookEntry(const VmtHookEntry &) = delete;
+        VmtHookEntry &operator=(const VmtHookEntry &) = delete;
+        VmtHookEntry(VmtHookEntry &&) = default;
+        VmtHookEntry &operator=(VmtHookEntry &&) = default;
+
+    private:
+        std::string m_name;
+        safetyhook::VmtHook m_vmt_hook;
+        std::unordered_map<size_t, safetyhook::VmHook> m_method_hooks;
+    };
+
+    /**
      * @class HookManager
-     * @brief Manages the lifecycle of all hooks (Inline and Mid) using SafetyHook.
+     * @brief Manages the lifecycle of all hooks (Inline, Mid, and VMT) using SafetyHook.
      * @details Provides a centralized API for creating, removing, enabling, and disabling hooks.
      *          Thread-safe for all public methods. Uses std::expected for explicit error handling.
      */
@@ -396,6 +463,204 @@ namespace DetourModKit
             ptrdiff_t aob_offset,
             safetyhook::MidHookFn detour_function,
             const HookConfig &config = HookConfig());
+
+        // --- VMT Hook API ---
+
+        /**
+         * @brief Creates a VMT hook for the given object, cloning its vtable.
+         * @param name A unique, descriptive name for the VMT hook.
+         * @param object Pointer to the polymorphic object whose vptr will be replaced.
+         * @return std::expected<std::string, HookError> The hook name if successful, error code otherwise.
+         */
+        [[nodiscard]] std::expected<std::string, HookError> create_vmt_hook(
+            std::string_view name, void *object);
+
+        /**
+         * @brief Hooks a specific virtual method by index in a named VMT hook.
+         * @tparam T The type of the destination function (function pointer or member function pointer).
+         * @param vmt_name The name of the VMT hook (from create_vmt_hook).
+         * @param method_index The zero-based vtable index of the method to hook.
+         * @param destination The replacement function.
+         * @return std::expected<size_t, HookError> The method index if successful, error code otherwise.
+         */
+        template <typename T>
+        [[nodiscard]] std::expected<size_t, HookError> hook_vmt_method(
+            std::string_view vmt_name, size_t method_index, T destination)
+        {
+            struct DeferredLogEntry
+            {
+                std::string msg;
+                LogLevel level;
+            };
+
+            auto [result, deferred_logs] = [&]() -> std::pair<std::expected<size_t, HookError>, std::vector<DeferredLogEntry>>
+            {
+                std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+
+                if (m_shutdown_called.load(std::memory_order_acquire))
+                {
+                    return {std::unexpected(HookError::ShutdownInProgress),
+                            {{std::format("HookManager: Shutdown in progress. Cannot hook VMT method on '{}'.", vmt_name), LogLevel::Error}}};
+                }
+
+                auto vmt_it = m_vmt_hooks.find(vmt_name);
+                if (vmt_it == m_vmt_hooks.end())
+                {
+                    return {std::unexpected(HookError::VmtHookNotFound),
+                            {{std::format("HookManager: VMT hook '{}' not found for method hook at index {}.", vmt_name, method_index), LogLevel::Error}}};
+                }
+
+                if (vmt_it->second.has_method_hook(method_index))
+                {
+                    return {std::unexpected(HookError::MethodAlreadyHooked),
+                            {{std::format("HookManager: VMT '{}' method index {} is already hooked.", vmt_name, method_index), LogLevel::Error}}};
+                }
+
+                try
+                {
+                    auto hook_result = vmt_it->second.vmt_hook().hook_method(method_index, destination);
+
+                    if (!hook_result)
+                    {
+                        return {std::unexpected(HookError::SafetyHookError),
+                                {{std::format("HookManager: Failed to hook VMT '{}' method index {}.", vmt_name, method_index), LogLevel::Error}}};
+                    }
+
+                    vmt_it->second.add_method_hook(method_index, std::move(hook_result.value()));
+
+                    return {method_index,
+                            {{std::format("HookManager: Successfully hooked VMT '{}' method index {}.", vmt_name, method_index), LogLevel::Info}}};
+                }
+                catch (const std::exception &e)
+                {
+                    return {std::unexpected(HookError::UnknownError),
+                            {{std::format("HookManager: Exception hooking VMT '{}' method index {}: {}", vmt_name, method_index, e.what()), LogLevel::Error}}};
+                }
+                catch (...)
+                {
+                    return {std::unexpected(HookError::UnknownError),
+                            {{std::format("HookManager: Unknown exception hooking VMT '{}' method index {}.", vmt_name, method_index), LogLevel::Error}}};
+                }
+            }();
+
+            for (const auto &entry : deferred_logs)
+            {
+                m_logger.log(entry.level, entry.msg);
+            }
+            return result;
+        }
+
+        /**
+         * @brief Removes an entire VMT hook, restoring the original vtable on all applied objects.
+         * @param vmt_name The name of the VMT hook to remove.
+         * @return true if found and removed, false otherwise.
+         */
+        [[nodiscard]] bool remove_vmt_hook(std::string_view vmt_name);
+
+        /**
+         * @brief Removes a single method hook from a VMT, restoring the original method.
+         * @param vmt_name The name of the VMT hook.
+         * @param method_index The vtable index of the method to unhook.
+         * @return true if found and removed, false otherwise.
+         */
+        [[nodiscard]] bool remove_vmt_method(std::string_view vmt_name, size_t method_index);
+
+        /**
+         * @brief Applies the cloned (hooked) vtable to an additional object.
+         * @param vmt_name The name of the VMT hook.
+         * @param object The object to apply the hooked vtable to.
+         * @return true if the VMT hook was found and applied, false otherwise.
+         */
+        [[nodiscard]] bool apply_vmt_hook(std::string_view vmt_name, void *object);
+
+        /**
+         * @brief Removes the hooked vtable from a specific object, restoring its original vptr.
+         * @param vmt_name The name of the VMT hook.
+         * @param object The object to restore.
+         * @return true if the VMT hook was found and the object was restored, false otherwise.
+         */
+        [[nodiscard]] bool remove_vmt_from_object(std::string_view vmt_name, void *object);
+
+        /**
+         * @brief Removes all VMT hooks, restoring original vtables on all applied objects.
+         */
+        void remove_all_vmt_hooks();
+
+        /**
+         * @brief Returns the names of all active VMT hooks.
+         * @return std::vector<std::string> Vector containing the names of the VMT hooks.
+         */
+        std::vector<std::string> get_vmt_hook_names() const;
+
+        /**
+         * @brief Safely accesses a VmHook (method hook) within a named VMT hook.
+         * @details The callback is invoked while the shared_mutex is held as a reader.
+         * @tparam F Callable type accepting (safetyhook::VmHook&) and returning a value.
+         * @param vmt_name The name of the VMT hook.
+         * @param method_index The vtable index of the method hook.
+         * @param fn The callback to invoke with the VmHook reference.
+         * @return std::optional<R> The callback's return value, or std::nullopt if not found.
+         */
+        template <typename F>
+            requires std::invocable<F, safetyhook::VmHook &> &&
+                     (!std::is_void_v<std::invoke_result_t<F, safetyhook::VmHook &>>) &&
+                     (!std::is_reference_v<std::invoke_result_t<F, safetyhook::VmHook &>>)
+        [[nodiscard]] auto with_vmt_method(std::string_view vmt_name, size_t method_index, F &&fn)
+            -> std::optional<std::invoke_result_t<F, safetyhook::VmHook &>>
+        {
+            if (get_reentrancy_guard() > 0)
+            {
+                m_logger.error("HookManager: Reentrant callback detected in with_vmt_method('{}'/{})!", vmt_name, method_index);
+                return std::nullopt;
+            }
+            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
+            ReentrancyGuard guard(get_reentrancy_guard());
+            auto vmt_it = m_vmt_hooks.find(vmt_name);
+            if (vmt_it != m_vmt_hooks.end())
+            {
+                auto *vm_hook = vmt_it->second.get_method_hook(method_index);
+                if (vm_hook)
+                {
+                    return std::invoke(std::forward<F>(fn), *vm_hook);
+                }
+            }
+            return std::nullopt;
+        }
+
+        /**
+         * @brief Safely accesses a VmHook for a void-returning callback.
+         * @details Same locking and reentrancy semantics as the value-returning overload.
+         * @param vmt_name The name of the VMT hook.
+         * @param method_index The vtable index of the method hook.
+         * @param fn The void-returning callback to invoke with the VmHook reference.
+         * @return true if the method hook was found and the callback was invoked, false otherwise.
+         */
+        template <typename F>
+            requires std::invocable<F, safetyhook::VmHook &> &&
+                     std::is_void_v<std::invoke_result_t<F, safetyhook::VmHook &>>
+        [[nodiscard]] bool with_vmt_method(std::string_view vmt_name, size_t method_index, F &&fn)
+        {
+            if (get_reentrancy_guard() > 0)
+            {
+                m_logger.error("HookManager: Reentrant callback detected in with_vmt_method('{}'/{})!", vmt_name, method_index);
+                return false;
+            }
+            std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
+            ReentrancyGuard guard(get_reentrancy_guard());
+            auto vmt_it = m_vmt_hooks.find(vmt_name);
+            if (vmt_it != m_vmt_hooks.end())
+            {
+                auto *vm_hook = vmt_it->second.get_method_hook(method_index);
+                if (vm_hook)
+                {
+                    std::invoke(std::forward<F>(fn), *vm_hook);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // --- End VMT Hook API ---
 
         /**
          * @brief Removes a hook identified by its name.
@@ -656,6 +921,7 @@ namespace DetourModKit
 
         mutable std::shared_mutex m_hooks_mutex;
         std::unordered_map<std::string, std::unique_ptr<Hook>, TransparentStringHash, std::equal_to<>> m_hooks;
+        std::unordered_map<std::string, VmtHookEntry, TransparentStringHash, std::equal_to<>> m_vmt_hooks;
         Logger &m_logger;
         std::shared_ptr<safetyhook::Allocator> m_allocator;
         std::atomic<bool> m_shutdown_called{false};
@@ -683,6 +949,11 @@ namespace DetourModKit
         bool hook_id_exists_locked(std::string_view hook_id) const
         {
             return m_hooks.find(hook_id) != m_hooks.end();
+        }
+
+        bool vmt_hook_exists_locked(std::string_view name) const
+        {
+            return m_vmt_hooks.find(name) != m_vmt_hooks.end();
         }
     };
 } // namespace DetourModKit

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -189,6 +189,8 @@ namespace DetourModKit
                 return "Invalid trampoline pointer";
             case HookError::HookAlreadyExists:
                 return "Hook already exists";
+            case HookError::ShutdownInProgress:
+                return "Shutdown in progress";
             case HookError::SafetyHookError:
                 return "SafetyHook error";
             case HookError::InvalidObject:
@@ -464,8 +466,6 @@ namespace DetourModKit
             safetyhook::MidHookFn detour_function,
             const HookConfig &config = HookConfig());
 
-        // --- VMT Hook API ---
-
         /**
          * @brief Creates a VMT hook for the given object, cloning its vtable.
          * @param name A unique, descriptive name for the VMT hook.
@@ -659,8 +659,6 @@ namespace DetourModKit
             }
             return false;
         }
-
-        // --- End VMT Hook API ---
 
         /**
          * @brief Removes a hook identified by its name.

--- a/src/hook_manager.cpp
+++ b/src/hook_manager.cpp
@@ -43,6 +43,7 @@ HookManager::~HookManager() noexcept
     if (!m_shutdown_called.load(std::memory_order_acquire))
     {
         std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+        m_vmt_hooks.clear();
         for (auto &[name, hook] : m_hooks)
         {
             hook->disable();
@@ -59,6 +60,7 @@ void HookManager::shutdown()
 
     {
         std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+        m_vmt_hooks.clear();
         for (auto &[name, hook] : m_hooks)
         {
             hook->disable();
@@ -430,6 +432,14 @@ bool HookManager::remove_hook(std::string_view hook_id)
 void HookManager::remove_all_hooks()
 {
     std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+
+    size_t num_vmt = m_vmt_hooks.size();
+    if (num_vmt > 0)
+    {
+        m_logger.info("HookManager: Removing all {} VMT hooks...", num_vmt);
+        m_vmt_hooks.clear();
+    }
+
     if (!m_hooks.empty())
     {
         size_t num_hooks = m_hooks.size();
@@ -437,13 +447,13 @@ void HookManager::remove_all_hooks()
         m_hooks.clear();
         m_logger.info("HookManager: All {} managed hooks have been removed and unhooked.", num_hooks);
     }
-    else
+    else if (num_vmt == 0)
     {
         m_logger.debug("HookManager: remove_all_hooks called, but no hooks were active to remove.");
     }
 
     // Reset shutdown flag to allow reuse after a full reset.
-    // Safe because all hooks have been cleared — no double-free risk.
+    // Safe because all hooks have been cleared -- no double-free risk.
     m_shutdown_called.store(false, std::memory_order_release);
 }
 
@@ -554,4 +564,171 @@ std::vector<std::string> HookManager::get_hook_ids(std::optional<HookStatus> sta
         }
     }
     return ids;
+}
+
+// --- VMT Hook Implementation ---
+
+std::expected<std::string, HookError> HookManager::create_vmt_hook(
+    std::string_view name, void *object)
+{
+    auto [result, deferred_logs] = [&]() -> std::pair<std::expected<std::string, HookError>, std::vector<DeferredLog>>
+    {
+        std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+
+        if (m_shutdown_called.load(std::memory_order_acquire))
+        {
+            return {std::unexpected(HookError::ShutdownInProgress),
+                    {{std::format("HookManager: Shutdown in progress. Cannot create VMT hook '{}'.", name), LogLevel::Error}}};
+        }
+        if (object == nullptr)
+        {
+            return {std::unexpected(HookError::InvalidObject),
+                    {{std::format("HookManager: Object pointer is NULL for VMT hook '{}'.", name), LogLevel::Error}}};
+        }
+        if (vmt_hook_exists_locked(name))
+        {
+            return {std::unexpected(HookError::HookAlreadyExists),
+                    {{std::format("HookManager: A VMT hook with the name '{}' already exists.", name), LogLevel::Error}}};
+        }
+
+        try
+        {
+            auto vmt_result = safetyhook::VmtHook::create(object);
+
+            if (!vmt_result)
+            {
+                return {std::unexpected(HookError::SafetyHookError),
+                        {{std::format("HookManager: Failed to create SafetyHook::VmtHook for '{}' on object {}.",
+                                      name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(object))),
+                          LogLevel::Error}}};
+            }
+
+            std::string name_str{name};
+
+            std::vector<DeferredLog> logs;
+            logs.push_back({std::format("HookManager: Successfully created VMT hook '{}' on object {}.",
+                                        name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(object))),
+                            LogLevel::Info});
+
+            m_vmt_hooks.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple(name_str),
+                std::forward_as_tuple(name_str, std::move(vmt_result.value())));
+
+            return {std::move(name_str), std::move(logs)};
+        }
+        catch (const std::exception &e)
+        {
+            return {std::unexpected(HookError::UnknownError),
+                    {{std::format("HookManager: Exception during VMT hook creation for '{}': {}", name, e.what()),
+                      LogLevel::Error}}};
+        }
+        catch (...)
+        {
+            return {std::unexpected(HookError::UnknownError),
+                    {{std::format("HookManager: Unknown exception during VMT hook creation for '{}'.", name),
+                      LogLevel::Error}}};
+        }
+    }();
+
+    for (const auto &entry : deferred_logs)
+    {
+        m_logger.log(entry.level, entry.msg);
+    }
+    return result;
+}
+
+bool HookManager::remove_vmt_hook(std::string_view vmt_name)
+{
+    std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+    auto it = m_vmt_hooks.find(vmt_name);
+    if (it != m_vmt_hooks.end())
+    {
+        std::string removed_name = it->second.get_name();
+        m_vmt_hooks.erase(it);
+        m_logger.info("HookManager: VMT hook '{}' has been removed.", removed_name);
+        return true;
+    }
+    m_logger.warning("HookManager: Attempted to remove VMT hook '{}', but it was not found.", vmt_name);
+    return false;
+}
+
+bool HookManager::remove_vmt_method(std::string_view vmt_name, size_t method_index)
+{
+    std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+    auto it = m_vmt_hooks.find(vmt_name);
+    if (it == m_vmt_hooks.end())
+    {
+        m_logger.warning("HookManager: VMT hook '{}' not found for method removal.", vmt_name);
+        return false;
+    }
+
+    if (it->second.remove_method_hook(method_index))
+    {
+        m_logger.info("HookManager: VMT '{}' method index {} has been unhooked.", vmt_name, method_index);
+        return true;
+    }
+
+    m_logger.warning("HookManager: VMT '{}' has no hooked method at index {}.", vmt_name, method_index);
+    return false;
+}
+
+bool HookManager::apply_vmt_hook(std::string_view vmt_name, void *object)
+{
+    std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+    auto it = m_vmt_hooks.find(vmt_name);
+    if (it == m_vmt_hooks.end())
+    {
+        m_logger.warning("HookManager: VMT hook '{}' not found for apply.", vmt_name);
+        return false;
+    }
+
+    it->second.vmt_hook().apply(object);
+    m_logger.info("HookManager: VMT hook '{}' applied to object {}.",
+                  vmt_name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(object)));
+    return true;
+}
+
+bool HookManager::remove_vmt_from_object(std::string_view vmt_name, void *object)
+{
+    std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+    auto it = m_vmt_hooks.find(vmt_name);
+    if (it == m_vmt_hooks.end())
+    {
+        m_logger.warning("HookManager: VMT hook '{}' not found for object removal.", vmt_name);
+        return false;
+    }
+
+    it->second.vmt_hook().remove(object);
+    m_logger.info("HookManager: VMT hook '{}' removed from object {}.",
+                  vmt_name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(object)));
+    return true;
+}
+
+void HookManager::remove_all_vmt_hooks()
+{
+    std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
+    if (!m_vmt_hooks.empty())
+    {
+        size_t num_hooks = m_vmt_hooks.size();
+        m_logger.info("HookManager: Removing all {} VMT hooks...", num_hooks);
+        m_vmt_hooks.clear();
+        m_logger.info("HookManager: All {} VMT hooks have been removed.", num_hooks);
+    }
+    else
+    {
+        m_logger.debug("HookManager: remove_all_vmt_hooks called, but no VMT hooks were active.");
+    }
+}
+
+std::vector<std::string> HookManager::get_vmt_hook_names() const
+{
+    std::shared_lock<std::shared_mutex> lock(m_hooks_mutex);
+    std::vector<std::string> names;
+    names.reserve(m_vmt_hooks.size());
+    for (const auto &[name, entry] : m_vmt_hooks)
+    {
+        names.push_back(name);
+    }
+    return names;
 }

--- a/src/hook_manager.cpp
+++ b/src/hook_manager.cpp
@@ -566,8 +566,6 @@ std::vector<std::string> HookManager::get_hook_ids(std::optional<HookStatus> sta
     return ids;
 }
 
-// --- VMT Hook Implementation ---
-
 std::expected<std::string, HookError> HookManager::create_vmt_hook(
     std::string_view name, void *object)
 {
@@ -675,6 +673,12 @@ bool HookManager::remove_vmt_method(std::string_view vmt_name, size_t method_ind
 
 bool HookManager::apply_vmt_hook(std::string_view vmt_name, void *object)
 {
+    if (object == nullptr)
+    {
+        m_logger.warning("HookManager: Cannot apply VMT hook '{}' to null object.", vmt_name);
+        return false;
+    }
+
     std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
     auto it = m_vmt_hooks.find(vmt_name);
     if (it == m_vmt_hooks.end())
@@ -691,6 +695,12 @@ bool HookManager::apply_vmt_hook(std::string_view vmt_name, void *object)
 
 bool HookManager::remove_vmt_from_object(std::string_view vmt_name, void *object)
 {
+    if (object == nullptr)
+    {
+        m_logger.warning("HookManager: Cannot remove VMT hook '{}' from null object.", vmt_name);
+        return false;
+    }
+
     std::unique_lock<std::shared_mutex> lock(m_hooks_mutex);
     auto it = m_vmt_hooks.find(vmt_name);
     if (it == m_vmt_hooks.end())

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -1578,6 +1578,8 @@ TEST_F(HookManagerTest, VmtHook_CreateSuccess)
     auto names = hook_manager_->get_vmt_hook_names();
     EXPECT_EQ(names.size(), 1u);
     EXPECT_EQ(names[0], "TestVmt");
+
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_CreateNullObject)
@@ -1597,6 +1599,8 @@ TEST_F(HookManagerTest, VmtHook_CreateDuplicate)
     auto r2 = hook_manager_->create_vmt_hook("DupVmt", target.get());
     ASSERT_FALSE(r2.has_value());
     EXPECT_EQ(r2.error(), HookError::HookAlreadyExists);
+
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_HookMethod)
@@ -1620,6 +1624,7 @@ TEST_F(HookManagerTest, VmtHook_HookMethod)
     EXPECT_EQ(target->compute(3, 4), 1007);
 
     g_compute_vm_hook = nullptr;
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_HookMethodDuplicate)
@@ -1639,6 +1644,7 @@ TEST_F(HookManagerTest, VmtHook_HookMethodDuplicate)
     EXPECT_EQ(r2.error(), HookError::MethodAlreadyHooked);
 
     g_compute_vm_hook = nullptr;
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_HookMethodNotFound)
@@ -1673,6 +1679,8 @@ TEST_F(HookManagerTest, VmtHook_RemoveMethod)
     EXPECT_EQ(target->compute(5, 5), 10);
 
     EXPECT_FALSE(hook_manager_->remove_vmt_method("RemMethodVmt", VMT_COMPUTE_INDEX));
+
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_RemoveEntireHook)
@@ -1734,6 +1742,7 @@ TEST_F(HookManagerTest, VmtHook_ApplyToMultipleObjects)
     EXPECT_EQ(target1->compute(1, 1), 1002);
 
     g_compute_vm_hook = nullptr;
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_RemoveAllVmt)
@@ -1771,6 +1780,8 @@ TEST_F(HookManagerTest, VmtHook_ShutdownClearsVmt)
     EXPECT_TRUE(hook_manager_->get_vmt_hook_names().empty());
 
     ASSERT_TRUE(hook_manager_->create_vmt_hook("VmtPostShutdown", target.get()).has_value());
+
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_WithVmtMethod_ValueCallback)
@@ -1793,6 +1804,7 @@ TEST_F(HookManagerTest, VmtHook_WithVmtMethod_ValueCallback)
     EXPECT_TRUE(*result);
 
     g_compute_vm_hook = nullptr;
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_WithVmtMethod_NotFound)
@@ -1817,6 +1829,8 @@ TEST_F(HookManagerTest, VmtHook_WithVmtMethod_MethodNotFound)
         { return true; });
 
     EXPECT_FALSE(result.has_value());
+
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_WithVmtMethod_VoidCallback)
@@ -1840,6 +1854,7 @@ TEST_F(HookManagerTest, VmtHook_WithVmtMethod_VoidCallback)
     EXPECT_TRUE(callback_executed);
 
     g_compute_vm_hook = nullptr;
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_ErrorStrings)
@@ -1856,6 +1871,8 @@ TEST_F(HookManagerTest, VmtHook_ApplyNullObject)
     ASSERT_TRUE(hook_manager_->create_vmt_hook("ApplyNullVmt", target.get()).has_value());
 
     EXPECT_FALSE(hook_manager_->apply_vmt_hook("ApplyNullVmt", nullptr));
+
+    hook_manager_->remove_all_vmt_hooks();
 }
 
 TEST_F(HookManagerTest, VmtHook_RemoveFromNullObject)
@@ -1864,4 +1881,6 @@ TEST_F(HookManagerTest, VmtHook_RemoveFromNullObject)
     ASSERT_TRUE(hook_manager_->create_vmt_hook("RemNullVmt", target.get()).has_value());
 
     EXPECT_FALSE(hook_manager_->remove_vmt_from_object("RemNullVmt", nullptr));
+
+    hook_manager_->remove_all_vmt_hooks();
 }

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -1530,3 +1530,321 @@ TEST_F(HookManagerTest, WithMidHook_VoidCallback_NotFound)
     EXPECT_FALSE(found);
     EXPECT_FALSE(callback_executed);
 }
+
+class VmtTestInterface
+{
+public:
+    virtual ~VmtTestInterface() = default;
+    virtual int compute(int a, int b) = 0;
+    virtual int transform(int x) = 0;
+};
+
+class VmtTestTarget : public VmtTestInterface
+{
+public:
+    int compute(int a, int b) override { return a + b; }
+    int transform(int x) override { return x * 2; }
+};
+
+// Vtable layout differs between MSVC (single destructor slot) and
+// Itanium ABI (two destructor slots used by GCC/MinGW).
+#if defined(_MSC_VER)
+static constexpr size_t VMT_COMPUTE_INDEX = 1;
+static constexpr size_t VMT_TRANSFORM_INDEX = 2;
+#else
+static constexpr size_t VMT_COMPUTE_INDEX = 2;
+static constexpr size_t VMT_TRANSFORM_INDEX = 3;
+#endif
+
+static safetyhook::VmHook *g_compute_vm_hook = nullptr;
+
+class VmtTestHook : public VmtTestTarget
+{
+public:
+    int hooked_compute(int a, int b)
+    {
+        return g_compute_vm_hook->thiscall<int>(this, a, b) + 1000;
+    }
+};
+
+TEST_F(HookManagerTest, VmtHook_CreateSuccess)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+
+    auto result = hook_manager_->create_vmt_hook("TestVmt", target.get());
+    ASSERT_TRUE(result.has_value()) << "VMT hook creation should succeed";
+    EXPECT_EQ(*result, "TestVmt");
+
+    auto names = hook_manager_->get_vmt_hook_names();
+    EXPECT_EQ(names.size(), 1u);
+    EXPECT_EQ(names[0], "TestVmt");
+}
+
+TEST_F(HookManagerTest, VmtHook_CreateNullObject)
+{
+    auto result = hook_manager_->create_vmt_hook("NullVmt", nullptr);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), HookError::InvalidObject);
+}
+
+TEST_F(HookManagerTest, VmtHook_CreateDuplicate)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+
+    auto r1 = hook_manager_->create_vmt_hook("DupVmt", target.get());
+    ASSERT_TRUE(r1.has_value());
+
+    auto r2 = hook_manager_->create_vmt_hook("DupVmt", target.get());
+    ASSERT_FALSE(r2.has_value());
+    EXPECT_EQ(r2.error(), HookError::HookAlreadyExists);
+}
+
+TEST_F(HookManagerTest, VmtHook_HookMethod)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+    EXPECT_EQ(target->compute(3, 4), 7);
+
+    auto vmt_result = hook_manager_->create_vmt_hook("MethodVmt", target.get());
+    ASSERT_TRUE(vmt_result.has_value());
+
+    auto method_result = hook_manager_->hook_vmt_method(
+        "MethodVmt", VMT_COMPUTE_INDEX, &VmtTestHook::hooked_compute);
+    ASSERT_TRUE(method_result.has_value()) << "Method hook should succeed";
+    EXPECT_EQ(*method_result, VMT_COMPUTE_INDEX);
+
+    ASSERT_TRUE(hook_manager_->with_vmt_method(
+        "MethodVmt", VMT_COMPUTE_INDEX,
+        [](safetyhook::VmHook &hook)
+        { g_compute_vm_hook = &hook; }));
+
+    EXPECT_EQ(target->compute(3, 4), 1007);
+
+    g_compute_vm_hook = nullptr;
+}
+
+TEST_F(HookManagerTest, VmtHook_HookMethodDuplicate)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+
+    auto vmt_result = hook_manager_->create_vmt_hook("DupMethodVmt", target.get());
+    ASSERT_TRUE(vmt_result.has_value());
+
+    auto r1 = hook_manager_->hook_vmt_method(
+        "DupMethodVmt", VMT_COMPUTE_INDEX, &VmtTestHook::hooked_compute);
+    ASSERT_TRUE(r1.has_value());
+
+    auto r2 = hook_manager_->hook_vmt_method(
+        "DupMethodVmt", VMT_COMPUTE_INDEX, &VmtTestHook::hooked_compute);
+    ASSERT_FALSE(r2.has_value());
+    EXPECT_EQ(r2.error(), HookError::MethodAlreadyHooked);
+
+    g_compute_vm_hook = nullptr;
+}
+
+TEST_F(HookManagerTest, VmtHook_HookMethodNotFound)
+{
+    auto result = hook_manager_->hook_vmt_method(
+        "NonExistentVmt", 0, &VmtTestHook::hooked_compute);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), HookError::VmtHookNotFound);
+}
+
+TEST_F(HookManagerTest, VmtHook_RemoveMethod)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+
+    auto vmt_result = hook_manager_->create_vmt_hook("RemMethodVmt", target.get());
+    ASSERT_TRUE(vmt_result.has_value());
+
+    auto method_result = hook_manager_->hook_vmt_method(
+        "RemMethodVmt", VMT_COMPUTE_INDEX, &VmtTestHook::hooked_compute);
+    ASSERT_TRUE(method_result.has_value());
+
+    ASSERT_TRUE(hook_manager_->with_vmt_method(
+        "RemMethodVmt", VMT_COMPUTE_INDEX,
+        [](safetyhook::VmHook &hook)
+        { g_compute_vm_hook = &hook; }));
+
+    EXPECT_EQ(target->compute(5, 5), 1010);
+
+    g_compute_vm_hook = nullptr;
+    EXPECT_TRUE(hook_manager_->remove_vmt_method("RemMethodVmt", VMT_COMPUTE_INDEX));
+
+    EXPECT_EQ(target->compute(5, 5), 10);
+
+    EXPECT_FALSE(hook_manager_->remove_vmt_method("RemMethodVmt", VMT_COMPUTE_INDEX));
+}
+
+TEST_F(HookManagerTest, VmtHook_RemoveEntireHook)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+    EXPECT_EQ(target->compute(1, 2), 3);
+
+    auto vmt_result = hook_manager_->create_vmt_hook("RemVmt", target.get());
+    ASSERT_TRUE(vmt_result.has_value());
+
+    auto method_result = hook_manager_->hook_vmt_method(
+        "RemVmt", VMT_COMPUTE_INDEX, &VmtTestHook::hooked_compute);
+    ASSERT_TRUE(method_result.has_value());
+
+    ASSERT_TRUE(hook_manager_->with_vmt_method(
+        "RemVmt", VMT_COMPUTE_INDEX,
+        [](safetyhook::VmHook &hook)
+        { g_compute_vm_hook = &hook; }));
+
+    EXPECT_EQ(target->compute(1, 2), 1003);
+
+    g_compute_vm_hook = nullptr;
+    EXPECT_TRUE(hook_manager_->remove_vmt_hook("RemVmt"));
+
+    EXPECT_EQ(target->compute(1, 2), 3);
+    EXPECT_TRUE(hook_manager_->get_vmt_hook_names().empty());
+}
+
+TEST_F(HookManagerTest, VmtHook_RemoveNotFound)
+{
+    EXPECT_FALSE(hook_manager_->remove_vmt_hook("NonExistent"));
+}
+
+TEST_F(HookManagerTest, VmtHook_ApplyToMultipleObjects)
+{
+    auto target1 = std::make_unique<VmtTestTarget>();
+    auto target2 = std::make_unique<VmtTestTarget>();
+
+    auto vmt_result = hook_manager_->create_vmt_hook("MultiVmt", target1.get());
+    ASSERT_TRUE(vmt_result.has_value());
+
+    auto method_result = hook_manager_->hook_vmt_method(
+        "MultiVmt", VMT_COMPUTE_INDEX, &VmtTestHook::hooked_compute);
+    ASSERT_TRUE(method_result.has_value());
+
+    ASSERT_TRUE(hook_manager_->with_vmt_method(
+        "MultiVmt", VMT_COMPUTE_INDEX,
+        [](safetyhook::VmHook &hook)
+        { g_compute_vm_hook = &hook; }));
+
+    EXPECT_EQ(target1->compute(1, 1), 1002);
+    EXPECT_EQ(target2->compute(1, 1), 2);
+
+    EXPECT_TRUE(hook_manager_->apply_vmt_hook("MultiVmt", target2.get()));
+    EXPECT_EQ(target2->compute(1, 1), 1002);
+
+    EXPECT_TRUE(hook_manager_->remove_vmt_from_object("MultiVmt", target2.get()));
+    EXPECT_EQ(target2->compute(1, 1), 2);
+    EXPECT_EQ(target1->compute(1, 1), 1002);
+
+    g_compute_vm_hook = nullptr;
+}
+
+TEST_F(HookManagerTest, VmtHook_RemoveAllVmt)
+{
+    auto target1 = std::make_unique<VmtTestTarget>();
+    auto target2 = std::make_unique<VmtTestTarget>();
+
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("Vmt1", target1.get()).has_value());
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("Vmt2", target2.get()).has_value());
+
+    EXPECT_EQ(hook_manager_->get_vmt_hook_names().size(), 2u);
+
+    hook_manager_->remove_all_vmt_hooks();
+    EXPECT_TRUE(hook_manager_->get_vmt_hook_names().empty());
+}
+
+TEST_F(HookManagerTest, VmtHook_RemoveAllHooksClearsVmt)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("VmtCleared", target.get()).has_value());
+    EXPECT_EQ(hook_manager_->get_vmt_hook_names().size(), 1u);
+
+    hook_manager_->remove_all_hooks();
+    EXPECT_TRUE(hook_manager_->get_vmt_hook_names().empty());
+}
+
+TEST_F(HookManagerTest, VmtHook_ShutdownClearsVmt)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("VmtShutdown", target.get()).has_value());
+
+    hook_manager_->shutdown();
+    EXPECT_TRUE(hook_manager_->get_vmt_hook_names().empty());
+
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("VmtPostShutdown", target.get()).has_value());
+}
+
+TEST_F(HookManagerTest, VmtHook_WithVmtMethod_ValueCallback)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("CbVmt", target.get()).has_value());
+    ASSERT_TRUE(hook_manager_->hook_vmt_method(
+                                 "CbVmt", VMT_COMPUTE_INDEX, &VmtTestHook::hooked_compute)
+                    .has_value());
+
+    auto result = hook_manager_->with_vmt_method(
+        "CbVmt", VMT_COMPUTE_INDEX,
+        [](safetyhook::VmHook &hook) -> bool
+        {
+            return hook.original<void *>() != nullptr;
+        });
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(*result);
+
+    g_compute_vm_hook = nullptr;
+}
+
+TEST_F(HookManagerTest, VmtHook_WithVmtMethod_NotFound)
+{
+    auto result = hook_manager_->with_vmt_method(
+        "NonExistentVmt", 0,
+        [](safetyhook::VmHook &) -> bool
+        { return true; });
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(HookManagerTest, VmtHook_WithVmtMethod_MethodNotFound)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("NoMethodVmt", target.get()).has_value());
+
+    auto result = hook_manager_->with_vmt_method(
+        "NoMethodVmt", 99,
+        [](safetyhook::VmHook &) -> bool
+        { return true; });
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(HookManagerTest, VmtHook_WithVmtMethod_VoidCallback)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("VoidCbVmt", target.get()).has_value());
+    ASSERT_TRUE(hook_manager_->hook_vmt_method(
+                                 "VoidCbVmt", VMT_COMPUTE_INDEX, &VmtTestHook::hooked_compute)
+                    .has_value());
+
+    bool callback_executed = false;
+    bool found = hook_manager_->with_vmt_method(
+        "VoidCbVmt", VMT_COMPUTE_INDEX,
+        [&callback_executed](safetyhook::VmHook &)
+        {
+            callback_executed = true;
+        });
+
+    EXPECT_TRUE(found);
+    EXPECT_TRUE(callback_executed);
+
+    g_compute_vm_hook = nullptr;
+}
+
+TEST_F(HookManagerTest, VmtHook_ErrorStrings)
+{
+    EXPECT_EQ(Hook::error_to_string(HookError::InvalidObject), "Invalid object pointer");
+    EXPECT_EQ(Hook::error_to_string(HookError::VmtHookNotFound), "VMT hook not found");
+    EXPECT_EQ(Hook::error_to_string(HookError::MethodAlreadyHooked), "VMT method already hooked");
+}

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -1844,7 +1844,24 @@ TEST_F(HookManagerTest, VmtHook_WithVmtMethod_VoidCallback)
 
 TEST_F(HookManagerTest, VmtHook_ErrorStrings)
 {
+    EXPECT_EQ(Hook::error_to_string(HookError::ShutdownInProgress), "Shutdown in progress");
     EXPECT_EQ(Hook::error_to_string(HookError::InvalidObject), "Invalid object pointer");
     EXPECT_EQ(Hook::error_to_string(HookError::VmtHookNotFound), "VMT hook not found");
     EXPECT_EQ(Hook::error_to_string(HookError::MethodAlreadyHooked), "VMT method already hooked");
+}
+
+TEST_F(HookManagerTest, VmtHook_ApplyNullObject)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("ApplyNullVmt", target.get()).has_value());
+
+    EXPECT_FALSE(hook_manager_->apply_vmt_hook("ApplyNullVmt", nullptr));
+}
+
+TEST_F(HookManagerTest, VmtHook_RemoveFromNullObject)
+{
+    auto target = std::make_unique<VmtTestTarget>();
+    ASSERT_TRUE(hook_manager_->create_vmt_hook("RemNullVmt", target.get()).has_value());
+
+    EXPECT_FALSE(hook_manager_->remove_vmt_from_object("RemNullVmt", nullptr));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Virtual Method Table (VMT) hooking: per-object vtable cloning, per-method add/remove by index, apply/remove hooks to objects, reusable hooked vtables, and callback access to method hooks.

* **Documentation**
  * Expanded Hook Manager docs to include inline, mid-function, and VMT hooks; added VMT testing guidance and submodule update instructions.

* **Tests**
  * Added extensive unit tests for VMT hook lifecycle, method errors, per-object behavior, callbacks, and shutdown/cleanup paths.

* **Bug Fixes**
  * VMT hooks are now cleared during full reset/shutdown and when removing all hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->