### PR TITLE
feat(profiler): add opt-in lock-free profiler with Chrome Tracing export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,13 @@ cmake --build build/msvc-debug --parallel
 ctest --preset msvc-debug
 ```
 
+### Profiling
+
+```bash
+cmake --preset mingw-debug -DDMK_ENABLE_PROFILING=ON
+cmake --build build/mingw-debug --parallel
+```
+
 ### Sanitizers and coverage (MinGW only)
 
 ```bash
@@ -83,6 +90,7 @@ include/DetourModKit/    # Public headers -- one per module
   input.hpp              # Input polling (keyboard/mouse/XInput)
   input_codes.hpp        # Unified InputCode type and named key tables
   memory.hpp             # Memory read/write, sharded region cache
+  profiler.hpp           # Opt-in scoped timing (zero-cost when disabled)
   format.hpp             # std::format utilities (header-only)
   math.hpp               # Angle conversions (header-only)
   filesystem.hpp         # Module directory resolution (wide-string API)
@@ -237,6 +245,7 @@ PATH="/c/msys64/mingw64/bin:$PATH" ./build/mingw-debug/tests/DetourModKit_tests.
 | InputManager | `mutex` for lifecycle, `atomic<InputPoller*>` for reads | Lock-free `is_binding_active()` |
 | Memory cache | Sharded `SRWLOCK` + epoch-based shutdown | Shared reader locks per shard |
 | Config | `mutex` for registration; deferred setter invocation outside lock (no reentrancy guard needed -- setters may call back into Config) | N/A (startup only) |
+| Profiler | Lock-free ring buffer via atomic `fetch_add` on write position | Single atomic increment + array write per sample |
 
 ### Performance-critical paths
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,14 @@ message(STATUS "  Install Docs Dir:            ${CMAKE_INSTALL_DOCDIR} (standard
 message(STATUS "  DirectXMath Include Dir:    ${DIRECTXMATH_INCLUDE_DIR}")
 message(STATUS "---------------------------------------------------------------------")
 
+# --- Profiling ---
+option(DMK_ENABLE_PROFILING "Enable profiling instrumentation (opt-in, zero cost when OFF)" OFF)
+
+if(DMK_ENABLE_PROFILING)
+  target_compile_definitions(DetourModKit PUBLIC DMK_ENABLE_PROFILING)
+  message(STATUS "Profiling instrumentation enabled")
+endif()
+
 # --- Sanitizers ---
 option(DMK_ENABLE_SANITIZERS "Enable ASan and UBSan (GCC/Clang only)" OFF)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in g
 * **Logger:** A flexible singleton logger for outputting messages to a log file. Supports configurable log levels, timestamps, and prefixes. Features **async logging** for high-throughput scenarios, **format string placeholders** for concise log messages, **concurrent file access** via Win32 shared-access file handles (log files can be read by external tools while logging is active), and `is_enabled(LogLevel)` for gating expensive trace-only work.
 * **Async Logger:** A lock-free, bounded queue-based async logger that decouples log message production from file I/O. Designed for minimal latency on the producer side with batched writes on the consumer thread. Features configurable overflow policies (DropNewest/DropOldest/Block/SyncFallback), bounded Block policy with 16 ms default timeout (one frame at 60 fps) to prevent thread starvation, inline buffer optimization for messages of size <= 512 bytes (inclusive), and message size validation with truncation for messages larger than 16 MB (messages > 16 MB are truncated to 16 MB rather than rejected).
 * **Memory Utilities:** Functions for checking memory readability/writability and writing bytes to memory. Includes an optional memory region cache with sharded SRWLOCK concurrency, LRU eviction, and stampede coalescing. Provides `is_readable_nonblocking()` (tri-state: readable/not-readable/unknown) for latency-sensitive threads, `read_ptr_unsafe()` for safe pointer reads in hot paths (SEH-protected on MSVC, cache-accelerated with VirtualQuery fallback on MinGW), and `read_ptr_unchecked()` -- an inline header-only variant with a configurable low-address validity guard for pointer chain traversal without per-call SEH overhead (caller must guarantee structural pointer validity).
+* **Profiler:** Opt-in scoped timing instrumentation with zero overhead when disabled. Compile-time gated via `DMK_ENABLE_PROFILING`. When enabled, records lock-free timing samples (~50 ns per scope) into a fixed-size ring buffer (64K samples, ~1.5 MB). Exports to [Chrome Tracing JSON](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview) format viewable in `chrome://tracing` or [Perfetto](https://ui.perfetto.dev). Use `DMK_PROFILE_SCOPE("name")` or `DMK_PROFILE_FUNCTION()` macros to instrument code paths; use `Profiler::export_to_file()` to dump results after a profiling session.
 * **String Utilities:** Whitespace trimming for string cleanup.
 * **Format Utilities:** Inline formatting helpers for memory addresses, byte values, VK codes, and hex integer vectors using `std::format`.
 * **Filesystem Utilities:** Basic filesystem operations, notably getting the current module's runtime directory.
@@ -204,6 +205,17 @@ To treat compiler warnings as errors (enabled by default in CI):
 cmake --preset mingw-debug -DDMK_WARNINGS_AS_ERRORS=ON
 cmake --build --preset mingw-debug --parallel
 ```
+
+### Enabling Profiling
+
+To enable the opt-in profiler instrumentation (`DMK_PROFILE_SCOPE` / `DMK_PROFILE_FUNCTION` macros):
+
+```bash
+cmake --preset mingw-debug -DDMK_ENABLE_PROFILING=ON
+cmake --build --preset mingw-debug --parallel
+```
+
+When `DMK_ENABLE_PROFILING` is OFF (the default), all profiling macros expand to `((void)0)` with zero overhead. The `Profiler` class and `ScopedProfile` are still compiled into the library (so tests always work), but the macros that instrument user code are no-ops.
 
 ### Enabling Sanitizers
 

--- a/include/DetourModKit.hpp
+++ b/include/DetourModKit.hpp
@@ -22,6 +22,7 @@
 #include "DetourModKit/format.hpp"
 #include "DetourModKit/math.hpp"
 #include "DetourModKit/memory.hpp"
+#include "DetourModKit/profiler.hpp"
 #include "DetourModKit/scanner.hpp"
 
 /**
@@ -37,6 +38,7 @@ namespace DMKFormat = DetourModKit::Format;
 namespace DMKFilesystem = DetourModKit::Filesystem;
 namespace DMKMemory = DetourModKit::Memory;
 namespace DMKMath = DetourModKit::Math;
+namespace DMKProfiler = DetourModKit;
 
 #ifndef DMK_NO_SHORT_NAMES
 /**
@@ -61,6 +63,9 @@ using DMKInputCode = DetourModKit::InputCode;
 using DMKKeyCombo = DetourModKit::Config::KeyCombo;
 using DMKKeyComboList = DetourModKit::Config::KeyComboList;
 using DMKInputBinding = DetourModKit::InputBinding;
+using DMKProfiler = DetourModKit::Profiler;
+using DMKScopedProfile = DetourModKit::ScopedProfile;
+using DMKProfileSample = DetourModKit::ProfileSample;
 #endif // DMK_NO_SHORT_NAMES
 
 /**

--- a/include/DetourModKit.hpp
+++ b/include/DetourModKit.hpp
@@ -38,7 +38,6 @@ namespace DMKFormat = DetourModKit::Format;
 namespace DMKFilesystem = DetourModKit::Filesystem;
 namespace DMKMemory = DetourModKit::Memory;
 namespace DMKMath = DetourModKit::Math;
-namespace DMKProfiler = DetourModKit;
 
 #ifndef DMK_NO_SHORT_NAMES
 /**

--- a/include/DetourModKit/profiler.hpp
+++ b/include/DetourModKit/profiler.hpp
@@ -1,0 +1,194 @@
+#ifndef DETOURMODKIT_PROFILER_HPP
+#define DETOURMODKIT_PROFILER_HPP
+
+/**
+ * @file profiler.hpp
+ * @brief Opt-in profiling instrumentation for measuring hook and subsystem timing.
+ *
+ * @details Provides zero-overhead profiling when disabled at compile time.
+ *          When enabled via DMK_ENABLE_PROFILING, records scoped timing samples
+ *          into a lock-free ring buffer and exports to Chrome Tracing JSON format
+ *          (viewable in chrome://tracing or https://ui.perfetto.dev).
+ *
+ *          **Compile-time control:**
+ *          - Define DMK_ENABLE_PROFILING before including this header, or
+ *          - Pass -DDMK_ENABLE_PROFILING=ON to CMake.
+ *
+ *          **Performance characteristics (when enabled):**
+ *          - ~50 ns per scoped measurement (two QPC calls + one atomic store)
+ *          - Fixed-size ring buffer (no heap allocations on the hot path)
+ *          - Lock-free recording from multiple threads
+ *
+ *          **Usage:**
+ *          @code
+ *          void on_camera_update(void* camera_ptr) {
+ *              DMK_PROFILE_SCOPE("camera_update");
+ *              // ... hook logic ...
+ *          }
+ *
+ *          // Export after a profiling session
+ *          DMKProfiler::get_instance().export_to_file("profile.json");
+ *          @endcode
+ */
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#ifdef DMK_ENABLE_PROFILING
+
+// Scoped timing measurement. Name must be a string literal.
+#define DMK_PROFILE_SCOPE(name) \
+    ::DetourModKit::ScopedProfile dmk_scoped_profile_##__LINE__{name}
+
+// Scoped timing using the enclosing function name.
+#define DMK_PROFILE_FUNCTION() \
+    ::DetourModKit::ScopedProfile dmk_scoped_profile_func_{__FUNCTION__}
+
+#else
+
+#define DMK_PROFILE_SCOPE(name) ((void)0)
+#define DMK_PROFILE_FUNCTION()  ((void)0)
+
+#endif // DMK_ENABLE_PROFILING
+
+namespace DetourModKit
+{
+    /**
+     * @brief A single timing sample recorded by the profiler.
+     * @details Packed to 24 bytes for cache-friendly storage. The ring buffer
+     *          holds contiguous ProfileSample arrays for predictable access patterns.
+     */
+    struct ProfileSample
+    {
+        const char *name{nullptr}; ///< Non-owning pointer to a string literal.
+        int64_t start_ticks{0};    ///< QPC tick count at scope entry.
+        uint32_t duration_us{0};   ///< Duration in microseconds (max ~71 minutes).
+        uint32_t thread_id{0};     ///< Win32 thread ID of the recording thread.
+    };
+
+    /**
+     * @brief Lock-free ring buffer profiler with Chrome Tracing JSON export.
+     *
+     * @details Uses a fixed-capacity power-of-2 ring buffer. Recording is lock-free
+     *          via a single atomic fetch_add on the write position. When the buffer
+     *          wraps, oldest samples are silently overwritten (no allocation, no lock).
+     *
+     *          The profiler is a singleton. All public methods are safe to call from
+     *          multiple threads. Export methods take a consistent snapshot by reading
+     *          the current write position and walking backwards.
+     *
+     * **Thread safety:**
+     * - `record()`: lock-free (atomic fetch_add)
+     * - `reset()`: safe when no concurrent `record()` calls are in flight
+     * - `export_chrome_json()` / `export_to_file()`: safe to call concurrently
+     *   with `record()` (snapshot-based); exported data may include partial
+     *   samples from in-flight scopes
+     */
+    class Profiler
+    {
+    public:
+        /// Default ring buffer capacity (must be a power of 2).
+        static constexpr size_t DEFAULT_CAPACITY{65536};
+
+        Profiler(const Profiler &) = delete;
+        Profiler &operator=(const Profiler &) = delete;
+        Profiler(Profiler &&) = delete;
+        Profiler &operator=(Profiler &&) = delete;
+
+        /// Returns the global profiler singleton.
+        [[nodiscard]] static Profiler &get_instance() noexcept;
+
+        /**
+         * @brief Records a completed timing sample.
+         * @param name Non-owning pointer to a string literal (must outlive the profiler).
+         * @param start_ticks QPC tick count at scope entry.
+         * @param end_ticks QPC tick count at scope exit.
+         * @param thread_id Win32 thread ID of the recording thread.
+         * @note Lock-free. Safe to call from any thread at any time.
+         */
+        void record(const char *name, int64_t start_ticks, int64_t end_ticks,
+                    uint32_t thread_id) noexcept;
+
+        /**
+         * @brief Resets the profiler, discarding all recorded samples.
+         * @note Not safe to call while other threads are calling record().
+         *       Intended for use between profiling sessions.
+         */
+        void reset() noexcept;
+
+        /**
+         * @brief Exports recorded samples as a Chrome Tracing JSON string.
+         * @details Output conforms to the Chrome Trace Event Format (array form).
+         *          Open the result in chrome://tracing or https://ui.perfetto.dev.
+         * @return JSON string containing all recorded samples.
+         */
+        [[nodiscard]] std::string export_chrome_json() const;
+
+        /**
+         * @brief Exports recorded samples to a JSON file on disk.
+         * @param path File path to write (created or overwritten).
+         * @return true on success, false on I/O failure.
+         */
+        [[nodiscard]] bool export_to_file(std::string_view path) const;
+
+        /// Returns the number of samples recorded (may exceed capacity due to wrapping).
+        [[nodiscard]] size_t total_samples_recorded() const noexcept;
+
+        /// Returns the number of valid samples available for export (min of recorded, capacity).
+        [[nodiscard]] size_t available_samples() const noexcept;
+
+        /// Returns the ring buffer capacity.
+        [[nodiscard]] size_t capacity() const noexcept;
+
+        /// Returns the QPC frequency (ticks per second) used for timing.
+        [[nodiscard]] int64_t qpc_frequency() const noexcept;
+
+    private:
+        Profiler();
+        ~Profiler() = default;
+
+        std::unique_ptr<ProfileSample[]> buffer_;
+        size_t capacity_;
+        size_t mask_; // capacity_ - 1 for power-of-2 index wrapping
+        alignas(64) std::atomic<size_t> write_pos_{0};
+        int64_t qpc_frequency_{0};
+    };
+
+    /**
+     * @brief RAII scoped profiler that records timing on destruction.
+     *
+     * @details Captures QPC tick count and thread ID in the constructor.
+     *          On destruction, computes duration and records the sample in the
+     *          global Profiler ring buffer.
+     *
+     *          This class is only active when DMK_ENABLE_PROFILING is defined.
+     *          Use the DMK_PROFILE_SCOPE() macro instead of constructing directly.
+     */
+    class ScopedProfile
+    {
+    public:
+        /**
+         * @brief Begins a profiling scope.
+         * @param name Non-owning pointer to a string literal. Must outlive this object.
+         */
+        explicit ScopedProfile(const char *name) noexcept;
+        ~ScopedProfile() noexcept;
+
+        ScopedProfile(const ScopedProfile &) = delete;
+        ScopedProfile &operator=(const ScopedProfile &) = delete;
+        ScopedProfile(ScopedProfile &&) = delete;
+        ScopedProfile &operator=(ScopedProfile &&) = delete;
+
+    private:
+        const char *name_;
+        int64_t start_ticks_;
+        uint32_t thread_id_;
+    };
+
+} // namespace DetourModKit
+
+#endif // DETOURMODKIT_PROFILER_HPP

--- a/include/DetourModKit/profiler.hpp
+++ b/include/DetourModKit/profiler.hpp
@@ -40,13 +40,17 @@
 
 #ifdef DMK_ENABLE_PROFILING
 
+// Two-level indirection so __LINE__ expands before token pasting.
+#define DMK_CONCAT_IMPL(a, b) a##b
+#define DMK_CONCAT(a, b) DMK_CONCAT_IMPL(a, b)
+
 // Scoped timing measurement. Name must be a string literal.
 #define DMK_PROFILE_SCOPE(name) \
-    ::DetourModKit::ScopedProfile dmk_scoped_profile_##__LINE__{name}
+    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_, __LINE__){name}
 
 // Scoped timing using the enclosing function name.
 #define DMK_PROFILE_FUNCTION() \
-    ::DetourModKit::ScopedProfile dmk_scoped_profile_func_{__FUNCTION__}
+    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_func_, __LINE__){__FUNCTION__}
 
 #else
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1,0 +1,161 @@
+/**
+ * @file profiler.cpp
+ * @brief Implementation of the lock-free ring buffer profiler with Chrome Tracing export.
+ */
+
+#include "DetourModKit/profiler.hpp"
+
+#include <windows.h>
+#include <algorithm>
+#include <cstdio>
+#include <format>
+#include <memory>
+#include <string>
+
+namespace DetourModKit
+{
+    // --- Profiler ---
+
+    Profiler::Profiler()
+        : buffer_(std::make_unique<ProfileSample[]>(DEFAULT_CAPACITY)),
+          capacity_(DEFAULT_CAPACITY),
+          mask_(DEFAULT_CAPACITY - 1)
+    {
+        LARGE_INTEGER freq;
+        QueryPerformanceFrequency(&freq);
+        qpc_frequency_ = freq.QuadPart;
+    }
+
+    Profiler &Profiler::get_instance() noexcept
+    {
+        static Profiler instance;
+        return instance;
+    }
+
+    void Profiler::record(const char *name, int64_t start_ticks, int64_t end_ticks,
+                          uint32_t thread_id) noexcept
+    {
+        const int64_t delta_ticks = end_ticks - start_ticks;
+
+        // Convert ticks to microseconds: (delta * 1'000'000) / frequency.
+        // Use 64-bit intermediate to avoid overflow for deltas up to ~9200 seconds
+        // at a 10 MHz QPC frequency (common on modern hardware).
+        const auto duration_us = static_cast<uint32_t>(
+            std::min<int64_t>((delta_ticks * 1'000'000) / qpc_frequency_,
+                              static_cast<int64_t>(UINT32_MAX)));
+
+        const size_t idx = write_pos_.fetch_add(1, std::memory_order_relaxed) & mask_;
+
+        auto &sample = buffer_[idx];
+        sample.name = name;
+        sample.start_ticks = start_ticks;
+        sample.duration_us = duration_us;
+        sample.thread_id = thread_id;
+    }
+
+    void Profiler::reset() noexcept
+    {
+        write_pos_.store(0, std::memory_order_relaxed);
+        std::fill_n(buffer_.get(), capacity_, ProfileSample{});
+    }
+
+    std::string Profiler::export_chrome_json() const
+    {
+        const size_t total = write_pos_.load(std::memory_order_relaxed);
+        const size_t count = std::min(total, capacity_);
+
+        if (count == 0)
+        {
+            return "[]";
+        }
+
+        // Determine start index: if the buffer has wrapped, start from the
+        // oldest surviving sample; otherwise start from 0.
+        const size_t start_idx = (total > capacity_) ? (total & mask_) : 0;
+
+        // Pre-allocate: ~120 bytes per JSON event is a reasonable estimate.
+        std::string json;
+        json.reserve(count * 120 + 4);
+        json += "[\n";
+
+        // QPC frequency for converting start_ticks to microseconds
+        const double ticks_to_us = 1'000'000.0 / static_cast<double>(qpc_frequency_);
+
+        bool first = true;
+        for (size_t i = 0; i < count; ++i)
+        {
+            const auto &s = buffer_[(start_idx + i) & mask_];
+            if (s.name == nullptr)
+            {
+                continue;
+            }
+
+            if (!first)
+            {
+                json += ",\n";
+            }
+            first = false;
+
+            // Chrome Trace Event Format: "X" = complete event (has duration)
+            const double ts = static_cast<double>(s.start_ticks) * ticks_to_us;
+            json += std::format(
+                R"({{"name":"{}","ph":"X","ts":{:.1f},"dur":{},"pid":1,"tid":{}}})",
+                s.name, ts, s.duration_us, s.thread_id);
+        }
+
+        json += "\n]";
+        return json;
+    }
+
+    bool Profiler::export_to_file(std::string_view path) const
+    {
+        const std::string json = export_chrome_json();
+        const std::string path_str(path);
+        std::FILE *fp = std::fopen(path_str.c_str(), "wb");
+        if (fp == nullptr)
+        {
+            return false;
+        }
+        const size_t written = std::fwrite(json.data(), 1, json.size(), fp);
+        std::fclose(fp);
+        return written == json.size();
+    }
+
+    size_t Profiler::total_samples_recorded() const noexcept
+    {
+        return write_pos_.load(std::memory_order_relaxed);
+    }
+
+    size_t Profiler::available_samples() const noexcept
+    {
+        return std::min(write_pos_.load(std::memory_order_relaxed), capacity_);
+    }
+
+    size_t Profiler::capacity() const noexcept
+    {
+        return capacity_;
+    }
+
+    int64_t Profiler::qpc_frequency() const noexcept
+    {
+        return qpc_frequency_;
+    }
+
+    // --- ScopedProfile ---
+
+    ScopedProfile::ScopedProfile(const char *name) noexcept
+        : name_(name), thread_id_(GetCurrentThreadId())
+    {
+        LARGE_INTEGER ticks;
+        QueryPerformanceCounter(&ticks);
+        start_ticks_ = ticks.QuadPart;
+    }
+
+    ScopedProfile::~ScopedProfile() noexcept
+    {
+        LARGE_INTEGER ticks;
+        QueryPerformanceCounter(&ticks);
+        Profiler::get_instance().record(name_, start_ticks_, ticks.QuadPart, thread_id_);
+    }
+
+} // namespace DetourModKit

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -53,6 +53,10 @@ namespace DetourModKit
         sample.thread_id = thread_id;
     }
 
+    // Caller must ensure no concurrent record() calls are in flight.
+    // There is no runtime guard because adding an atomic "recording active"
+    // counter would penalize every record() call on the hot path for a
+    // contract that is only relevant during session boundaries.
     void Profiler::reset() noexcept
     {
         write_pos_.store(0, std::memory_order_relaxed);
@@ -111,13 +115,15 @@ namespace DetourModKit
     {
         const std::string json = export_chrome_json();
         const std::string path_str(path);
-        std::FILE *fp = std::fopen(path_str.c_str(), "wb");
-        if (fp == nullptr)
+
+        const auto closer = [](std::FILE *f) { std::fclose(f); };
+        std::unique_ptr<std::FILE, decltype(closer)> fp(
+            std::fopen(path_str.c_str(), "wb"), closer);
+        if (!fp)
         {
             return false;
         }
-        const size_t written = std::fwrite(json.data(), 1, json.size(), fp);
-        std::fclose(fp);
+        const size_t written = std::fwrite(json.data(), 1, json.size(), fp.get());
         return written == json.size();
     }
 

--- a/tests/test_profiler.cpp
+++ b/tests/test_profiler.cpp
@@ -1,0 +1,337 @@
+#include <gtest/gtest.h>
+
+#include "DetourModKit/profiler.hpp"
+
+#include <windows.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace DetourModKit;
+
+// --- Profiler singleton ---
+
+TEST(ProfilerTest, GetInstance_ReturnsSameInstance)
+{
+    auto &a = Profiler::get_instance();
+    auto &b = Profiler::get_instance();
+    EXPECT_EQ(&a, &b);
+}
+
+TEST(ProfilerTest, DefaultCapacity_IsPowerOfTwo)
+{
+    const auto &profiler = Profiler::get_instance();
+    const size_t cap = profiler.capacity();
+    EXPECT_GT(cap, 0u);
+    EXPECT_EQ(cap & (cap - 1), 0u); // power of 2
+}
+
+TEST(ProfilerTest, QpcFrequency_IsPositive)
+{
+    const auto &profiler = Profiler::get_instance();
+    EXPECT_GT(profiler.qpc_frequency(), 0);
+}
+
+// --- Recording ---
+
+class ProfilerRecordTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        Profiler::get_instance().reset();
+    }
+    void TearDown() override
+    {
+        Profiler::get_instance().reset();
+    }
+};
+
+TEST_F(ProfilerRecordTest, Record_IncrementsSampleCount)
+{
+    auto &profiler = Profiler::get_instance();
+    EXPECT_EQ(profiler.total_samples_recorded(), 0u);
+
+    LARGE_INTEGER start, end;
+    QueryPerformanceCounter(&start);
+    QueryPerformanceCounter(&end);
+
+    profiler.record("test_scope", start.QuadPart, end.QuadPart, 42);
+    EXPECT_EQ(profiler.total_samples_recorded(), 1u);
+    EXPECT_EQ(profiler.available_samples(), 1u);
+}
+
+TEST_F(ProfilerRecordTest, Record_MultipleSamples)
+{
+    auto &profiler = Profiler::get_instance();
+
+    LARGE_INTEGER tick;
+    QueryPerformanceCounter(&tick);
+
+    for (int i = 0; i < 100; ++i)
+    {
+        profiler.record("loop_iter", tick.QuadPart, tick.QuadPart + 1000, 1);
+    }
+    EXPECT_EQ(profiler.total_samples_recorded(), 100u);
+    EXPECT_EQ(profiler.available_samples(), 100u);
+}
+
+TEST_F(ProfilerRecordTest, Reset_ClearsAllSamples)
+{
+    auto &profiler = Profiler::get_instance();
+
+    LARGE_INTEGER tick;
+    QueryPerformanceCounter(&tick);
+
+    profiler.record("before_reset", tick.QuadPart, tick.QuadPart + 100, 1);
+    EXPECT_EQ(profiler.total_samples_recorded(), 1u);
+
+    profiler.reset();
+    EXPECT_EQ(profiler.total_samples_recorded(), 0u);
+    EXPECT_EQ(profiler.available_samples(), 0u);
+}
+
+TEST_F(ProfilerRecordTest, RingBuffer_WrapsAtCapacity)
+{
+    auto &profiler = Profiler::get_instance();
+    const size_t cap = profiler.capacity();
+
+    LARGE_INTEGER tick;
+    QueryPerformanceCounter(&tick);
+
+    // Fill buffer + 10 extra to trigger wrap
+    for (size_t i = 0; i < cap + 10; ++i)
+    {
+        profiler.record("wrap_test", tick.QuadPart, tick.QuadPart + 1, 1);
+    }
+
+    EXPECT_EQ(profiler.total_samples_recorded(), cap + 10);
+    EXPECT_EQ(profiler.available_samples(), cap);
+}
+
+// --- ScopedProfile ---
+
+TEST_F(ProfilerRecordTest, ScopedProfile_RecordsSample)
+{
+    auto &profiler = Profiler::get_instance();
+
+    {
+        ScopedProfile sp("scoped_test");
+        // Simulate some work
+        volatile int sum = 0;
+        for (int i = 0; i < 1000; ++i)
+        {
+            sum += i;
+        }
+        (void)sum;
+    }
+
+    EXPECT_EQ(profiler.total_samples_recorded(), 1u);
+}
+
+TEST_F(ProfilerRecordTest, ScopedProfile_MeasuresPositiveDuration)
+{
+    auto &profiler = Profiler::get_instance();
+
+    {
+        ScopedProfile sp("duration_test");
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    ASSERT_EQ(profiler.total_samples_recorded(), 1u);
+
+    // Export and verify the sample has a positive duration
+    const std::string json = profiler.export_chrome_json();
+    EXPECT_NE(json.find("\"dur\":"), std::string::npos);
+    // Duration should be >= 1000 us (1 ms sleep)
+    EXPECT_NE(json.find("duration_test"), std::string::npos);
+}
+
+// --- Chrome Tracing JSON export ---
+
+TEST_F(ProfilerRecordTest, ExportChromeJson_EmptyBuffer)
+{
+    const auto &profiler = Profiler::get_instance();
+    const std::string json = profiler.export_chrome_json();
+    EXPECT_EQ(json, "[]");
+}
+
+TEST_F(ProfilerRecordTest, ExportChromeJson_SingleSample)
+{
+    auto &profiler = Profiler::get_instance();
+
+    LARGE_INTEGER tick;
+    QueryPerformanceCounter(&tick);
+    profiler.record("single", tick.QuadPart, tick.QuadPart + 10000, 99);
+
+    const std::string json = profiler.export_chrome_json();
+
+    // Verify required Chrome Trace Event fields
+    EXPECT_NE(json.find("\"name\":\"single\""), std::string::npos);
+    EXPECT_NE(json.find("\"ph\":\"X\""), std::string::npos);
+    EXPECT_NE(json.find("\"ts\":"), std::string::npos);
+    EXPECT_NE(json.find("\"dur\":"), std::string::npos);
+    EXPECT_NE(json.find("\"tid\":99"), std::string::npos);
+    EXPECT_NE(json.find("\"pid\":1"), std::string::npos);
+}
+
+TEST_F(ProfilerRecordTest, ExportChromeJson_MultipleSamples_ValidArray)
+{
+    auto &profiler = Profiler::get_instance();
+
+    LARGE_INTEGER tick;
+    QueryPerformanceCounter(&tick);
+
+    profiler.record("first", tick.QuadPart, tick.QuadPart + 100, 1);
+    profiler.record("second", tick.QuadPart + 200, tick.QuadPart + 400, 2);
+
+    const std::string json = profiler.export_chrome_json();
+
+    // Must start with [ and end with ]
+    EXPECT_EQ(json.front(), '[');
+    EXPECT_EQ(json.back(), ']');
+
+    // Both samples present
+    EXPECT_NE(json.find("\"name\":\"first\""), std::string::npos);
+    EXPECT_NE(json.find("\"name\":\"second\""), std::string::npos);
+}
+
+// --- File export ---
+
+TEST_F(ProfilerRecordTest, ExportToFile_WritesValidFile)
+{
+    auto &profiler = Profiler::get_instance();
+
+    LARGE_INTEGER tick;
+    QueryPerformanceCounter(&tick);
+    profiler.record("file_test", tick.QuadPart, tick.QuadPart + 5000, 1);
+
+    const std::string path = std::format("dmk_profiler_test_{}.json", _getpid());
+    const bool ok = profiler.export_to_file(path);
+    EXPECT_TRUE(ok);
+
+    // Read back and verify
+    std::FILE *fp = std::fopen(path.c_str(), "rb");
+    ASSERT_NE(fp, nullptr);
+    std::fseek(fp, 0, SEEK_END);
+    const long size = std::ftell(fp);
+    std::fseek(fp, 0, SEEK_SET);
+    std::string content(static_cast<size_t>(size), '\0');
+    (void)std::fread(content.data(), 1, static_cast<size_t>(size), fp);
+    std::fclose(fp);
+    std::remove(path.c_str());
+
+    EXPECT_NE(content.find("file_test"), std::string::npos);
+    EXPECT_EQ(content.front(), '[');
+}
+
+TEST_F(ProfilerRecordTest, ExportToFile_InvalidPath_ReturnsFalse)
+{
+    const auto &profiler = Profiler::get_instance();
+    const bool ok = profiler.export_to_file("Z:\\nonexistent\\dir\\file.json");
+    EXPECT_FALSE(ok);
+}
+
+// --- Concurrent recording ---
+
+TEST_F(ProfilerRecordTest, ConcurrentRecord_NoDataRace)
+{
+    auto &profiler = Profiler::get_instance();
+    constexpr int threads = 8;
+    constexpr int samples_per_thread = 1000;
+
+    std::vector<std::thread> workers;
+    workers.reserve(threads);
+
+    for (int t = 0; t < threads; ++t)
+    {
+        workers.emplace_back([&profiler]() {
+            LARGE_INTEGER tick;
+            for (int i = 0; i < samples_per_thread; ++i)
+            {
+                QueryPerformanceCounter(&tick);
+                profiler.record("concurrent", tick.QuadPart,
+                                tick.QuadPart + 100, GetCurrentThreadId());
+            }
+        });
+    }
+
+    for (auto &w : workers)
+    {
+        w.join();
+    }
+
+    EXPECT_EQ(profiler.total_samples_recorded(),
+              static_cast<size_t>(threads * samples_per_thread));
+}
+
+TEST_F(ProfilerRecordTest, ConcurrentScopedProfile_NoDataRace)
+{
+    auto &profiler = Profiler::get_instance();
+    constexpr int threads = 4;
+    constexpr int scopes_per_thread = 500;
+
+    std::vector<std::thread> workers;
+    workers.reserve(threads);
+
+    for (int t = 0; t < threads; ++t)
+    {
+        workers.emplace_back([]() {
+            for (int i = 0; i < scopes_per_thread; ++i)
+            {
+                ScopedProfile sp("concurrent_scope");
+            }
+        });
+    }
+
+    for (auto &w : workers)
+    {
+        w.join();
+    }
+
+    EXPECT_EQ(profiler.total_samples_recorded(),
+              static_cast<size_t>(threads * scopes_per_thread));
+}
+
+// --- Macro tests ---
+
+#ifdef DMK_ENABLE_PROFILING
+
+TEST_F(ProfilerRecordTest, ProfileScopeMacro_RecordsSample)
+{
+    auto &profiler = Profiler::get_instance();
+
+    {
+        DMK_PROFILE_SCOPE("macro_test");
+    }
+
+    EXPECT_EQ(profiler.total_samples_recorded(), 1u);
+}
+
+TEST_F(ProfilerRecordTest, ProfileFunctionMacro_RecordsSample)
+{
+    auto &profiler = Profiler::get_instance();
+
+    {
+        DMK_PROFILE_FUNCTION();
+    }
+
+    EXPECT_EQ(profiler.total_samples_recorded(), 1u);
+}
+
+#else
+
+TEST_F(ProfilerRecordTest, ProfileScopeMacro_IsNoOpWhenDisabled)
+{
+    auto &profiler = Profiler::get_instance();
+
+    {
+        DMK_PROFILE_SCOPE("should_not_record");
+    }
+
+    // Macros expand to ((void)0), so nothing is recorded
+    EXPECT_EQ(profiler.total_samples_recorded(), 0u);
+}
+
+#endif // DMK_ENABLE_PROFILING

--- a/tests/test_profiler.cpp
+++ b/tests/test_profiler.cpp
@@ -216,6 +216,7 @@ TEST_F(ProfilerRecordTest, ExportToFile_WritesValidFile)
     ASSERT_NE(fp, nullptr);
     std::fseek(fp, 0, SEEK_END);
     const long size = std::ftell(fp);
+    ASSERT_GE(size, 0L) << "ftell failed";
     std::fseek(fp, 0, SEEK_SET);
     std::string content(static_cast<size_t>(size), '\0');
     (void)std::fread(content.data(), 1, static_cast<size_t>(size), fp);


### PR DESCRIPTION
## Summary

Adds an opt-in profiling module for measuring hook and subsystem timing in game mods.

- Lock-free ring buffer (64K samples, ~1.5 MB) with atomic `fetch_add` recording
- RAII `ScopedProfile` timer (~50 ns overhead per scope when enabled)
- `DMK_PROFILE_SCOPE("name")` / `DMK_PROFILE_FUNCTION()` macros that expand to `((void)0)` when `DMK_ENABLE_PROFILING` is OFF (zero cost)
- Chrome Tracing JSON export for `chrome://tracing` and Perfetto
- 17 new tests (singleton, recording, ring buffer wrap, JSON export, file export, concurrent access)
- `DMK_ENABLE_PROFILING` CMake option (OFF by default, propagated as PUBLIC compile definition)

## Test plan

- [x] `mingw-debug`: 796/796 tests pass (779 existing + 17 new)
- [x] `msvc-debug`: CI green
- [x] Profiler macros are no-ops when `DMK_ENABLE_PROFILING` is OFF
- [x] Live demo: 185 samples across 2 threads, valid Chrome Tracing JSON output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced opt-in profiling instrumentation for performance timing measurement
  * Added ability to export profiling data to Chrome Trace JSON and Perfetto formats
  * Enabled via CMake configuration flag

* **Documentation**
  * Updated build instructions with profiling enablement guide
  * Added profiler feature documentation and usage examples to README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->