### PR TITLE
test: improve branch coverage across modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,7 @@ hook_manager.with_inline_hook("camera_update", [](InlineHook &hook) {
 
 - **Framework:** GoogleTest. Test entry point is `tests/main.cpp`.
 - **One test file per module:** `tests/test_<module>.cpp` mirrors `src/<module>.cpp`.
+- **Shutdown orchestration tests:** `tests/test_shutdown.cpp` tests the `DMK_Shutdown()` function from `DetourModKit.hpp`, verifying idempotent shutdown, hot-reload re-initialization, and correct teardown ordering across all subsystems.
 - **Integration tests:** `tests/test_hook_integration.cpp` tests cross-module hooking against `tests/fixtures/hook_target_lib.cpp` (built as a DLL). The DLL exports `extern "C"` functions with volatile magic constants for stable AOB patterns. Includes hot-reload integration tests that exercise full hook/teardown/re-hook cycles, multi-type reload, enable/disable toggling, and repeated cycle stress.
 - **Platform tests:** `tests/test_platform.cpp` tests internal loader-lock detection and module pinning utilities from `src/platform.hpp`.
 - **Test fixture pattern:** Each suite uses a `::testing::Test` subclass with `SetUp()`/`TearDown()` for temp file cleanup. Temp file paths must include the process ID (`_getpid()`) and a counter to avoid collisions when CTest runs tests in parallel as separate processes.

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -277,19 +277,20 @@ tests/
 ├── fixtures/
 │   └── hook_target_lib.cpp     # Fixture DLL (exported functions for integration tests)
 ├── test_async_logger.cpp       # Async logger tests
-├── test_hook_manager.cpp       # Hook manager unit tests
-├── test_hook_integration.cpp   # Cross-module hook integration tests
-├── test_input.cpp              # Input system tests
-├── test_memory.cpp             # Memory utilities tests
-├── test_scanner.cpp            # AOB scanner tests
-├── test_logger.cpp             # Logger tests
 ├── test_config.cpp             # Configuration tests
 ├── test_event_dispatcher.cpp   # Event dispatcher tests
-├── test_format.cpp             # Format utilities tests
 ├── test_filesystem.cpp         # Filesystem tests
+├── test_format.cpp             # Format utilities tests
+├── test_hook_integration.cpp   # Cross-module hook integration tests
+├── test_hook_manager.cpp       # Hook manager unit tests
+├── test_input.cpp              # Input system and input code tests
+├── test_logger.cpp             # Logger tests
 ├── test_math.cpp               # Math utilities tests
-├── test_platform.cpp           # Platform-specific tests (loader lock, module pinning)
+├── test_memory.cpp             # Memory utilities tests
+├── test_platform.cpp           # Platform detection and version macro tests
 ├── test_profiler.cpp           # Profiler tests
+├── test_scanner.cpp            # AOB scanner tests
+├── test_shutdown.cpp           # DMK_Shutdown orchestration tests
 ├── test_string.cpp             # String utilities tests
 └── test_win_file_stream.cpp    # Win32 file stream tests
 
@@ -335,10 +336,3 @@ g++ -o test_compile.exe docs/tests/test_compile.cpp
 5. **Guard platform-specific tests**: Use `GTEST_SKIP()` for architecture-dependent logic.
 6. **Clean rebuild for coverage**: After major changes, delete `.gcda` files or rebuild from scratch.
 7. **Follow naming conventions**: `s_` for file-scope statics, `m_` for members, `snake_case` for functions.
-
----
-
-## Related Documentation
-
-- [Project README](../../README.md) - Overview, build instructions, and API reference
-- [Hot-Reload Guide](../hot-reload/README.md) - Two-DLL hot-reload architecture for iterative mod development

--- a/tests/test_event_dispatcher.cpp
+++ b/tests/test_event_dispatcher.cpp
@@ -438,3 +438,62 @@ TEST(EventDispatcherTest, SubscriptionsInVector_CleanupOnClear)
     subs.clear();
     EXPECT_EQ(dispatcher.subscriber_count(), 0u);
 }
+
+TEST(EventDispatcherTest, Emit_PropagatesHandlerException)
+{
+    EventDispatcher<SimpleEvent> dispatcher;
+
+    auto sub = dispatcher.subscribe([](const SimpleEvent &) {
+        throw std::runtime_error("handler error");
+    });
+
+    EXPECT_THROW(dispatcher.emit(SimpleEvent{1}), std::runtime_error);
+}
+
+TEST(EventDispatcherTest, EmitSafe_AllHandlersRunDespiteMultipleExceptions)
+{
+    EventDispatcher<SimpleEvent> dispatcher;
+    int success_count = 0;
+
+    auto sub1 = dispatcher.subscribe([](const SimpleEvent &) {
+        throw std::runtime_error("error 1");
+    });
+    auto sub2 = dispatcher.subscribe([&success_count](const SimpleEvent &) {
+        ++success_count;
+    });
+    auto sub3 = dispatcher.subscribe([](const SimpleEvent &) {
+        throw std::logic_error("error 2");
+    });
+    auto sub4 = dispatcher.subscribe([&success_count](const SimpleEvent &) {
+        ++success_count;
+    });
+
+    // emit_safe must not propagate; all non-throwing handlers must execute
+    dispatcher.emit_safe(SimpleEvent{1});
+    EXPECT_EQ(success_count, 2);
+}
+
+TEST(EventDispatcherTest, UnsubscribeInsideHandler_SucceedsOnDestruction)
+{
+    // Verifies that a subscription whose reset() was deferred during emit
+    // is properly cleaned up when the Subscription object is destroyed.
+    EventDispatcher<SimpleEvent> dispatcher;
+    int call_count = 0;
+
+    {
+        Subscription held_sub;
+        held_sub = dispatcher.subscribe([&](const SimpleEvent &) {
+            ++call_count;
+            // Deferred: reset() inside handler is silently skipped
+            held_sub.reset();
+        });
+
+        dispatcher.emit(SimpleEvent{1});
+        EXPECT_EQ(call_count, 1);
+        EXPECT_EQ(dispatcher.subscriber_count(), 1u);
+        // held_sub destroyed here -- destructor retries reset() outside handler
+    }
+
+    EXPECT_EQ(dispatcher.subscriber_count(), 0u);
+}
+

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -2109,3 +2109,170 @@ TEST_F(HookManagerTest, VmtHook_ConcurrentCreateAndShutdown)
     // the test-local targets are destroyed.
     hook_manager_->remove_all_vmt_hooks();
 }
+
+TEST_F(HookManagerTest, ApplyVmtHook_NotFoundName_ReturnsFalse)
+{
+    int dummy_object = 0;
+    EXPECT_FALSE(hook_manager_->apply_vmt_hook("NonExistentVmt", &dummy_object));
+}
+
+TEST_F(HookManagerTest, RemoveVmtFromObject_NotFoundName_ReturnsFalse)
+{
+    int dummy_object = 0;
+    EXPECT_FALSE(hook_manager_->remove_vmt_from_object("NonExistentVmt", &dummy_object));
+}
+
+TEST_F(HookManagerTest, RemoveAllVmtHooks_WhenEmpty_NoOp)
+{
+    EXPECT_NO_THROW(hook_manager_->remove_all_vmt_hooks());
+    EXPECT_TRUE(hook_manager_->get_vmt_hook_names().empty());
+}
+
+TEST_F(HookManagerTest, GetHookIds_FilterByActive_ReturnsMatching)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "ActiveFilterHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    auto active_ids = hook_manager_->get_hook_ids(HookStatus::Active);
+    ASSERT_FALSE(active_ids.empty());
+
+    bool found = false;
+    for (const auto &id : active_ids)
+    {
+        if (id == "ActiveFilterHook")
+        {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST_F(HookManagerTest, GetHookIds_FilterByDisabled_AfterDisable)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "DisableFilterHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    EXPECT_TRUE(hook_manager_->disable_hook("DisableFilterHook").has_value());
+
+    auto disabled_ids = hook_manager_->get_hook_ids(HookStatus::Disabled);
+    ASSERT_FALSE(disabled_ids.empty());
+
+    bool found = false;
+    for (const auto &id : disabled_ids)
+    {
+        if (id == "DisableFilterHook")
+        {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST_F(HookManagerTest, ShutdownThenEnable_ReturnsNotFound)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "ShutEnableHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    hook_manager_->shutdown();
+
+    auto enable_result = hook_manager_->enable_hook("ShutEnableHook");
+    ASSERT_FALSE(enable_result.has_value());
+    EXPECT_EQ(enable_result.error(), HookError::HookNotFound);
+}
+
+TEST_F(HookManagerTest, ShutdownThenDisable_ReturnsNotFound)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "ShutDisableHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    hook_manager_->shutdown();
+
+    auto disable_result = hook_manager_->disable_hook("ShutDisableHook");
+    ASSERT_FALSE(disable_result.has_value());
+    EXPECT_EQ(disable_result.error(), HookError::HookNotFound);
+}
+
+TEST_F(HookManagerTest, ShutdownThenRemove_ReturnsNotFound)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "ShutRemoveHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    hook_manager_->shutdown();
+
+    auto remove_result = hook_manager_->remove_hook("ShutRemoveHook");
+    ASSERT_FALSE(remove_result.has_value());
+    EXPECT_EQ(remove_result.error(), HookError::HookNotFound);
+}
+
+TEST_F(HookManagerTest, ShutdownThenGetStatus_ReturnsNullopt)
+{
+    void *tramp = nullptr;
+    auto result = hook_manager_->create_inline_hook(
+        "ShutStatusHook",
+        reinterpret_cast<uintptr_t>(&real_hook_target_add),
+        reinterpret_cast<void *>(&real_hook_detour_add),
+        &tramp);
+    ASSERT_TRUE(result.has_value());
+
+    hook_manager_->shutdown();
+
+    auto status = hook_manager_->get_hook_status("ShutStatusHook");
+    EXPECT_FALSE(status.has_value());
+}
+
+TEST(HookErrorStringTest, ErrorToString_InvalidEnum_ReturnsInvalidCode)
+{
+    auto result = Hook::error_to_string(static_cast<HookError>(9999));
+    EXPECT_EQ(result, "Invalid error code");
+}
+
+TEST(HookStatusStringTest, StatusToString_InvalidEnum_ReturnsUnknown)
+{
+    auto result = Hook::status_to_string(static_cast<HookStatus>(9999));
+    EXPECT_EQ(result, "Unknown");
+}
+
+TEST_F(HookManagerTest, RemoveAllHooks_WithOnlyVmtHooks)
+{
+    struct FakeVtable
+    {
+        void *methods[4]{};
+    };
+    FakeVtable vtable{};
+    void *vptr = &vtable;
+
+    auto vmt_result = hook_manager_->create_vmt_hook("VmtOnlyHook", &vptr);
+    ASSERT_TRUE(vmt_result.has_value());
+    EXPECT_FALSE(hook_manager_->get_vmt_hook_names().empty());
+
+    hook_manager_->remove_all_hooks();
+
+    EXPECT_TRUE(hook_manager_->get_vmt_hook_names().empty());
+}

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <stdexcept>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "DetourModKit/input.hpp"
@@ -1610,4 +1611,75 @@ TEST(InputStringTest, InputSourceToString_IsNoexcept)
 {
     static_assert(noexcept(input_source_to_string(InputSource::Keyboard)));
     static_assert(noexcept(input_source_to_string(InputSource::Gamepad)));
+}
+
+// --- InputCodeHash ---
+
+TEST(InputCodeHashTest, DifferentCodesProduceDifferentHashes)
+{
+    InputCodeHash hasher;
+
+    InputCode kb_a = keyboard_key(0x41);
+    InputCode kb_b = keyboard_key(0x42);
+    InputCode mouse_1 = mouse_button(0x01);
+    InputCode gp_a = gamepad_button(GamepadCode::A);
+
+    std::size_t h1 = hasher(kb_a);
+    std::size_t h2 = hasher(kb_b);
+    std::size_t h3 = hasher(mouse_1);
+    std::size_t h4 = hasher(gp_a);
+
+    EXPECT_NE(h1, h2);
+    EXPECT_NE(h1, h3);
+    EXPECT_NE(h1, h4);
+    EXPECT_NE(h2, h3);
+    EXPECT_NE(h2, h4);
+    EXPECT_NE(h3, h4);
+}
+
+TEST(InputCodeHashTest, SameCodeProducesSameHash)
+{
+    InputCodeHash hasher;
+
+    InputCode a1 = keyboard_key(0x41);
+    InputCode a2 = keyboard_key(0x41);
+
+    EXPECT_EQ(hasher(a1), hasher(a2));
+}
+
+TEST(InputCodeHashTest, UsableInUnorderedSet)
+{
+    std::unordered_set<InputCode, InputCodeHash> codes;
+
+    codes.insert(keyboard_key(0x41));
+    codes.insert(keyboard_key(0x42));
+    codes.insert(mouse_button(0x01));
+    codes.insert(gamepad_button(GamepadCode::A));
+    codes.insert(keyboard_key(0x41));
+
+    EXPECT_EQ(codes.size(), 4u);
+    EXPECT_EQ(codes.count(keyboard_key(0x41)), 1u);
+    EXPECT_EQ(codes.count(keyboard_key(0x42)), 1u);
+    EXPECT_EQ(codes.count(mouse_button(0x01)), 1u);
+    EXPECT_EQ(codes.count(gamepad_button(GamepadCode::A)), 1u);
+    EXPECT_NE(codes.find(keyboard_key(0x41)), codes.end());
+    EXPECT_EQ(codes.find(keyboard_key(0x99)), codes.end());
+}
+
+TEST(InputCodeNameTest, FormatInputCode_UnknownMouseCode_FallsBackToHex)
+{
+    InputCode unknown_mouse = mouse_button(0xFE);
+    EXPECT_EQ(format_input_code(unknown_mouse), "0xFE");
+}
+
+TEST(InputSourceTest, UnknownSourceToString)
+{
+    auto unknown = static_cast<InputSource>(999);
+    EXPECT_EQ(input_source_to_string(unknown), "Unknown");
+}
+
+TEST(InputModeTest, UnknownModeToString)
+{
+    auto unknown = static_cast<InputMode>(999);
+    EXPECT_EQ(input_mode_to_string(unknown), "Unknown");
 }

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -939,6 +939,131 @@ TEST_F(LoggerTest, StringToLogLevel_ConcurrentWithConfigure)
     SUCCEED();
 }
 
+TEST_F(LoggerTest, Reconfigure_InvalidPath_KeepsOldFile)
+{
+    Logger &logger = Logger::get_instance();
+    logger.set_log_level(LogLevel::Info);
+
+    logger.info("BEFORE_INVALID_RECONFIG_3k7m");
+    logger.flush();
+
+    logger.reconfigure("BAD", "Z:\\nonexistent\\dir\\test.log", "%Y-%m-%d %H:%M:%S");
+
+    logger.info("AFTER_INVALID_RECONFIG_9p2x");
+    logger.flush();
+
+    std::ifstream ifs(test_log_file_);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("BEFORE_INVALID_RECONFIG_3k7m"), std::string::npos);
+}
+
+TEST_F(LoggerTest, FlushAsync_DrainsPendingMessages)
+{
+    Logger &logger = Logger::get_instance();
+    logger.set_log_level(LogLevel::Info);
+
+    logger.enable_async_mode();
+    ASSERT_TRUE(logger.is_async_mode_enabled());
+
+    for (int i = 0; i < 20; ++i)
+    {
+        logger.info("ASYNC_DRAIN_MSG_{}", i);
+    }
+
+    logger.flush();
+    logger.disable_async_mode();
+
+    std::ifstream ifs(test_log_file_);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("ASYNC_DRAIN_MSG_0"), std::string::npos);
+    EXPECT_NE(content.find("ASYNC_DRAIN_MSG_19"), std::string::npos);
+}
+
+TEST_F(LoggerTest, ShutdownWithAsyncMode_NoHang)
+{
+    Logger &logger = Logger::get_instance();
+    logger.set_log_level(LogLevel::Info);
+
+    logger.enable_async_mode();
+    ASSERT_TRUE(logger.is_async_mode_enabled());
+
+    for (int i = 0; i < 50; ++i)
+    {
+        logger.info("SHUTDOWN_NOHANG_MSG_{}", i);
+    }
+
+    auto start = std::chrono::steady_clock::now();
+    logger.shutdown();
+    auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_LT(elapsed, std::chrono::seconds(5));
+}
+
+TEST_F(LoggerTest, Configure_AbsolutePath_Works)
+{
+    static std::atomic<int> s_abs_counter{0};
+    auto abs_log_file = std::filesystem::temp_directory_path() /
+                        ("test_logger_abspath_" + std::to_string(GetCurrentProcessId()) + "_" + std::to_string(s_abs_counter.fetch_add(1)) + ".log");
+
+    Logger::configure("ABS_TEST", abs_log_file.string(), "%Y-%m-%d %H:%M:%S");
+
+    Logger &logger = Logger::get_instance();
+    logger.set_log_level(LogLevel::Info);
+    logger.info("ABS_PATH_VERIFY_2w5q");
+    logger.flush();
+
+    EXPECT_TRUE(std::filesystem::exists(abs_log_file));
+
+    std::ifstream ifs(abs_log_file);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("ABS_PATH_VERIFY_2w5q"), std::string::npos);
+
+    try
+    {
+        if (std::filesystem::exists(abs_log_file))
+            std::filesystem::remove(abs_log_file);
+    }
+    catch (const std::filesystem::filesystem_error &)
+    {
+    }
+}
+
+TEST_F(LoggerTest, Reconfigure_WhileAsyncMode_Works)
+{
+    Logger &logger = Logger::get_instance();
+    logger.set_log_level(LogLevel::Info);
+
+    logger.enable_async_mode();
+    ASSERT_TRUE(logger.is_async_mode_enabled());
+
+    static std::atomic<int> s_reconfig_counter{0};
+    auto new_file = std::filesystem::temp_directory_path() /
+                    ("test_logger_async_reconfig_" + std::to_string(GetCurrentProcessId()) + "_" + std::to_string(s_reconfig_counter.fetch_add(1)) + ".log");
+
+    logger.reconfigure("ASYNC_RECONFIG", new_file.string(), "%Y-%m-%d %H:%M:%S");
+
+    logger.info("ASYNC_RECONFIG_VERIFY_8n4j");
+    logger.flush();
+    logger.disable_async_mode();
+
+    std::ifstream ifs(new_file);
+    ASSERT_TRUE(ifs.is_open());
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    EXPECT_NE(content.find("ASYNC_RECONFIG_VERIFY_8n4j"), std::string::npos);
+
+    try
+    {
+        if (std::filesystem::exists(new_file))
+            std::filesystem::remove(new_file);
+    }
+    catch (const std::filesystem::filesystem_error &)
+    {
+    }
+}
+
 TEST_F(LoggerTest, AsyncMode_ConcurrentLogAndDisable)
 {
     Logger &logger = Logger::get_instance();

--- a/tests/test_profiler.cpp
+++ b/tests/test_profiler.cpp
@@ -386,3 +386,56 @@ TEST_F(ProfilerRecordTest, ProfileScopeMacro_IsNoOpWhenDisabled)
 }
 
 #endif // DMK_ENABLE_PROFILING
+
+TEST_F(ProfilerRecordTest, AvailableSamples_InitiallyZero)
+{
+    const auto &profiler = Profiler::get_instance();
+    EXPECT_EQ(profiler.available_samples(), 0u);
+}
+
+TEST_F(ProfilerRecordTest, AvailableSamples_MatchesRecordCount)
+{
+    auto &profiler = Profiler::get_instance();
+
+    LARGE_INTEGER tick;
+    QueryPerformanceCounter(&tick);
+
+    for (int i = 0; i < 5; ++i)
+    {
+        profiler.record("sample", tick.QuadPart, tick.QuadPart + 100, 1);
+    }
+    EXPECT_EQ(profiler.available_samples(), 5u);
+}
+
+TEST_F(ProfilerRecordTest, Capacity_MatchesDefaultCapacity)
+{
+    const auto &profiler = Profiler::get_instance();
+    EXPECT_EQ(profiler.capacity(), Profiler::DEFAULT_CAPACITY);
+}
+
+TEST_F(ProfilerRecordTest, ExportToFile_ContentMatchesChromeJson)
+{
+    auto &profiler = Profiler::get_instance();
+
+    LARGE_INTEGER tick;
+    QueryPerformanceCounter(&tick);
+    profiler.record("match_test", tick.QuadPart, tick.QuadPart + 5000, 1);
+
+    const std::string expected = profiler.export_chrome_json();
+
+    const std::string path = std::format("dmk_profiler_match_test_{}.json", _getpid());
+    ASSERT_TRUE(profiler.export_to_file(path));
+
+    std::FILE *fp = std::fopen(path.c_str(), "rb");
+    ASSERT_NE(fp, nullptr);
+    std::fseek(fp, 0, SEEK_END);
+    const long size = std::ftell(fp);
+    ASSERT_GE(size, 0L);
+    std::fseek(fp, 0, SEEK_SET);
+    std::string content(static_cast<size_t>(size), '\0');
+    (void)std::fread(content.data(), 1, static_cast<size_t>(size), fp);
+    std::fclose(fp);
+    std::remove(path.c_str());
+
+    EXPECT_EQ(content, expected);
+}

--- a/tests/test_shutdown.cpp
+++ b/tests/test_shutdown.cpp
@@ -1,0 +1,125 @@
+#include <gtest/gtest.h>
+#include <string>
+#include <filesystem>
+#include <process.h>
+
+#include "DetourModKit/config.hpp"
+#include "DetourModKit/hook_manager.hpp"
+#include "DetourModKit/input.hpp"
+#include "DetourModKit/logger.hpp"
+#include "DetourModKit/memory.hpp"
+#include "DetourModKit.hpp"
+
+using namespace DetourModKit;
+using DetourModKit::keyboard_key;
+
+class DMKShutdownTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        DMK_Shutdown();
+    }
+
+    void TearDown() override
+    {
+        DMK_Shutdown();
+    }
+};
+
+TEST_F(DMKShutdownTest, IdempotentShutdown)
+{
+    DMK_Shutdown();
+    EXPECT_NO_THROW(DMK_Shutdown());
+}
+
+TEST_F(DMKShutdownTest, ShutdownWithNoSubsystemsInitialized)
+{
+    EXPECT_NO_THROW(DMK_Shutdown());
+}
+
+TEST_F(DMKShutdownTest, HotReloadScenario)
+{
+    int call_count_a = 0;
+    Config::register_int("Section", "Key", "hot_reload_a", [&call_count_a](int)
+                         { ++call_count_a; }, 10);
+    EXPECT_EQ(call_count_a, 1); // Default applied once
+
+    DMK_Shutdown();
+
+    // After shutdown, old registrations are cleared.
+    // Re-register with new items for the "second load".
+    int call_count_b = 0;
+    Config::register_int("Section", "Key", "hot_reload_b", [&call_count_b](int)
+                         { ++call_count_b; }, 20);
+    EXPECT_EQ(call_count_b, 1); // Default applied once
+
+    // Reset counters before load
+    call_count_a = 0;
+    call_count_b = 0;
+
+    auto ini_path = std::filesystem::temp_directory_path() /
+                    ("test_shutdown_hotreload_" + std::to_string(_getpid()) + ".ini");
+    EXPECT_NO_THROW(Config::load(ini_path.string()));
+
+    // Old callback must not fire; new callback fires with default
+    EXPECT_EQ(call_count_a, 0);
+    EXPECT_EQ(call_count_b, 1);
+
+    if (std::filesystem::exists(ini_path))
+    {
+        std::filesystem::remove(ini_path);
+    }
+}
+
+TEST_F(DMKShutdownTest, ShutdownWithLoggerConfigured)
+{
+    auto log_path = std::filesystem::temp_directory_path() / "test_shutdown_logger.log";
+    Logger::get_instance().configure("DMK_TEST", log_path.string(), "%Y-%m-%d %H:%M:%S");
+    Logger::get_instance().log(LogLevel::Info, "Shutdown test message");
+
+    EXPECT_NO_THROW(DMK_Shutdown());
+
+    if (std::filesystem::exists(log_path))
+    {
+        std::filesystem::remove(log_path);
+    }
+}
+
+TEST_F(DMKShutdownTest, ShutdownWithMemoryCacheInitialized)
+{
+    bool init_ok = Memory::init_cache();
+    ASSERT_TRUE(init_ok);
+
+    DMK_Shutdown();
+
+    // After shutdown, re-init should succeed and stats should reflect a fresh cache
+    bool reinit_ok = Memory::init_cache();
+    ASSERT_TRUE(reinit_ok);
+
+    std::string stats = Memory::get_cache_stats();
+    EXPECT_NE(stats.find("Hits: 0"), std::string::npos);
+    EXPECT_NE(stats.find("Misses: 0"), std::string::npos);
+}
+
+TEST_F(DMKShutdownTest, ShutdownWithInputManagerRegistered)
+{
+    auto &mgr = InputManager::get_instance();
+    mgr.register_press("shutdown_test_key", {keyboard_key(0x41)}, []() {});
+    EXPECT_EQ(mgr.binding_count(), 1u);
+
+    DMK_Shutdown();
+
+    EXPECT_EQ(mgr.binding_count(), 0u);
+}
+
+TEST_F(DMKShutdownTest, ShutdownWithHookManager)
+{
+    DMK_Shutdown();
+
+    auto counts = HookManager::get_instance().get_hook_counts();
+    for (const auto &[status, count] : counts)
+    {
+        EXPECT_EQ(count, 0u);
+    }
+}


### PR DESCRIPTION
## Summary

- Add 37 new tests (837 -> 874) targeting previously uncovered branches across 7 modules
- New `test_shutdown.cpp` for `DMK_Shutdown()` orchestration (was at 0% coverage)
- Append tests to existing files for HookManager (VMT edge cases, shutdown-then-operate, filtered hook IDs), Logger (async flush, invalid reconfigure, async shutdown), EventDispatcher (emit exception propagation), Profiler (accessor methods, file export verification), and input_codes (hash correctness, hex fallback, unknown enums)
- Update `docs/tests/README.md` project structure to list all 18 test files
- Update `AGENTS.md` testing section to document shutdown tests

## Test plan

- [x] All 874 tests pass on MinGW debug build
- [x] No flaky tests -- all new tests use deterministic assertions
- [x] No duplicate tests -- verified against existing test names
- [x] Existing tests unmodified -- new tests appended only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across event dispatching, hook management, input handling, logging, profiling, and shutdown semantics, including idempotence, hot-reload re-initialization, error-paths, and cleanup verification.
* **Documentation**
  * Updated test documentation and guidance to reflect the revised test lineup, reordered descriptions, and added shutdown orchestration guidance; removed the related-docs subsection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->