### PR TITLE
fix(profiler): eliminate MSVC build warnings

### DIFF
--- a/include/DetourModKit/profiler.hpp
+++ b/include/DetourModKit/profiler.hpp
@@ -50,7 +50,7 @@
 
 // Scoped timing using the enclosing function name.
 #define DMK_PROFILE_FUNCTION() \
-    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_func_, __LINE__) { __FUNCTION__ }
+    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_func_, __LINE__) { __func__ }
 
 #else
 

--- a/include/DetourModKit/profiler.hpp
+++ b/include/DetourModKit/profiler.hpp
@@ -46,16 +46,16 @@
 
 // Scoped timing measurement. Name must be a string literal.
 #define DMK_PROFILE_SCOPE(name) \
-    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_, __LINE__){name}
+    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_, __LINE__) { name }
 
 // Scoped timing using the enclosing function name.
 #define DMK_PROFILE_FUNCTION() \
-    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_func_, __LINE__){__FUNCTION__}
+    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_func_, __LINE__) { __FUNCTION__ }
 
 #else
 
 #define DMK_PROFILE_SCOPE(name) ((void)0)
-#define DMK_PROFILE_FUNCTION()  ((void)0)
+#define DMK_PROFILE_FUNCTION() ((void)0)
 
 #endif // DMK_ENABLE_PROFILING
 
@@ -171,10 +171,12 @@ namespace DetourModKit
         Profiler();
         ~Profiler() = default;
 
+        // write_pos_ first to avoid 40 bytes of padding (alignas(64) requirement).
+        // This placement ensures cache-line alignment for the lock-free ring buffer.
+        alignas(64) std::atomic<size_t> write_pos_{0};
         std::unique_ptr<ProfileSample[]> buffer_;
         size_t capacity_;
         size_t mask_; // capacity_ - 1 for power-of-2 index wrapping
-        alignas(64) std::atomic<size_t> write_pos_{0};
         int64_t qpc_frequency_{0};
     };
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -217,13 +217,26 @@ namespace DetourModKit
         const std::string json = export_chrome_json();
         const std::string path_str(path);
 
-        const auto closer = [](std::FILE *f) { std::fclose(f); };
-        std::unique_ptr<std::FILE, decltype(closer)> fp(
-            std::fopen(path_str.c_str(), "wb"), closer);
-        if (!fp)
+        const auto closer = [](std::FILE *f)
+        { std::fclose(f); };
+        std::FILE *file_ptr = nullptr;
+
+#if defined(_MSC_VER)
+        const errno_t err = std::fopen_s(&file_ptr, path_str.c_str(), "wb");
+        if (err != 0 || file_ptr == nullptr)
         {
             return false;
         }
+#else
+        // MinGW lacks std::fopen_s; use std::fopen directly.
+        file_ptr = std::fopen(path_str.c_str(), "wb");
+        if (file_ptr == nullptr)
+        {
+            return false;
+        }
+#endif
+
+        std::unique_ptr<std::FILE, decltype(closer)> fp(file_ptr, closer);
         const size_t written = std::fwrite(json.data(), 1, json.size(), fp.get());
         return written == json.size();
     }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -238,7 +238,20 @@ namespace DetourModKit
 
         std::unique_ptr<std::FILE, decltype(closer)> fp(file_ptr, closer);
         const size_t written = std::fwrite(json.data(), 1, json.size(), fp.get());
-        return written == json.size();
+        if (written != json.size())
+        {
+            return false;
+        }
+        if (std::fflush(fp.get()) != 0)
+        {
+            return false;
+        }
+        // Release the pointer so unique_ptr does not double-close.
+        if (std::fclose(fp.release()) != 0)
+        {
+            return false;
+        }
+        return true;
     }
 
     size_t Profiler::total_samples_recorded() const noexcept


### PR DESCRIPTION
## Summary

- Fix C4324 structure padding warning by moving alignas(64) member to struct start
- Fix C4996 deprecated fopen warning with cross-platform fopen_s for MSVC

## Test plan

- [x] Full test suite passes (878 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and error detection when exporting profiler data to disk across platforms.

* **Chores**
  * Internal formatting and private-layout adjustments for maintainability and alignment; no user-visible API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->