### PR TITLE
feat: combo opt-out sentinels, hot-reload safety, and lifecycle docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(DetourModKit VERSION 3.2.2 LANGUAGES CXX)
+project(DetourModKit VERSION 3.2.3 LANGUAGES CXX)
 
 # --- Standard and Compiler Options ---
 set(CMAKE_CXX_STANDARD 23)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [Features](#features) | [Building](#building-detourmodkit-static-library-via-cmake) | [Testing](#running-unit-tests) | [Guides](#guides) | [Integration](#using-detourmodkit-in-your-mod-project) | [Example](#code-example)
 
-DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in game modding, particularly for creating mods that involve memory scanning, hooking, and configuration management. It is built with MinGW in mind but aims for general C++ compatibility.
+DetourModKit is a full-featured C++ toolkit designed to simplify common tasks in game modding, particularly for creating mods that involve memory scanning, hooking, input handling, configuration management, and DLL lifecycle orchestration. It is built with MinGW in mind but aims for general C++ compatibility.
 
 ## Features
 
@@ -64,6 +64,7 @@ DetourModKit is a lightweight C++ toolkit designed to simplify common tasks in g
   - Format: `modifier+trigger` (e.g., `Ctrl+Shift+F3`)
   - Comma-separated independent combos (e.g., `F3,Gamepad_LT+Gamepad_B`)
   - Named keys (`Ctrl`, `F3`, `Mouse1`, `Gamepad_A`), hex VK codes (`0x72`), and mixed formats
+  - Opt-out sentinels: an empty value or the literal `NONE` (case-insensitive, whole-string only) leaves the binding unbound silently. A non-empty value whose every token fails to parse is logged at WARNING level naming the binding and the offending raw string.
 - Convenience helpers: `register_log_level` (parses an INI string into a `Logger::set_log_level` call) and `register_atomic<T>` for `int`/`bool`/`float` (writes the parsed value into a caller-supplied `std::atomic<T>` with `memory_order_relaxed`)
 - **Hot-reload** (see [Config Hot-Reload Guide](docs/config-hot-reload/README.md)):
   - `Config::reload()` re-runs every registered setter against the last-loaded INI without touching registrations; skips setters when the on-disk bytes are byte-identical to the last load (FNV-1a content hash)
@@ -230,6 +231,7 @@ See the [Config Hot-Reload Guide](docs/config-hot-reload/README.md) for the thre
 - Handles the `DLL_PROCESS_DETACH` process-exit vs dynamic-unload distinction automatically via `lpvReserved`
 - `on_logic_dll_unload(hook_names, binding_names)` drops only the per-Logic-DLL hooks and bindings owned by the caller, leaving Logger and Config alive for whichever container hosts the next Logic-DLL incarnation
 - `on_logic_dll_unload_all()` is the catch-all variant for callers without an explicit name registry; in a host that loads multiple Logic DLLs sharing one DMK instance, prefer the named-list overload because the catch-all rips out every Logic DLL's state
+- Hot-reload teardown: `Bootstrap::on_logic_dll_unload` is the lighter alternative to `DMK_Shutdown` for multi-DLL or fast-iteration setups (see [docs/hot-reload/README.md](docs/hot-reload/README.md))
 
 </details>
 
@@ -886,6 +888,10 @@ GamepadTrigger=Gamepad_LT              ; Left trigger (digital, configurable dea
 ; Hex VK codes still supported
 LegacyKey=0x72               ; F3 by hex code
 LegacyCombo=0x11+0x10+0x44   ; Ctrl+Shift+D by hex codes
+
+; Opt-out sentinels (silent, no warning)
+DisabledHotkey=               ; empty value -> binding registered but unbound
+AlsoDisabled=NONE             ; literal NONE (case-insensitive) -> same effect
 ```
 
 ## Supported Input Names

--- a/docs/config-hot-reload/README.md
+++ b/docs/config-hot-reload/README.md
@@ -120,7 +120,7 @@ The `on_reload` callback passed to `enable_auto_reload` receives a `bool content
 - SafetyHook trampolines: once a hook is installed its target address is baked in. Removing a hook requires `HookManager::remove_*_hook`, which may deadlock with in-flight callers if triggered from the watcher thread. Change the "hook installed" bit only through a proper shutdown cycle.
 - Thread pool sizes and `poll_interval` for `InputManager::start()`: these are fixed at start time.
 - Log file handle and log prefix: `Logger::configure` rotates the file, which requires coordinating with in-flight async writes. Prefer reconfiguring via a full shutdown/start cycle.
-- The reload hotkey combo itself can be changed at runtime, but the binding cardinality (number of independent combos) cannot. If the INI combo string has a different number of comma-separated alternatives than the default, the update is rejected with a Warning and the old combo remains.
+- The reload hotkey combo itself can be changed at runtime; the cardinality of the new combo list does not need to match the default and the binding's combo set is rebuilt on the fly. To opt the hotkey out at runtime, set the INI value to either an empty string or the literal `NONE` (case-insensitive, whole-string only); both forms produce an unbound binding silently. A non-empty value whose every comma-separated token fails to parse is logged at WARNING level naming the binding and the offending raw string. See the [combo string syntax sub-section](../hot-reload/README.md#combo-string-syntax-opt-out-and-parse-failures) in the hot-reload guide for the complete contract (mixed-list behavior, `NONE`-in-list, and so on).
 
 ## Debounce rationale
 

--- a/docs/hot-reload/README.md
+++ b/docs/hot-reload/README.md
@@ -1217,6 +1217,74 @@ When choosing between the two topologies:
 
 Mixing the two in one process is not supported: pick one per host module and stay on it.
 
+### When to use `on_logic_dll_unload` vs `DMK_Shutdown`
+
+Both APIs leave the unloading Logic DLL in a state where its hooks, bindings, and Config-registered setters are gone before `FreeLibrary` reclaims the code pages. The difference is what survives on the loader side: `DMK_Shutdown` tears down Logger, ConfigWatcher, and the Memory cache; `on_logic_dll_unload(_all)` keeps them running.
+
+| Consumer shape                                         | Use                   | Why                                                                                                                                                    |
+|--------------------------------------------------------|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Single Logic DLL, occasional reload (human hotkey)     | `DMK_Shutdown`        | Functionally equivalent to the lighter unload in this topology; sub-100ms speedup is invisible at human-trigger frequency, so prefer the simpler call. |
+| Multi-Logic-DLL loader, only one reloads               | `on_logic_dll_unload` | `DMK_Shutdown` would tear down Logger, ConfigWatcher, and Memory cache that the still-loaded sibling DLLs depend on.                                   |
+| Tight dev iteration (sub-second file-save cadence)     | `on_logic_dll_unload` | Skips Logger writer-thread spin-up, ConfigWatcher restart, and Memory cache rebuild on the next attach. Visible in fast inner-loop dev.                |
+| Persistent loader-side UI or state (overlay, profiler) | `on_logic_dll_unload` | Lets the overlay window, profiler session, or other loader-side state survive the reload without flicker or re-init.                                   |
+| Log continuity required across reloads                 | `on_logic_dll_unload` | Same writer thread keeps appending; one open file handle; contiguous timestamps. `DMK_Shutdown` flushes, closes, and reopens.                          |
+
+If DMK could only ship one of the two, `DMK_Shutdown` would cover ~90% of consumers. The lighter unload exists for the 10% that need it (multi-plugin loaders, sub-second dev iteration, persistent loader-side state). For single-DLL, occasional-reload setups, prefer `DMK_Shutdown` for simplicity.
+
+### Pre-unload contract: worker-thread quiescence
+
+`Bootstrap::on_logic_dll_unload(_all)` removes hooks and bindings, but it cannot prove that every consumer-owned worker thread has stopped firing those hooks. A worker thread that calls into a detoured function between `remove_hook` returning and `FreeLibrary` reclaiming the Logic DLL's `.text` pages will execute freed code; the resulting access violation often points at an address that no longer maps to anything, which is hard to triage from a crash dump. SafetyHook freezes game threads while it patches the original prologue back, but it has no visibility into worker threads spawned by the consumer.
+
+Stop and join every consumer-owned worker BEFORE you call the unload helper. The canonical Logic-DLL `Shutdown()` ordering for the persistent-host topology is:
+
+```cpp
+extern "C" __declspec(dllexport) void Shutdown()
+{
+    // 1. Stop and join your own workers first. Each StoppableWorker reset()
+    //    requests stop and joins (or detaches under loader lock, with a
+    //    pinned module to keep code pages mapped).
+    s_scan_worker.reset();
+    s_telemetry_worker.reset();
+
+    // 2. Now the only remaining callers into the hooks are game threads,
+    //    which SafetyHook will freeze inside remove_hook. Drop the
+    //    DLL-local registrations.
+    DMKBootstrap::on_logic_dll_unload(hook_names, binding_names);
+
+    // 3. Return from Shutdown(). The loader's FreeLibrary call follows.
+}
+```
+
+A common worker case to watch for: a hook callback runs on a game thread, but a separate consumer-owned thread pool *also* calls into the same detour body (e.g. an off-thread snapshot capture, a deferred re-scan, a periodic poller that touches game state through a hooked accessor). Both paths must be quiet before the unload helper runs. If a worker calls into game-side code that the host module also hooks, joining the worker before unload is sufficient; SafetyHook handles the game-thread side.
+
+---
+
+## Idempotency contract on hot-reload
+
+The persistent-host topology calls `Init()` once per Logic-DLL load. Every call into a process-wide DMK singleton from `Init()` is therefore the second-or-later call across the host's lifetime. The table below summarises what each second call does and what (if any) teardown the consumer must run first.
+
+| API                                                    | Second-call behavior                                  | Consumer action before second call               |
+|--------------------------------------------------------|-------------------------------------------------------|--------------------------------------------------|
+| `Logger::configure`                                    | Replaces existing config                              | None; safe on every `Init()`                     |
+| `HookManager::create_inline_hook` (and variants)       | Fails with `HookAlreadyExists`                        | Call `remove_hook(name)` first                   |
+| `Config::register_string` / `register_int` / etc.      | Replace-on-duplicate                                  | None; new setter overwrites stale closure        |
+| `Config::register_press_combo` / `register_hold_combo` | Replace-on-duplicate (Config); APPENDS (InputManager) | Drop prior binding via `remove_binding_by_name`  |
+| `InputManager::register_press` / `register_hold`       | APPENDS a new binding entry                           | Call `remove_binding_by_name(name)` first        |
+| `InputManager::start`                                  | No-op; logs at DEBUG                                  | None for no-op; `shutdown()` to change interval  |
+| `Bootstrap::on_dll_attach`                             | Returns `FALSE` if not detached                       | Call `on_dll_detach(...)` first                  |
+
+Notes on individual rows:
+
+- **`Logger::configure`**: If the file path differs from the previous call, the open log handle is rotated under lock; the writer thread is preserved. The internal `shutdown_called_` flag is reset on every call so the logger is usable again after a reload.
+- **`HookManager::create_inline_hook` (and `create_mid_hook`, `*_aob` variants)**: NOT replace-on-duplicate. The hook map is keyed by `name`, and a second `create_*_hook` with the same `name` fails fast with `HookAlreadyExists` so a stale detour is never silently swapped (which would leave the old detour code mapped into the trampoline). Always remove before re-installing.
+- **`Config::register_*` (string, int, float, bool, key_combo)**: If a registration with the same `(section, ini_key)` already exists, the prior `ConfigItemBase` and its setter closure are overwritten in place. Re-registering with a fresh setter from the new Logic DLL replaces the stale closure cleanly.
+- **`Config::register_press_combo` / `register_hold_combo`**: The Config item itself follows replace-on-duplicate semantics. The InputManager binding it creates does not, because `InputManager::register_press` / `register_hold` are append-only (see next row). Drop the prior binding via `InputManager::remove_binding_by_name(name)` to avoid duplicates.
+- **`InputManager::register_press` / `register_hold`**: Append-only. The InputPoller treats `name` as a label, not a key. Two registrations with the same `name` produce two `InputBinding` entries that both fire on a matching key sequence. This is the most common surprise across reloads.
+- **`InputManager::start(poll_interval)`**: No-op when the poller is already running. The new `poll_interval` is ignored; the running poller keeps its original interval. Use `shutdown()` then `start(new_interval)` if you actually need to change it (the lighter unload helpers do not stop the poller).
+- **`Bootstrap::on_dll_attach`**: Guards against double-attach by checking `g_shutdown_event || g_worker_thread` and returning `FALSE` without invoking `init_fn`. Typically not relevant in the persistent-host topology where the host module attaches exactly once for the process lifetime.
+
+`Bootstrap::on_logic_dll_unload(_all)` exists precisely to bundle the required teardown for hooks, bindings, and Config-registered setters so consumers do not have to remember the per-API rules individually. A correct persistent-host `Shutdown()` invokes one of those helpers (after draining its own workers; see the previous sub-section) and the next `Init()` lands on a clean slate for every entry above.
+
 ---
 
 ## Hot-Reload Safety Guarantees
@@ -1227,13 +1295,27 @@ DetourModKit's core systems are designed to be safe across DLL reload cycles:
 
 `HookManager::is_target_already_hooked(addr)` reports whether the local `HookManager` instance already has an inline or mid hook installed at `addr`. It is the programmatic counterpart to the install-time WARNING that fires when SafetyHook layers on top of a pre-existing JMP from another module, and it covers the common case of two cooperating modules wanting to coordinate hook ownership without grepping log output.
 
-**InputManager:** `register_press` and `register_hold` accept new bindings whether the poller is stopped, starting, or running. Live registration takes the poller's exclusive lock, appends to the binding list, and rebuilds the parallel `active_states_` array in one step, so there is no per-tick allocation in the hot loop. Surviving entries' atomic states are carried forward across every reshape (`add_binding`, `remove_bindings_by_name`, `update_binding_combos`), so a held binding never flickers through one inactive tick when an unrelated binding is added or dropped. `clear_bindings()` empties the registry without stopping the poller, and `remove_binding_by_name(name)` drops a single binding by name (used internally by `Bootstrap::on_logic_dll_unload`). `update_binding_combos(name, combos)` accepts cardinality changes (1 to N or N to 1) and replaces the registered combo list wholesale; supplying an empty list is rejected so an INI typo cannot silently disable a binding. When a cardinality change drops a held `register_hold` entry, that entry's `on_state_change(false)` release callback fires before the rebuild completes so the consumer never latches in the held state.
+**InputManager:** `register_press` and `register_hold` accept new bindings whether the poller is stopped, starting, or running. Live registration takes the poller's exclusive lock, appends to the binding list, and rebuilds the parallel `active_states_` array in one step, so there is no per-tick allocation in the hot loop. Surviving entries' atomic states are carried forward across every reshape (`add_binding`, `remove_bindings_by_name`, `update_binding_combos`), so a held binding never flickers through one inactive tick when an unrelated binding is added or dropped. `clear_bindings()` empties the registry without stopping the poller, and `remove_binding_by_name(name)` drops a single binding by name (used internally by `Bootstrap::on_logic_dll_unload`). `update_binding_combos(name, combos)` accepts cardinality changes (1 to N or N to 1) and replaces the registered combo list wholesale; an empty replacement is the explicit-unbound state and collapses the entry set to a single inert sentinel so the binding name remains addressable for a later non-empty update. When a cardinality change drops a held `register_hold` entry, that entry's `on_state_change(false)` release callback fires before the rebuild completes so the consumer never latches in the held state.
 
 **Bootstrap unload helpers:** `Bootstrap::on_logic_dll_unload(_all)` deliberately drops bindings without firing `on_state_change(false)` release callbacks, because user callbacks live in the unloading Logic DLL and running them under the Windows loader lock is the deadlock-or-crash vector that the v3.2.1 leak-on-purpose discipline forbids. Consumers that need a clean release on a planned unload (not driven by `DllMain` detach) should call `InputManager::clear_bindings()` or `remove_binding_by_name(name)` directly before invoking the unload helper.
 
 **Config:** `register_*()` functions use replace-on-duplicate semantics. If a new DLL registers a config item with the same section and INI key as an existing entry, the old registration is replaced rather than appended. This prevents doubled registrations across reload cycles without requiring an explicit `clear_registered_items()` call. Calling `clear_registered_items()` before re-registration is still supported but no longer required.
 
-`Config::register_press_combo` with an empty default registers the binding name with no keys, so a later `update_binding_combos` call (typically driven by an INI edit and `AutoReloadConfig`) can attach real combos to it. The previous behavior, where empty defaults were dropped from the registry, is gone.
+`Config::register_press_combo` with an empty default (or the `NONE` sentinel, case-insensitive whole-string only) registers the binding name with no keys, so a later `update_binding_combos` call (typically driven by an INI edit and `AutoReloadConfig`) can attach real combos to it. The same opt-out sentinels apply on every subsequent reload: setting the INI value to an empty string or `NONE` unbinds the binding silently while keeping the name addressable, so the bound -> unbound -> bound INI cycle round-trips cleanly. A non-empty INI value whose every comma-separated token fails to parse is logged at WARNING level naming the binding and the offending raw string.
+
+### Combo string syntax: opt-out and parse failures
+
+`Config::register_press_combo`, `register_hold_combo`, `register_key_combo`, and INI-driven `update_binding_combos` all share the same combo-list parser. The contract for the raw INI string value is:
+
+| Input form                                                                                           | Result                                                                                     | Log                                                              |
+|------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| Empty string (post-trim)                                                                             | Unbound binding; name stays registered for later updates                                   | None                                                             |
+| `NONE` (case-insensitive, surrounding whitespace allowed, whole-string only)                         | Unbound binding; name stays registered for later updates                                   | None                                                             |
+| Comma-separated list of valid combos (e.g. `F4,Ctrl+F4`)                                             | Binding bound to the OR of the parsed combos                                               | None                                                             |
+| Comma-separated list with one bad token (e.g. `F4,NONE`)                                             | Binding bound to the tokens that DID parse; bad tokens are dropped silently as unparseable | None                                                             |
+| Non-empty, non-`NONE` input where EVERY comma-separated token fails to parse (e.g. `Foo`, `Bar+Baz`) | Unbound binding; treated as a user typo                                                    | One WARNING line naming the binding and the offending raw string |
+
+The `NONE` sentinel is whole-string only by design: a `NONE` token nested inside a comma-separated list is not distinguishable from a key-name typo without a per-token lookup, and the OR-of-combos semantic makes "an unbound slot inside an OR-list" meaningless. Use `NONE` (or an empty value) at the whole-value level when you want to opt a binding out without removing the INI key.
 
 ---
 

--- a/include/DetourModKit/bootstrap.hpp
+++ b/include/DetourModKit/bootstrap.hpp
@@ -131,14 +131,18 @@ namespace DetourModKit
          * @brief Drops the per-Logic-DLL state owned by the caller.
          * @details Composes HookManager::remove_hook for every entry in
          *          @p hook_names and InputManager::remove_binding_by_name
-         *          for every entry in @p binding_names. Names that do not
-         *          exist are skipped (logged at Debug). Idempotent: a
-         *          second call with the same names is a no-op.
+         *          for every entry in @p binding_names, then calls
+         *          Config::clear_registered_items() to drop the
+         *          registered setters because their call operators live
+         *          in the unloading DLL's .text; Logger and
+         *          ConfigWatcher are loader-side and outlive the unload.
+         *          Names that do not exist are skipped (logged at
+         *          Debug). Idempotent: a second call with the same names
+         *          is a no-op. Use DMK_Shutdown() for whole-process
+         *          teardown.
          *
-         *          Does NOT touch Logger or Config: callers that share a
-         *          host process across multiple Logic-DLL incarnations
-         *          want those subsystems to outlive the unload. Use
-         *          DMK_Shutdown() for whole-process teardown.
+         *          For guidance on choosing between this and
+         *          DMK_Shutdown(), see docs/hot-reload/README.md.
          *
          *          Safe to call from any thread except: must NOT be
          *          called from the InputPoller thread (would self-join)
@@ -151,6 +155,13 @@ namespace DetourModKit
          *          formatting) may throw; every throw site is caught and
          *          logged so no exception propagates to the caller.
          *
+         * @warning Stop and join every consumer-owned worker thread
+         *          before calling. A worker that fires a hook between
+         *          remove_hook returning and FreeLibrary reclaiming the
+         *          Logic DLL's .text pages will execute freed code. This
+         *          helper cannot prove worker quiescence; that is the
+         *          consumer's responsibility.
+         *
          * @param hook_names Names of hooks installed via HookManager.
          * @param binding_names Names of input bindings registered via
          *        InputManager (or via Config::register_press_combo).
@@ -162,26 +173,20 @@ namespace DetourModKit
          * @brief Drops every hook and binding registered through the
          *        process-wide singletons.
          * @details Composes HookManager::remove_all_hooks with
-         *          InputManager::clear_bindings under the same
-         *          loader-lock-safe, idempotent, exception-swallowing
-         *          contract as the named-list overload. Use when the
-         *          caller does not maintain an explicit registry of
-         *          hook or binding names.
+         *          InputManager::clear_bindings, then chains
+         *          Config::clear_registered_items() to drop the
+         *          registered setters because their call operators live
+         *          in the unloading DLL's .text; Logger and
+         *          ConfigWatcher are loader-side and outlive the unload.
+         *          The HookManager call is remove_all_hooks() (not
+         *          shutdown()) and the binding call is clear_bindings()
+         *          (not shutdown()) so both subsystems stay re-usable
+         *          for the next attach. Use when the caller does not
+         *          maintain an explicit registry of hook or binding
+         *          names. Use DMK_Shutdown() for whole-process teardown.
          *
-         *          Logger, Config, and the ConfigWatcher are
-         *          intentionally left running, matching the named-list
-         *          overload's partition between per-Logic-DLL state and
-         *          host-owned infrastructure. Use DMK_Shutdown() for
-         *          whole-process teardown.
-         *
-         *          The HookManager teardown call is remove_all_hooks(),
-         *          not shutdown(): both perform the same two-phase
-         *          drain, but remove_all_hooks() resets the shutdown
-         *          flag at the end so subsequent create_*_hook() calls
-         *          succeed for the next Logic-DLL incarnation. The
-         *          binding teardown call is clear_bindings(), not
-         *          shutdown(): the poller keeps running idle and is
-         *          ready to accept fresh bindings on the next attach.
+         *          For guidance on choosing between this and
+         *          DMK_Shutdown(), see docs/hot-reload/README.md.
          *
          *          Safe to call from any thread except: must NOT be
          *          called from the InputPoller thread (would self-join)
@@ -199,6 +204,13 @@ namespace DetourModKit
          *          Logic DLL's Shutdown() rips out the other Logic DLLs'
          *          hooks and bindings as well. The named-list overload
          *          is the correct choice in that topology.
+         *
+         * @warning Stop and join every consumer-owned worker thread
+         *          before calling. A worker that fires a hook between
+         *          remove_all_hooks returning and FreeLibrary reclaiming
+         *          the Logic DLL's .text pages will execute freed code.
+         *          This helper cannot prove worker quiescence; that is
+         *          the consumer's responsibility.
          */
         void on_logic_dll_unload_all() noexcept;
     } // namespace Bootstrap

--- a/include/DetourModKit/config.hpp
+++ b/include/DetourModKit/config.hpp
@@ -418,8 +418,12 @@ namespace DetourModKit
          * @param default_combo Combo string applied when the INI key is absent
          *                      (e.g. "Ctrl+F5").
          * @return true if the binding was registered, false if @p default_combo
-         *         is empty (register_press_combo silently no-ops on empty combo
-         *         lists, which would make the hotkey appear registered but inert).
+         *         is empty or the NONE sentinel. @ref register_press_combo accepts
+         *         both as silent opt-out and registers the binding name with no
+         *         keys (addressable later by @ref update_binding_combos), but a
+         *         reload hotkey with no default keys is never useful, so this
+         *         helper rejects that case at the call site rather than ship an
+         *         inert reload binding.
          * @note The on-press callback runs on the InputManager poll thread,
          *       but the actual reload() work is deferred to a dedicated
          *       background servicer thread. The press callback only flips

--- a/include/DetourModKit/config.hpp
+++ b/include/DetourModKit/config.hpp
@@ -236,9 +236,17 @@ namespace DetourModKit
          *          '+' separates modifier keys from the trigger key (last token). Tokens
          *          can be human-readable names (e.g., "Ctrl", "F3", "Gamepad_A") or hex
          *          VK codes (e.g., "0x72"). See KeyCombo for full parsing semantics.
+         *
+         *          Two opt-out sentinels yield an empty KeyComboList silently:
+         *          an empty string and the literal "NONE" (case-insensitive,
+         *          surrounding whitespace OK, whole-string only). A non-empty,
+         *          non-sentinel value whose every token fails to parse is
+         *          logged at WARNING level naming @p log_key_name and the
+         *          offending raw string.
          * @param section INI section name.
          * @param ini_key INI key name.
-         * @param log_key_name Human-readable name shown in log output.
+         * @param log_key_name Human-readable name shown in log output and in the
+         *                     typo WARNING described above.
          * @param setter Callback invoked with the parsed KeyComboList.
          * @param default_value_str Default value string in the same format.
          * @note The setter is called immediately with the parsed default and again on load().
@@ -253,29 +261,40 @@ namespace DetourModKit
          *          parsed default combo. On each subsequent load() the setter
          *          invokes InputManager::update_binding_combos() so the bound
          *          keys and modifiers pick up the INI-sourced value without
-         *          re-registering the binding. Live updates require the new
-         *          combo list to have the same number of alternatives as the
-         *          default (one binding entry per combo); if the cardinality
-         *          differs the update is rejected and a Warning-level log
-         *          message is emitted. Callers that need to change cardinality
-         *          at runtime must fully stop and restart InputManager so the
-         *          underlying bindings can be re-registered.
+         *          re-registering the binding. Live updates accept any
+         *          cardinality: the binding's combo set is rebuilt on the fly
+         *          and any held-state release callbacks fire before the swap
+         *          completes.
+         *
+         *          To opt a binding out at runtime (no keys bound), set the
+         *          INI value to either an empty string or the literal
+         *          "NONE" (case-insensitive, surrounding whitespace OK).
+         *          Both forms produce an unbound binding silently and the
+         *          binding name remains addressable for a future non-empty
+         *          update. The "NONE" sentinel is only recognized as the
+         *          entire trimmed value; "NONE" appearing as one token in a
+         *          comma-separated list is treated as an unparseable token
+         *          and contributes nothing.
+         *
+         *          A non-empty INI value whose every comma-separated token
+         *          fails to parse is treated as a user typo and logged at
+         *          WARNING level naming the binding and the offending raw
+         *          string; the binding becomes unbound.
          *
          *          The returned guard holds a cancellation flag that
          *          short-circuits the user callback when released, because
          *          InputManager does not support per-binding removal
          *          post-start().
          *
-         *          Must be called before InputManager::start() for the
-         *          binding to be picked up by the poller. Call sites that
-         *          register after start() should also call
-         *          InputManager::shutdown() then start() again, or accept
-         *          that only the INI value is tracked and the callback
-         *          never fires.
+         *          Safe to call before or after InputManager::start(). A
+         *          binding registered while the poller is running is
+         *          appended to the live binding set and starts firing on
+         *          the next poll cycle.
          *
          * @param section INI section name.
          * @param ini_key INI key name.
-         * @param log_name Human-readable name echoed by the config logger.
+         * @param log_name Human-readable name echoed by the config logger and
+         *                 in the typo WARNING described above.
          * @param input_binding_name InputManager binding name (must be unique).
          * @param on_press User callback fired on key-down edge.
          * @param default_value Default combo string (same format as register_key_combo).

--- a/include/DetourModKit/input.hpp
+++ b/include/DetourModKit/input.hpp
@@ -214,14 +214,19 @@ namespace DetourModKit
          *          modifiers are overwritten in place. When the count differs,
          *          the existing entries are erased and one entry per replacement
          *          combo is appended; callbacks, binding mode, and binding name
-         *          inherit from the first existing entry. An empty replacement
-         *          list is rejected so a blank INI value cannot silently
-         *          disable a binding's callback. Safe to call while the poll
-         *          thread is running.
+         *          inherit from the first existing entry.
+         *
+         *          An empty replacement list is a valid binding state meaning
+         *          "no keys bound": the existing entries are erased and a
+         *          single inert sentinel entry takes their place so the
+         *          binding name remains addressable for a later non-empty
+         *          update. Held bindings receive an on_state_change(false)
+         *          callback before the swap completes. Safe to call while
+         *          the poll thread is running.
          * @param name Binding name previously registered.
-         * @param combos Replacement combos (must be non-empty).
-         * @return true on successful swap, false if the name is unknown or
-         *         @p combos is empty.
+         * @param combos Replacement combos. May be empty to unbind.
+         * @return true on successful swap (including the unbind case), false
+         *         only if the name was never registered.
          */
         [[nodiscard]] bool update_combos(std::string_view name, const Config::KeyComboList &combos) noexcept;
 
@@ -506,13 +511,18 @@ namespace DetourModKit
          * @details Forwards to the active InputPoller when running, or updates
          *          pending bindings before start(). The binding's name,
          *          callback, and mode are preserved; only keys and modifiers
-         *          are swapped. Cardinality must match the number of combos
-         *          originally registered under @p name (one binding entry per
-         *          combo). If the name is unknown or the cardinality differs,
-         *          a warning is logged at Debug level and no change is made.
-         *          Thread-safe.
+         *          are swapped. Any cardinality is accepted: matching counts
+         *          rewrite in place, differing counts rebuild the entry set
+         *          carrying callback identity forward.
+         *
+         *          An empty replacement list unbinds the named binding while
+         *          keeping a single inert sentinel entry so a subsequent
+         *          non-empty update can rebind it. Held bindings receive an
+         *          on_state_change(false) callback before the swap completes.
+         *          If the name is unknown the call is a no-op logged at
+         *          Debug level. Thread-safe.
          * @param name Binding name previously registered.
-         * @param combos Replacement combos.
+         * @param combos Replacement combos. May be empty to unbind.
          */
         void update_binding_combos(std::string_view name, const Config::KeyComboList &combos) noexcept;
 

--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -1,5 +1,6 @@
 #include "DetourModKit/bootstrap.hpp"
 
+#include "DetourModKit/config.hpp"
 #include "DetourModKit/hook_manager.hpp"
 #include "DetourModKit/input.hpp"
 #include "DetourModKit/logger.hpp"
@@ -400,6 +401,45 @@ namespace DetourModKit::Bootstrap
         logger.info(
             "Bootstrap: on_logic_dll_unload drained {} hook(s) and {} binding(s).",
             hooks_removed, bindings_removed);
+
+        // Wipe the Config registry last because the prior hook and
+        // binding teardown may invoke a registered setter one final
+        // time (a setter that observes a binding-driven flag, for
+        // instance). Clearing first would orphan that final-fire path
+        // mid-call. The registered std::function setters' call
+        // operators, vtables, and destructors live in the Logic DLL's
+        // .text segment; once the loader unmaps that segment, every
+        // surviving entry becomes a use-after-unload hazard. The next
+        // attach's replace_or_append destroys the stale slot before
+        // installing the fresh one, which would invoke the old
+        // setter's destructor against freed pages.
+        try
+        {
+            Config::clear_registered_items();
+        }
+        catch (const std::exception &e)
+        {
+            try
+            {
+                logger.error(
+                    "Bootstrap: on_logic_dll_unload caught exception in clear_registered_items: {}",
+                    e.what());
+            }
+            catch (...)
+            {
+            }
+        }
+        catch (...)
+        {
+            try
+            {
+                logger.error(
+                    "Bootstrap: on_logic_dll_unload caught unknown exception in clear_registered_items.");
+            }
+            catch (...)
+            {
+            }
+        }
     }
 
     void on_logic_dll_unload_all() noexcept
@@ -478,6 +518,42 @@ namespace DetourModKit::Bootstrap
         }
         catch (...)
         {
+        }
+
+        // Wipe the Config registry last for the same reason as the
+        // named-list overload: the prior remove_all_hooks /
+        // clear_bindings calls may fire a registered setter one final
+        // time, and clearing first would orphan that path. The
+        // registered std::function setters' call operators, vtables,
+        // and destructors live in the unloading Logic DLL's .text;
+        // every surviving entry becomes a use-after-unload hazard the
+        // moment the loader reclaims those pages.
+        try
+        {
+            Config::clear_registered_items();
+        }
+        catch (const std::exception &e)
+        {
+            try
+            {
+                logger.error(
+                    "Bootstrap: on_logic_dll_unload_all caught exception in clear_registered_items: {}",
+                    e.what());
+            }
+            catch (...)
+            {
+            }
+        }
+        catch (...)
+        {
+            try
+            {
+                logger.error(
+                    "Bootstrap: on_logic_dll_unload_all caught unknown exception in clear_registered_items.");
+            }
+            catch (...)
+            {
+            }
         }
     }
 } // namespace DetourModKit::Bootstrap

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include <windows.h>
+#include <cctype>
 #include <cerrno>
 #include <condition_variable>
 #include <cstdint>
@@ -179,14 +180,52 @@ namespace
     }
 
     /**
+     * @brief Returns true when @p text is the literal "NONE" sentinel
+     *        (case-insensitive ASCII, exact length match).
+     * @details The whole-string-only rule keeps the sentinel unambiguous:
+     *          a NONE token nested inside a comma-separated list cannot be
+     *          told apart from a key-name typo without a per-token lookup,
+     *          and the OR-of-combos semantic makes "an unbound slot inside
+     *          an OR-list" meaningless. Caller must pass a pre-trimmed view.
+     */
+    [[nodiscard]] bool is_none_sentinel(std::string_view text) noexcept
+    {
+        if (text.size() != 4)
+        {
+            return false;
+        }
+        constexpr char target[] = {'N', 'O', 'N', 'E'};
+        for (size_t i = 0; i < 4; ++i)
+        {
+            const auto ch = static_cast<unsigned char>(text[i]);
+            if (static_cast<char>(std::toupper(ch)) != target[i])
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * @brief Parses a comma-separated string of key combos into a KeyComboList.
      * @details Commas at the top level separate independent combos (OR logic between
      *          combos). Each combo is parsed by parse_key_combo. Handles inline
-     *          semicolon comments, whitespace, and gracefully skips empty/invalid combos.
+     *          semicolon comments and whitespace. Two opt-out sentinels yield an
+     *          empty result silently: an empty (post-trim) input, and the literal
+     *          "NONE" (case-insensitive, whole-string only). A non-empty input
+     *          that is not the NONE sentinel and whose every comma-separated token
+     *          fails to parse is treated as a user typo and emits a single WARNING
+     *          naming the binding and the offending raw string. Empty inner tokens
+     *          (e.g. "F4,,F5") are silently skipped; the WARNING fires only when
+     *          the entire result list is empty.
      * @param input The raw string to parse.
+     * @param binding_log_name Optional human-readable binding name used in the
+     *                         typo WARNING. Defaults to an empty view, in which
+     *                         case the WARNING uses "<unnamed>".
      * @return Config::KeyComboList Parsed list of key combinations.
      */
-    Config::KeyComboList parse_key_combo_list(const std::string &input)
+    Config::KeyComboList parse_key_combo_list(const std::string &input,
+                                              std::string_view binding_log_name = {})
     {
         Config::KeyComboList result;
 
@@ -194,7 +233,16 @@ namespace
         const size_t comment_pos = input.find(';');
         const std::string effective = trim(
             (comment_pos != std::string::npos) ? input.substr(0, comment_pos) : input);
+
+        // Disposition 1: explicit opt-out via empty string. Silent.
         if (effective.empty())
+        {
+            return result;
+        }
+
+        // Disposition 2: explicit opt-out via NONE sentinel (whole-string,
+        // case-insensitive, post-trim). Silent.
+        if (is_none_sentinel(effective))
         {
             return result;
         }
@@ -218,6 +266,19 @@ namespace
             {
                 result.push_back(std::move(combo));
             }
+        }
+
+        // Disposition 3: input was non-empty and not the NONE sentinel,
+        // yet every token failed to parse. Real user typo, name it.
+        if (result.empty())
+        {
+            const std::string_view name_view =
+                binding_log_name.empty() ? std::string_view{"<unnamed>"} : binding_log_name;
+            Logger::get_instance().warning(
+                "Config: combo string \"{}\" for binding '{}' did not parse to any "
+                "valid keys; binding will be unbound. Use \"\" or \"NONE\" to opt "
+                "out explicitly.",
+                effective, name_view);
         }
 
         return result;
@@ -402,7 +463,7 @@ namespace
         const char *ini_value_str = ini.GetValue(section.c_str(), ini_key.c_str(), nullptr);
         if (ini_value_str != nullptr)
         {
-            current_value = parse_key_combo_list(ini_value_str);
+            current_value = parse_key_combo_list(ini_value_str, log_key_name);
         }
         else
         {
@@ -906,7 +967,7 @@ void DetourModKit::Config::register_key_combo(std::string_view section, std::str
                                               std::string_view log_key_name, std::function<void(const KeyComboList &)> setter,
                                               std::string_view default_value_str)
 {
-    Config::KeyComboList default_combos = parse_key_combo_list(std::string(default_value_str));
+    Config::KeyComboList default_combos = parse_key_combo_list(std::string(default_value_str), log_key_name);
 
     std::function<void()> deferred;
     {
@@ -934,7 +995,7 @@ DetourModKit::Config::InputBindingGuard DetourModKit::Config::register_press_com
     std::string_view default_value)
 {
     auto enabled_flag = std::make_shared<std::atomic<bool>>(true);
-    auto current_combos = std::make_shared<KeyComboList>(parse_key_combo_list(std::string(default_value)));
+    auto current_combos = std::make_shared<KeyComboList>(parse_key_combo_list(std::string(default_value), log_name));
     std::string binding_name_str(input_binding_name);
 
     register_key_combo(section, ini_key, log_name, [current_combos, binding_name_str](const KeyComboList &combos)
@@ -1287,8 +1348,11 @@ void DetourModKit::Config::disable_auto_reload() noexcept
 bool DetourModKit::Config::register_reload_hotkey(std::string_view ini_key,
                                                   std::string_view default_combo)
 {
-    // An empty default causes register_press_combo to produce zero bindings,
-    // which leaves the hotkey silently inert. Fail loudly instead.
+    // An empty or explicitly-opt-out default would leave the hotkey
+    // silently inert (a binding registered without trigger keys never
+    // fires). Surface that to the caller as a false return so they can
+    // decide whether to fall back to a different combo or skip the
+    // hotkey entirely.
     if (default_combo.empty())
     {
         Logger::get_instance().warning(
@@ -1297,30 +1361,14 @@ bool DetourModKit::Config::register_reload_hotkey(std::string_view ini_key,
         return false;
     }
 
-    // Pre-parse the default to reject syntactically-invalid combos.
-    // register_press_combo silently no-ops on a zero-entry combo list
-    // (InputManager::register_press with empty combos registers the
-    // binding name but never fires). We detect this upstream so callers
-    // see a false return instead of a silently inert hotkey. Piggy-back
-    // on register_key_combo's parser by registering a scratch item
-    // whose setter captures the parsed list -- the real
-    // register_press_combo call below replaces this scratch entry via
-    // replace_or_append, so nothing leaks into the registry.
-    bool parse_succeeded = false;
+    // Pre-parse the default. The parser emits its own WARNING when a
+    // non-empty, non-sentinel string fails to parse, so no extra log is
+    // needed for the typo path. Explicit opt-out via the NONE sentinel
+    // still returns false because a hotkey with no keys is useless.
+    const Config::KeyComboList parsed = parse_key_combo_list(
+        std::string(default_combo), "Config reload hotkey");
+    if (parsed.empty())
     {
-        auto probe = [&parse_succeeded](const KeyComboList &combos)
-        {
-            parse_succeeded = !combos.empty();
-        };
-        register_key_combo("Input", ini_key,
-                           "Config reload hotkey (probe)",
-                           probe, default_combo);
-    }
-    if (!parse_succeeded)
-    {
-        Logger::get_instance().error(
-            "Config: register_reload_hotkey('{}', '{}'): combo string did not parse to any valid combo; hotkey not active.",
-            std::string(ini_key), std::string(default_combo));
         return false;
     }
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -553,7 +553,8 @@ namespace DetourModKit
             // if the binding name persists.
             std::vector<InputBinding> rebuilt;
             std::vector<uint8_t> rebuilt_states;
-            rebuilt.reserve(bindings_.size() - indices.size() + combos.size());
+            rebuilt.reserve(bindings_.size() - indices.size() +
+                            (combos.empty() ? 1 : combos.size()));
             rebuilt_states.reserve(rebuilt.capacity());
             size_t cursor = 0;
             for (size_t skip : indices)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -209,7 +209,7 @@ namespace DetourModKit
     {
         if (poll_thread_.joinable())
         {
-            Logger::get_instance().warning("InputPoller: start() called while already running");
+            Logger::get_instance().debug("InputPoller: start() called while already running; no-op.");
             return;
         }
 
@@ -496,17 +496,6 @@ namespace DetourModKit
                 return false;
             }
 
-            // Reject an empty replacement so a user editing the INI to a blank
-            // value cannot silently disable a callback. To clear a binding the
-            // caller must remove it explicitly.
-            if (combos.empty())
-            {
-                Logger::get_instance().warning(
-                    "InputPoller: update_combos(\"{}\") ignored: replacement combo list is empty",
-                    name);
-                return false;
-            }
-
             std::vector<size_t> indices = it->second;
             if (indices.empty())
             {
@@ -581,13 +570,30 @@ namespace DetourModKit
                 rebuilt_states.push_back(active_states_[i].load(std::memory_order_relaxed));
                 rebuilt.push_back(std::move(bindings_[i]));
             }
-            for (const auto &combo : combos)
+            if (combos.empty())
             {
+                // Empty replacement leaves one inert sentinel entry so the
+                // binding name stays addressable for a subsequent
+                // update_combos() call. Without the sentinel the name would
+                // vanish from name_index_ and a later non-empty update
+                // would be rejected as "name not found", breaking the
+                // bound -> unbound -> bound INI hot-reload cycle.
                 InputBinding b = prototype;
-                b.keys = combo.keys;
-                b.modifiers = combo.modifiers;
+                b.keys.clear();
+                b.modifiers.clear();
                 rebuilt.push_back(std::move(b));
                 rebuilt_states.push_back(0);
+            }
+            else
+            {
+                for (const auto &combo : combos)
+                {
+                    InputBinding b = prototype;
+                    b.keys = combo.keys;
+                    b.modifiers = combo.modifiers;
+                    rebuilt.push_back(std::move(b));
+                    rebuilt_states.push_back(0);
+                }
             }
             bindings_ = std::move(rebuilt);
 
@@ -993,7 +999,7 @@ namespace DetourModKit
 
         if (poller_)
         {
-            Logger::get_instance().warning("InputManager: start() called while already running");
+            Logger::get_instance().debug("InputManager: start() called while already running; no-op.");
             return;
         }
 
@@ -1076,16 +1082,6 @@ namespace DetourModKit
                     return;
                 }
 
-                // Reject an empty replacement so a blank INI value cannot
-                // silently disable a registered binding's callback.
-                if (combos.empty())
-                {
-                    Logger::get_instance().warning(
-                        "InputManager: update_binding_combos(\"{}\") ignored: replacement combo list is empty",
-                        name);
-                    return;
-                }
-
                 if (indices.size() == combos.size())
                 {
                     for (size_t i = 0; i < indices.size(); ++i)
@@ -1100,7 +1096,8 @@ namespace DetourModKit
                     InputBinding prototype = pending_bindings_[indices.front()];
                     std::sort(indices.begin(), indices.end());
                     std::vector<InputBinding> rebuilt;
-                    rebuilt.reserve(pending_bindings_.size() - indices.size() + combos.size());
+                    rebuilt.reserve(pending_bindings_.size() - indices.size() +
+                                    (combos.empty() ? 1 : combos.size()));
                     size_t cursor = 0;
                     for (size_t skip : indices)
                     {
@@ -1114,12 +1111,25 @@ namespace DetourModKit
                     {
                         rebuilt.push_back(std::move(pending_bindings_[i]));
                     }
-                    for (const auto &combo : combos)
+                    if (combos.empty())
                     {
+                        // Preserve a sentinel entry so the binding name
+                        // remains addressable for a later non-empty
+                        // update_binding_combos() call.
                         InputBinding b = prototype;
-                        b.keys = combo.keys;
-                        b.modifiers = combo.modifiers;
+                        b.keys.clear();
+                        b.modifiers.clear();
                         rebuilt.push_back(std::move(b));
+                    }
+                    else
+                    {
+                        for (const auto &combo : combos)
+                        {
+                            InputBinding b = prototype;
+                            b.keys = combo.keys;
+                            b.modifiers = combo.modifiers;
+                            rebuilt.push_back(std::move(b));
+                        }
                     }
                     pending_bindings_ = std::move(rebuilt);
                     updated_pending = true;

--- a/tests/test_bootstrap.cpp
+++ b/tests/test_bootstrap.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstring>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -11,6 +12,7 @@
 #include <windows.h>
 
 #include "DetourModKit/bootstrap.hpp"
+#include "DetourModKit/config.hpp"
 #include "DetourModKit/hook_manager.hpp"
 #include "DetourModKit/input.hpp"
 
@@ -779,4 +781,63 @@ TEST(BootstrapOnLogicDllUnloadAll, FixtureDllRoundTrip)
         strict).has_value());
 
     HookManager::get_instance().remove_all_hooks();
+}
+
+// Verifies that on_logic_dll_unload chains Config::clear_registered_items
+// after the hook and binding teardown so registered std::function
+// setters (whose call operator and destructor live in the unloading
+// Logic DLL) cannot survive into a second attach as use-after-unload
+// hazards.
+//
+// The verification path: a registered setter captures a shared_ptr by
+// value, so the setter closure stored inside the registry holds a
+// strong reference. While the registry retains the entry, use_count
+// stays >= 2 (one local sentinel ref plus one inside the captured
+// closure). Once the helper wipes the registry, the captured closure
+// is destroyed and the local sentinel is the sole owner.
+TEST(BootstrapOnLogicDllUnload, ClearsConfigRegisteredItems)
+{
+    HookManager::get_instance().remove_all_hooks();
+    InputManager::get_instance().shutdown();
+    Config::clear_registered_items();
+
+    auto sentinel = std::make_shared<int>(0);
+    EXPECT_EQ(sentinel.use_count(), 1L);
+
+    Config::register_string(
+        "BootstrapUnloadCfgClear", "Key", "Bootstrap unload key",
+        [sentinel](const std::string &) { /* keeps sentinel alive */ },
+        "default");
+
+    // After registration the captured-by-value shared_ptr lives inside
+    // the setter closure stored in the Config registry, so use_count
+    // includes both the local sentinel and the closure copy.
+    EXPECT_GE(sentinel.use_count(), 2L);
+
+    Bootstrap::on_logic_dll_unload({}, {});
+
+    // The unload helper must have dropped the registry entry, releasing
+    // its captured copy of the sentinel. The local variable is the
+    // only remaining owner.
+    EXPECT_EQ(sentinel.use_count(), 1L);
+}
+
+TEST(BootstrapOnLogicDllUnloadAll, ClearsConfigRegisteredItems)
+{
+    HookManager::get_instance().remove_all_hooks();
+    InputManager::get_instance().shutdown();
+    Config::clear_registered_items();
+
+    auto sentinel = std::make_shared<int>(0);
+    EXPECT_EQ(sentinel.use_count(), 1L);
+
+    Config::register_string(
+        "BootstrapUnloadAllCfgClear", "Key", "Bootstrap unload-all key",
+        [sentinel](const std::string &) { /* keeps sentinel alive */ },
+        "default");
+    EXPECT_GE(sentinel.use_count(), 2L);
+
+    Bootstrap::on_logic_dll_unload_all();
+
+    EXPECT_EQ(sentinel.use_count(), 1L);
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -2346,6 +2346,297 @@ TEST_F(ConfigTest, RegisterAtomic_IntRoundTrip)
 
 namespace
 {
+    // RAII helper that redirects the global Logger to a temporary file and
+    // exposes the captured contents for assertions. Restores the Logger to
+    // its previous file on destruction so subsequent tests see the original
+    // sink. Sync mode is forced because the tests inspect the file
+    // immediately after the logging call returns.
+    class LoggerFileCapture
+    {
+    public:
+        LoggerFileCapture()
+        {
+            static std::atomic<int> counter{0};
+            const int n = counter.fetch_add(1, std::memory_order_relaxed);
+            capture_file_ = std::filesystem::temp_directory_path() /
+                            ("dmk_capture_" + std::to_string(_getpid()) + "_" +
+                             std::to_string(n) + ".log");
+            auto &logger = DetourModKit::Logger::get_instance();
+            previous_async_ = logger.is_async_mode_enabled();
+            if (previous_async_)
+            {
+                logger.disable_async_mode();
+            }
+            logger.reconfigure("CAPTURE", capture_file_.string(), "%H:%M:%S");
+            previous_level_ = logger.get_log_level();
+            logger.set_log_level(DetourModKit::LogLevel::Trace);
+        }
+
+        ~LoggerFileCapture()
+        {
+            auto &logger = DetourModKit::Logger::get_instance();
+            logger.flush();
+            logger.set_log_level(previous_level_);
+            if (previous_async_)
+            {
+                logger.enable_async_mode();
+            }
+            std::error_code ec;
+            std::filesystem::remove(capture_file_, ec);
+        }
+
+        LoggerFileCapture(const LoggerFileCapture &) = delete;
+        LoggerFileCapture &operator=(const LoggerFileCapture &) = delete;
+
+        [[nodiscard]] std::string read_all() const
+        {
+            DetourModKit::Logger::get_instance().flush();
+            std::ifstream in(capture_file_);
+            if (!in)
+            {
+                return {};
+            }
+            return std::string(std::istreambuf_iterator<char>(in),
+                               std::istreambuf_iterator<char>());
+        }
+
+        [[nodiscard]] bool contains_warning_with(std::string_view needle) const
+        {
+            const std::string content = read_all();
+            std::size_t pos = 0;
+            while (true)
+            {
+                const std::size_t next = content.find('\n', pos);
+                const std::string_view line(
+                    content.data() + pos,
+                    (next == std::string::npos ? content.size() : next) - pos);
+                if (line.find("[WARNING]") != std::string_view::npos &&
+                    line.find(needle) != std::string_view::npos)
+                {
+                    return true;
+                }
+                if (next == std::string::npos)
+                {
+                    break;
+                }
+                pos = next + 1;
+            }
+            return false;
+        }
+
+        [[nodiscard]] std::size_t warning_count() const
+        {
+            const std::string content = read_all();
+            std::size_t count = 0;
+            std::size_t pos = 0;
+            while ((pos = content.find("[WARNING]", pos)) != std::string::npos)
+            {
+                ++count;
+                pos += 9;
+            }
+            return count;
+        }
+
+    private:
+        std::filesystem::path capture_file_;
+        DetourModKit::LogLevel previous_level_{DetourModKit::LogLevel::Info};
+        bool previous_async_{false};
+    };
+
+    // Drives parse_key_combo_list indirectly via register_key_combo, which
+    // is the only reachable entry point for the parser from outside the TU.
+    DetourModKit::Config::KeyComboList parse_via_register(
+        std::string_view default_value,
+        std::string_view log_name = "test binding")
+    {
+        DetourModKit::Config::clear_registered_items();
+        DetourModKit::Config::KeyComboList captured;
+        DetourModKit::Config::register_key_combo(
+            "ParserSec", "ParserKey", log_name,
+            [&captured](const DetourModKit::Config::KeyComboList &c)
+            { captured = c; },
+            default_value);
+        return captured;
+    }
+} // namespace
+
+TEST_F(ConfigTest, ParseKeyComboList_EmptyStringIsSilent)
+{
+    LoggerFileCapture cap;
+    auto result = parse_via_register("");
+    EXPECT_TRUE(result.empty());
+    EXPECT_EQ(cap.warning_count(), 0u)
+        << "Empty string is the explicit-empty sentinel; must not warn.";
+}
+
+TEST_F(ConfigTest, ParseKeyComboList_NoneSentinelIsSilent)
+{
+    for (std::string_view literal : {"NONE", "none", "None", "  None  ", "NoNe"})
+    {
+        LoggerFileCapture cap;
+        auto result = parse_via_register(literal);
+        EXPECT_TRUE(result.empty()) << "Failed for: \"" << literal << "\"";
+        EXPECT_EQ(cap.warning_count(), 0u)
+            << "NONE sentinel must be silent; failed for: \"" << literal << "\"";
+    }
+}
+
+TEST_F(ConfigTest, ParseKeyComboList_SingleValidComboNoWarning)
+{
+    LoggerFileCapture cap;
+    auto result = parse_via_register("F4");
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(cap.warning_count(), 0u);
+}
+
+TEST_F(ConfigTest, ParseKeyComboList_MultipleValidCombosNoWarning)
+{
+    LoggerFileCapture cap;
+    auto result = parse_via_register("F4,F5");
+    ASSERT_EQ(result.size(), 2u);
+    EXPECT_EQ(cap.warning_count(), 0u);
+}
+
+TEST_F(ConfigTest, ParseKeyComboList_TypoEmitsOneWarning)
+{
+    LoggerFileCapture cap;
+    auto result = parse_via_register("xyzzy", "press hotkey");
+    EXPECT_TRUE(result.empty());
+    EXPECT_EQ(cap.warning_count(), 1u);
+    EXPECT_TRUE(cap.contains_warning_with("xyzzy"));
+    EXPECT_TRUE(cap.contains_warning_with("press hotkey"));
+}
+
+TEST_F(ConfigTest, ParseKeyComboList_EmptyInnerTokensSkippedSilently)
+{
+    LoggerFileCapture cap;
+    auto result = parse_via_register("F4,,F5");
+    ASSERT_EQ(result.size(), 2u);
+    EXPECT_EQ(cap.warning_count(), 0u);
+}
+
+TEST_F(ConfigTest, ParseKeyComboList_AllTokensTypoEmitsOneWarning)
+{
+    LoggerFileCapture cap;
+    auto result = parse_via_register("xyzzy,blarg", "multi typo");
+    EXPECT_TRUE(result.empty());
+    EXPECT_EQ(cap.warning_count(), 1u);
+    EXPECT_TRUE(cap.contains_warning_with("multi typo"));
+}
+
+TEST_F(ConfigTest, ParseKeyComboList_PartialParseDoesNotWarn)
+{
+    // F4 parses, xyzzy does not. Result is non-empty, so no typo WARNING.
+    LoggerFileCapture cap;
+    auto result = parse_via_register("F4,xyzzy");
+    ASSERT_GE(result.size(), 1u);
+    EXPECT_EQ(cap.warning_count(), 0u);
+}
+
+TEST_F(ConfigTest, EndToEnd_EmptyDefaultThenReloadStaysSilent)
+{
+    InputManager::get_instance().shutdown();
+    {
+        std::ofstream f(test_ini_file_);
+        f << "[Hotkeys]\n";
+    }
+    LoggerFileCapture cap;
+    auto guard = Config::register_press_combo(
+        "Hotkeys", "EmptyKey", "empty default test",
+        "endtoend-empty-default", []() {}, "");
+
+    ASSERT_NO_THROW(Config::load(test_ini_file_.string()));
+    ASSERT_TRUE(Config::reload());
+
+    EXPECT_EQ(cap.warning_count(), 0u)
+        << "Empty default + missing INI key must produce no WARNING.";
+
+    guard.release();
+    InputManager::get_instance().shutdown();
+}
+
+TEST_F(ConfigTest, EndToEnd_BoundEmptyBoundCycle)
+{
+    // The bound -> unbound -> bound transition must complete without losing
+    // the binding name. Closes the Risk 6 secondary observation.
+    InputManager::get_instance().shutdown();
+    {
+        std::ofstream f(test_ini_file_);
+        f << "[Hotkeys]\nKey=F4\n";
+    }
+    auto guard = Config::register_press_combo(
+        "Hotkeys", "Key", "cycle test", "endtoend-cycle", []() {}, "F4");
+
+    ASSERT_NO_THROW(Config::load(test_ini_file_.string()));
+    EXPECT_EQ(InputManager::get_instance().binding_count(), static_cast<size_t>(1));
+
+    {
+        std::ofstream f(test_ini_file_);
+        f << "[Hotkeys]\nKey=\n";
+    }
+    LoggerFileCapture cap;
+    ASSERT_TRUE(Config::reload());
+    EXPECT_FALSE(InputManager::get_instance().is_binding_active("endtoend-cycle"));
+    EXPECT_EQ(cap.warning_count(), 0u)
+        << "Empty INI value must unbind silently.";
+
+    {
+        std::ofstream f(test_ini_file_);
+        f << "[Hotkeys]\nKey=F5\n";
+    }
+    ASSERT_TRUE(Config::reload());
+    EXPECT_EQ(InputManager::get_instance().binding_count(), static_cast<size_t>(1));
+
+    guard.release();
+    InputManager::get_instance().shutdown();
+}
+
+TEST_F(ConfigTest, EndToEnd_TypoEmitsOneWarning)
+{
+    InputManager::get_instance().shutdown();
+    {
+        std::ofstream f(test_ini_file_);
+        f << "[Hotkeys]\nKey=F4\n";
+    }
+    auto guard = Config::register_press_combo(
+        "Hotkeys", "Key", "typo test", "endtoend-typo", []() {}, "F4");
+
+    ASSERT_NO_THROW(Config::load(test_ini_file_.string()));
+
+    {
+        std::ofstream f(test_ini_file_);
+        f << "[Hotkeys]\nKey=xyzzy\n";
+    }
+    LoggerFileCapture cap;
+    ASSERT_TRUE(Config::reload());
+    EXPECT_EQ(cap.warning_count(), 1u);
+    EXPECT_TRUE(cap.contains_warning_with("xyzzy"));
+    EXPECT_TRUE(cap.contains_warning_with("typo test"));
+    EXPECT_FALSE(InputManager::get_instance().is_binding_active("endtoend-typo"));
+
+    guard.release();
+    InputManager::get_instance().shutdown();
+}
+
+TEST_F(ConfigTest, EndToEnd_NoneDefaultRegistersCleanly)
+{
+    InputManager::get_instance().shutdown();
+    LoggerFileCapture cap;
+    auto guard = Config::register_press_combo(
+        "Hotkeys", "Key", "none default", "endtoend-none-default",
+        []() {}, "NONE");
+
+    EXPECT_EQ(InputManager::get_instance().binding_count(), static_cast<size_t>(1))
+        << "NONE default must still reserve the binding name as a sentinel.";
+    EXPECT_EQ(cap.warning_count(), 0u)
+        << "NONE default must register without warning.";
+
+    guard.release();
+    InputManager::get_instance().shutdown();
+}
+
+namespace
+{
     // SFINAE probe: detects whether register_atomic<T> can be invoked. The
     // primary template is = delete, so only the explicit specialisations
     // (int, bool, float) yield a viable overload.

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -2347,10 +2347,12 @@ TEST_F(ConfigTest, RegisterAtomic_IntRoundTrip)
 namespace
 {
     // RAII helper that redirects the global Logger to a temporary file and
-    // exposes the captured contents for assertions. Restores the Logger to
-    // its previous file on destruction so subsequent tests see the original
-    // sink. Sync mode is forced because the tests inspect the file
-    // immediately after the logging call returns.
+    // exposes the captured contents for assertions. On destruction the Logger
+    // is parked on a stable per-process file so the capture file's handle is
+    // released and remove() succeeds on Windows; subsequent tests overwrite
+    // the parking sink as needed via their own reconfigure() calls. Sync mode
+    // is forced because the tests inspect the file immediately after the
+    // logging call returns.
     class LoggerFileCapture
     {
     public:
@@ -2376,6 +2378,10 @@ namespace
         {
             auto &logger = DetourModKit::Logger::get_instance();
             logger.flush();
+            const auto parking = std::filesystem::temp_directory_path() /
+                                 ("dmk_capture_parked_" +
+                                  std::to_string(_getpid()) + ".log");
+            logger.reconfigure("PARKED", parking.string(), "%H:%M:%S");
             logger.set_log_level(previous_level_);
             if (previous_async_)
             {

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -1750,8 +1750,11 @@ TEST(InputManagerUpdateCombos, CardinalityCanShrink)
     im.shutdown();
 }
 
-TEST(InputManagerUpdateCombos, EmptyReplacementIsRejected)
+TEST(InputManagerUpdateCombos, EmptyReplacementUnbindsAndPreservesName)
 {
+    // Empty replacement is the explicit-unbound state. The binding name
+    // must remain addressable so a follow-up non-empty update can rebind
+    // it; the entry count collapses to a single inert sentinel.
     auto &im = InputManager::get_instance();
     im.shutdown();
 
@@ -1762,6 +1765,13 @@ TEST(InputManagerUpdateCombos, EmptyReplacementIsRejected)
 
     Config::KeyComboList replacement;
     im.update_binding_combos("update-empty-clear", replacement);
+    EXPECT_EQ(im.binding_count(), static_cast<size_t>(1));
+    EXPECT_FALSE(im.is_binding_active("update-empty-clear"));
+
+    // Rebind the same name with a real combo; the sentinel must accept it.
+    Config::KeyComboList rebind;
+    rebind.push_back({{keyboard_key(0x42)}, {}});
+    im.update_binding_combos("update-empty-clear", rebind);
     EXPECT_EQ(im.binding_count(), static_cast<size_t>(1));
     im.shutdown();
 }

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -15,7 +15,7 @@ namespace
 
     TEST(VersionTest, VersionStringMatchesMacros)
     {
-        EXPECT_STREQ(DMK_VERSION_STRING, "3.2.2");
+        EXPECT_STREQ(DMK_VERSION_STRING, "3.2.3");
     }
 
     TEST(VersionTest, AtLeastComparisonsAreCorrect)

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -10,7 +10,7 @@ namespace
     {
         EXPECT_EQ(DMK_VERSION_MAJOR, 3);
         EXPECT_EQ(DMK_VERSION_MINOR, 2);
-        EXPECT_EQ(DMK_VERSION_PATCH, 2);
+        EXPECT_EQ(DMK_VERSION_PATCH, 3);
     }
 
     TEST(VersionTest, VersionStringMatchesMacros)
@@ -20,12 +20,13 @@ namespace
 
     TEST(VersionTest, AtLeastComparisonsAreCorrect)
     {
+        EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 3));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 2));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 1));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 1, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(2, 0, 0));
-        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 2, 3));
+        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 2, 4));
         EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 3, 0));
         EXPECT_FALSE(DMK_VERSION_AT_LEAST(4, 0, 0));
     }


### PR DESCRIPTION
## Summary

Behavioral and safety pass on top of v3.2.2. No public API additions.

* **Combo opt-out:** empty string and `NONE` (case-insensitive, post-trim, whole-string) are first-class silent opt-out sentinels for `register_press_combo` / `register_hold_combo` / `register_key_combo` and INI-driven `update_binding_combos`. The previous "empty replacement is rejected" guard moves to the parse boundary, where it logs exactly one WARNING naming the binding and the offending raw string. The bound -> unbound -> bound INI cycle now round-trips cleanly.
* **Hot-reload safety:** `Bootstrap::on_logic_dll_unload(_all)` chains `Config::clear_registered_items()` after the hook and binding teardown. Closes a use-after-unload hazard where registered `std::function` setters held call operators in the unloading Logic DLL's `.text` segment.
* **Log noise:** `InputPoller::start()` and `InputManager::start()` log "called while already running" at DEBUG instead of WARNING. The call has always been a no-op; the WARNING was per-reload spam in the persistent-host topology.
* **Docs:** `docs/hot-reload/README.md` gains four new sections that previously had to be reverse-engineered from headers:
  * Decision matrix for `on_logic_dll_unload` vs `DMK_Shutdown`.
  * Pre-unload contract (worker-thread quiescence).
  * Idempotency contract (which APIs are safe to call twice on hot-reload, which need a clear-and-rebind step first).
  * Combo string syntax (the three opt-out / parse dispositions).
* **README description** sharpened from "lightweight" to "full-featured" with the v3.x subsystem list.

## Backwards compatibility

All v3.2.0 through v3.2.2 APIs are unchanged. Behavioural changes are all in the direction of accepting previously rejected inputs without diagnostic; no previously valid call site changes meaning.

## Tests

1073/1073 pass on `mingw-debug`. Twelve new combo-parser tests cover the opt-out dispositions, the typo WARNING contract, and the bound -> unbound -> bound cycle. One new bootstrap test verifies the Config registry chain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v3.2.3

* **New Features**
  * Added support for `"NONE"` sentinel values and empty strings to disable hotkeys and key bindings.
  * Enabled unbinding via empty combo lists as a supported operation.

* **Documentation**
  * Expanded configuration and hot-reload guides with new opt-out semantics and clearer reload/teardown usage patterns.
  * Added guidance on input handling and DLL lifecycle orchestration.

* **Tests**
  * Added comprehensive tests for configuration parsing, opt-out behavior, and unload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->