### PR TITLE
chore: demote lifecycle log lines to debug/trace

### DIFF
--- a/src/hook_manager.cpp
+++ b/src/hook_manager.cpp
@@ -118,9 +118,9 @@ HookManager::HookManager(Logger &logger)
     }
     else
     {
-        m_logger.info("HookManager: SafetyHook global allocator obtained.");
+        m_logger.debug("HookManager: SafetyHook global allocator obtained.");
     }
-    m_logger.info("HookManager: Initialized.");
+    m_logger.debug("HookManager: Initialized.");
 }
 
 HookManager::~HookManager() noexcept
@@ -479,9 +479,9 @@ std::expected<std::string, HookError> HookManager::create_inline_hook_aob(
     }
 
     uintptr_t target_address = reinterpret_cast<uintptr_t>(found_address_start) + aob_offset;
-    m_logger.info("HookManager: AOB pattern for inline hook '{}' found at {}. Applying offset {}. Final target hook address: {}.",
-                  name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(found_address_start)),
-                  DetourModKit::Format::format_hex(aob_offset), DetourModKit::Format::format_address(target_address));
+    m_logger.debug("HookManager: AOB pattern for inline hook '{}' found at {}. Applying offset {}. Final target hook address: {}.",
+                   name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(found_address_start)),
+                   DetourModKit::Format::format_hex(aob_offset), DetourModKit::Format::format_address(target_address));
 
     return create_inline_hook(name, target_address, detour_function, original_trampoline, config);
 }
@@ -623,9 +623,9 @@ std::expected<std::string, HookError> HookManager::create_mid_hook_aob(
     }
 
     uintptr_t target_address = reinterpret_cast<uintptr_t>(found_address_start) + aob_offset;
-    m_logger.info("HookManager: AOB pattern for mid hook '{}' found at {}. Applying offset {}. Final target hook address: {}.",
-                  name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(found_address_start)),
-                  DetourModKit::Format::format_hex(aob_offset), DetourModKit::Format::format_address(target_address));
+    m_logger.debug("HookManager: AOB pattern for mid hook '{}' found at {}. Applying offset {}. Final target hook address: {}.",
+                   name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(found_address_start)),
+                   DetourModKit::Format::format_hex(aob_offset), DetourModKit::Format::format_address(target_address));
 
     return create_mid_hook(name, target_address, detour_function, config);
 }
@@ -681,8 +681,8 @@ std::expected<void, HookError> HookManager::remove_hook(std::string_view hook_id
         std::string name_of_removed_hook = it->second->get_name();
         HookType type_of_removed_hook = it->second->get_type();
         m_hooks.erase(it);
-        m_logger.info("HookManager: Hook '{}' of type '{}' has been removed and unhooked.",
-                      name_of_removed_hook, (type_of_removed_hook == HookType::Inline ? "Inline" : "Mid"));
+        m_logger.debug("HookManager: Hook '{}' of type '{}' has been removed and unhooked.",
+                       name_of_removed_hook, (type_of_removed_hook == HookType::Inline ? "Inline" : "Mid"));
     }
     return {};
 }
@@ -719,16 +719,16 @@ void HookManager::remove_all_hooks()
     size_t num_vmt = m_vmt_hooks.size();
     if (num_vmt > 0)
     {
-        m_logger.info("HookManager: Removing all {} VMT hooks...", num_vmt);
+        m_logger.debug("HookManager: Removing all {} VMT hooks...", num_vmt);
         m_vmt_hooks.clear();
     }
 
     if (!m_hooks.empty())
     {
         size_t num_hooks = m_hooks.size();
-        m_logger.info("HookManager: Removing all {} managed hooks...", num_hooks);
+        m_logger.debug("HookManager: Removing all {} managed hooks...", num_hooks);
         m_hooks.clear();
-        m_logger.info("HookManager: All {} managed hooks have been removed and unhooked.", num_hooks);
+        m_logger.debug("HookManager: All {} managed hooks have been removed and unhooked.", num_hooks);
     }
     else if (num_vmt == 0)
     {
@@ -769,7 +769,7 @@ std::expected<void, HookError> HookManager::enable_hook(std::string_view hook_id
     auto result = hook->enable();
     if (result)
     {
-        m_logger.info("HookManager: Hook '{}' successfully enabled.", hook_id);
+        m_logger.debug("HookManager: Hook '{}' successfully enabled.", hook_id);
         return {};
     }
 
@@ -811,7 +811,7 @@ std::expected<void, HookError> HookManager::disable_hook(std::string_view hook_i
     auto result = hook->disable();
     if (result)
     {
-        m_logger.info("HookManager: Hook '{}' successfully disabled.", hook_id);
+        m_logger.debug("HookManager: Hook '{}' successfully disabled.", hook_id);
         return {};
     }
 
@@ -958,7 +958,7 @@ std::expected<void, HookError> HookManager::remove_vmt_hook(std::string_view vmt
     {
         std::string removed_name = it->second.get_name();
         m_vmt_hooks.erase(it);
-        m_logger.info("HookManager: VMT hook '{}' has been removed.", removed_name);
+        m_logger.debug("HookManager: VMT hook '{}' has been removed.", removed_name);
         return {};
     }
     m_logger.warning("HookManager: Attempted to remove VMT hook '{}', but it was not found.", vmt_name);
@@ -984,7 +984,7 @@ std::expected<void, HookError> HookManager::remove_vmt_method(std::string_view v
 
     if (it->second.remove_method_hook(method_index))
     {
-        m_logger.info("HookManager: VMT '{}' method index {} has been unhooked.", vmt_name, method_index);
+        m_logger.debug("HookManager: VMT '{}' method index {} has been unhooked.", vmt_name, method_index);
         return {};
     }
 
@@ -1015,8 +1015,8 @@ bool HookManager::apply_vmt_hook(std::string_view vmt_name, void *object)
     }
 
     it->second.vmt_hook().apply(object);
-    m_logger.info("HookManager: VMT hook '{}' applied to object {}.",
-                  vmt_name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(object)));
+    m_logger.debug("HookManager: VMT hook '{}' applied to object {}.",
+                   vmt_name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(object)));
     return true;
 }
 
@@ -1043,8 +1043,8 @@ bool HookManager::remove_vmt_from_object(std::string_view vmt_name, void *object
     }
 
     it->second.vmt_hook().remove(object);
-    m_logger.info("HookManager: VMT hook '{}' removed from object {}.",
-                  vmt_name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(object)));
+    m_logger.debug("HookManager: VMT hook '{}' removed from object {}.",
+                   vmt_name, DetourModKit::Format::format_address(reinterpret_cast<uintptr_t>(object)));
     return true;
 }
 
@@ -1058,9 +1058,9 @@ void HookManager::remove_all_vmt_hooks()
     if (!m_vmt_hooks.empty())
     {
         size_t num_hooks = m_vmt_hooks.size();
-        m_logger.info("HookManager: Removing all {} VMT hooks...", num_hooks);
+        m_logger.debug("HookManager: Removing all {} VMT hooks...", num_hooks);
         m_vmt_hooks.clear();
-        m_logger.info("HookManager: All {} VMT hooks have been removed.", num_hooks);
+        m_logger.debug("HookManager: All {} VMT hooks have been removed.", num_hooks);
     }
     else
     {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1015,7 +1015,7 @@ namespace DetourModKit
 
         for (const auto &binding : pending_bindings_)
         {
-            logger.debug("InputManager: Registered {} binding \"{}\" with {} key(s)",
+            logger.trace("InputManager: Registered {} binding \"{}\" with {} key(s)",
                          input_mode_to_string(binding.mode), binding.name, binding.keys.size());
         }
 
@@ -1144,7 +1144,7 @@ namespace DetourModKit
         }
         else if (updated_pending)
         {
-            Logger::get_instance().debug(
+            Logger::get_instance().trace(
                 "InputManager: update_binding_combos(\"{}\") applied to pending bindings", name);
         }
     }

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -966,9 +966,9 @@ DetourModKit::Scanner::resolve_cascade(std::span<const AddrCandidate> candidates
     if (attempt.success)
     {
         const auto &winner = candidates[attempt.index];
-        logger.info("{} resolved via '{}' at {}", label,
-                    winner.name.empty() ? std::string_view{"<unnamed>"} : winner.name,
-                    Format::format_address(attempt.address));
+        logger.debug("{} resolved via '{}' at {}", label,
+                     winner.name.empty() ? std::string_view{"<unnamed>"} : winner.name,
+                     Format::format_address(attempt.address));
         return ResolveHit{attempt.address, winner.name};
     }
 
@@ -999,9 +999,9 @@ DetourModKit::Scanner::resolve_cascade_with_prologue_fallback(
     if (attempt.success)
     {
         const auto &winner = candidates[attempt.index];
-        logger.info("{} resolved via '{}' at {}", label,
-                    winner.name.empty() ? std::string_view{"<unnamed>"} : winner.name,
-                    Format::format_address(attempt.address));
+        logger.debug("{} resolved via '{}' at {}", label,
+                     winner.name.empty() ? std::string_view{"<unnamed>"} : winner.name,
+                     Format::format_address(attempt.address));
         return ResolveHit{attempt.address, winner.name};
     }
 
@@ -1009,7 +1009,7 @@ DetourModKit::Scanner::resolve_cascade_with_prologue_fallback(
     if (hooked.attempt.success)
     {
         const auto &winner = candidates[hooked.attempt.index];
-        logger.info(
+        logger.debug(
             "{} resolved via '{}' at {} (pre-hooked prologue; reusing target)",
             label,
             winner.name.empty() ? std::string_view{"<unnamed>"} : winner.name,

--- a/tests/test_scanner.cpp
+++ b/tests/test_scanner.cpp
@@ -2031,9 +2031,12 @@ TEST(ScannerCascade, PrologueFallbackRejectsAmbiguousTail)
     // collide with any other test's pattern, because residue in
     // freed-but-still-mapped memory could influence subsequent tests that
     // run in the same process.
+    // Prefix mimics a SafetyHook-installed JMP rel32 over the original
+    // prologue -- the only shape the fallback recognises before rebuilding
+    // the AOB from the literal tail described above.
     constexpr std::uint8_t kAmbiguousTemplate[] = {
-        0xE9, 0x00, 0x00, 0x00, 0x00,                                     // JMP rel32
-        0xA5, 0xB6, 0xC7, 0xD8, 0xE9, 0xFA, 0x0B, 0x1C, 0x2D, 0x3E, 0x4F, // unique 11-byte tail
+        0xE9, 0x00, 0x00, 0x00, 0x00,
+        0xA5, 0xB6, 0xC7, 0xD8, 0xE9, 0xFA, 0x0B, 0x1C, 0x2D, 0x3E, 0x4F,
     };
 
     // Seed two copies so the rebuilt fallback pattern tallies >= 2 hits in
@@ -2095,9 +2098,13 @@ TEST(ScannerCascade, PrologueFallbackRejectsExactlyTwoMatches)
 
     std::memset(buf.base, 0xCC, buf.size);
 
+    // Prefix mimics a SafetyHook-installed JMP rel32 over the original
+    // prologue (the shape the fallback rebuilds around). The 11-byte
+    // tail clears kPrologueFallbackMinTailLiterals so the test reaches
+    // the uniqueness check rather than the literal-floor refusal.
     constexpr std::uint8_t kTemplate[] = {
-        0xE9, 0x00, 0x00, 0x00, 0x00,                                     // JMP rel32
-        0x71, 0x82, 0x93, 0xA4, 0xB5, 0xC6, 0xD7, 0xE8, 0xF9, 0x0A, 0x1B, // unique 11-byte tail
+        0xE9, 0x00, 0x00, 0x00, 0x00,
+        0x71, 0x82, 0x93, 0xA4, 0xB5, 0xC6, 0xD7, 0xE8, 0xF9, 0x0A, 0x1B,
     };
 
     std::memcpy(buf.base + 0x000, kTemplate, sizeof(kTemplate));


### PR DESCRIPTION
## Summary

Reduces startup and lifecycle log noise. Successful resolution and hook lifecycle messages were INFO; they are now DEBUG. Per-binding registration in InputManager was DEBUG; now TRACE. Failures still log at WARNING/ERROR.

## Changes

- `Scanner::resolve_cascade*` success messages: INFO -> DEBUG
- `HookManager` init, AOB-found, enable/disable, per-hook and bulk removal messages: INFO -> DEBUG
- `InputManager` per-binding registration and `update_binding_combos` pending-update notice: DEBUG -> TRACE
- Two `test_scanner.cpp` byte-array comments rewritten to explain why the JMP rel32 prefix is present (test intent) instead of what the bytes are

## Rationale

End users do not need confirmation of every successful resolution or per-hook lifecycle event. Demoting these keeps INFO meaningful while preserving full detail at DEBUG/TRACE for diagnostics. No behavior or API change; the global `Log_Level` setting still controls visibility.

## Test plan

- [x] Library and full test suite build clean (MinGW)
- [x] Full test suite passes: 1075/1075
- [x] Grep confirms no tests assert on the demoted log strings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging verbosity levels across hook management, input binding, and pattern scanning systems to improve development diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tkhquang/DetourModKit/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->