### PR TITLE
feat(scanner): add function prologue helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ DetourModKit is a full-featured C++ toolkit designed to simplify common tasks in
 - Nth-occurrence matching (1-based) for patterns that hit multiple locations
 - RIP-relative instruction resolution for extracting absolute addresses from x86-64 code (returns `std::expected` with typed `RipResolveError` for actionable diagnostics)
 - `scan_executable_regions()` for scanning all committed executable pages in the process - useful for games with packed or protected binaries that unpack code into anonymous memory outside any loaded module (pure-execute pages without a read bit are skipped to avoid access violations)
+- `is_likely_function_prologue(addr)` heuristic that rejects scan poison (zero pages, alignment pads, bare RET stubs) while still accepting JMP-shaped patched prologues so nested-hook scenarios resolve
 
 </details>
 
@@ -73,7 +74,8 @@ DetourModKit is a full-featured C++ toolkit designed to simplify common tasks in
 
 </details>
 
-### Config hot-reload
+<details>
+<summary><strong>Config Hot-Reload</strong></summary>
 
 Two mechanisms share the same `Config::reload()` primitive - use either or both:
 
@@ -99,6 +101,8 @@ InputManager::get_instance().start();
 ```
 
 See the [Config Hot-Reload Guide](docs/config-hot-reload/README.md) for the thread-safety contract, debounce rationale, rename-swap-save handling, and the list of settings that are safe to hot-reload vs restart-required.
+
+</details>
 
 <details>
 <summary><strong>Logger</strong></summary>

--- a/docs/misc/aob-signatures.md
+++ b/docs/misc/aob-signatures.md
@@ -433,17 +433,15 @@ uintptr_t resolve_first_hit(
 
 A lone signature hit is necessary but not sufficient. Two lightweight checks catch the overwhelming majority of mis-hits:
 
-- **First-byte sanity check.** A function prologue does not start with `0x00`, `0xC2`, `0xC3`, or (usually) `0xCC`. Reject obvious garbage before you hand the address to SafetyHook.
-- **`Memory::is_readable()` guard.** Confirm the resolved address is inside a committed page with an expected protection flag before dereferencing or hooking.
+- **First-byte sanity check.** A function prologue does not start with `0x00`, `0xC2`, `0xC3`, or (usually) `0xCC`. Use `Scanner::is_likely_function_prologue(addr)` to reject scan poison before handing the address to SafetyHook. The helper accepts `0xE9` / `0xEB` / `0xFF 0x25` so a target already inline-hooked by another mod still passes.
+- **`Memory::is_readable()` guard.** Before reading more than a single byte (for example, disassembling a 5-byte trampoline or copying out an RTTI string), confirm the entire span is inside a committed page with an expected protection flag.
 
 ```cpp
-bool looks_like_prologue(const std::byte* addr)
-{
-    if (!DetourModKit::Memory::is_readable(addr, 1))
-        return false;
+using DetourModKit::Scanner::is_likely_function_prologue;
 
-    const auto b = static_cast<uint8_t>(*addr);
-    return b != 0x00 && b != 0xC2 && b != 0xC3 && b != 0xCC;
+if (!is_likely_function_prologue(resolved_addr))
+{
+    return; // scan poison: zero page, alignment pad, or bare RET
 }
 ```
 
@@ -577,7 +575,7 @@ Reminder: both `find_pattern` overloads return the marked byte when a `|` marker
 | `find_pattern` returns `nullptr` every time | Wildcards too broad, or the literal bytes include a byte the binary never has | Reduce wildcard count; print a few hex dumps around the expected site |
 | `find_pattern` hits the wrong site | Signature not unique | Pick a tighter neighbour, or use the Nth-occurrence overload with a confirmed N |
 | `resolve_rip_relative` returns `UnreadableDisplacement` | Match landed inside a guard page or at a region edge | Validate the caller's `search_length` and `instruction_length`; consider `scan_executable_regions` |
-| Hit address crashes on first call | Missing post-match verification; anchor drifted into padding on a new build | Add `looks_like_prologue` and an `is_readable` check before hooking |
+| Hit address crashes on first call | Missing post-match verification; anchor drifted into padding on a new build | Gate with `Scanner::is_likely_function_prologue(addr)` before hooking |
 | Works locally, fails on a different machine | Packer or anti-cheat transforming the module between load and scan | Switch to `scan_executable_regions`; add a later re-scan on first frame |
 | Multi-GB scan is slow | Patterns whose only literal bytes are common (`48 8B`, `E8`, etc.) | Broaden the anchor to include a rarer byte; the anchor selector prefers rarer bytes |
 

--- a/include/DetourModKit/scanner.hpp
+++ b/include/DetourModKit/scanner.hpp
@@ -352,6 +352,39 @@ namespace DetourModKit
                                                std::string_view label);
 
         /**
+         * @brief Cheap heuristic: does @p addr look like the first byte of a
+         *        real function body?
+         * @details Reads exactly one byte from @p addr behind a Memory::is_readable()
+         *          gate and rejects a small blacklist of bytes that are never the
+         *          first opcode of a callable x86-64 function:
+         *
+         *          - 0x00       uninitialised page / zero-fill BSS / NULL page
+         *          - 0xCC       int3 breakpoint / alignment pad / debugger trap
+         *          - 0xC2 0xC3  bare RET (stub, not a callable body)
+         *
+         *          Returns true for every other byte, including 0xE9 / 0xEB /
+         *          the 0xFF 0x25 prefix of an indirect JMP, so a target whose
+         *          prologue has already been overwritten by SafetyHook or MinHook
+         *          still passes -- the resolver must succeed for nested-hook
+         *          scenarios.
+         *
+         *          This is the negative complement to
+         *          resolve_cascade_with_prologue_fallback(), which is a positive
+         *          recovery (rebuild the hooked-prologue pattern and retry). Both
+         *          can be used together: the cascade resolves the target, then
+         *          this helper filters scan poison if the AOB happened to land on
+         *          a zero page or an alignment pad.
+         *
+         * @param addr Absolute address to probe. @p addr == 0 returns false
+         *             without reading memory. An unreadable address returns
+         *             false (the byte could not be read, so the answer is
+         *             "not a prologue").
+         * @return true if the byte at @p addr is not on the poison list and was
+         *         readable; false otherwise.
+         */
+        [[nodiscard]] bool is_likely_function_prologue(std::uintptr_t addr) noexcept;
+
+        /**
          * @enum SimdLevel
          * @brief Reports the highest SIMD tier available for pattern verification.
          */

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -1033,3 +1033,20 @@ DetourModKit::Scanner::resolve_cascade_with_prologue_fallback(
     logger.warning("{}: cascade AOB scan failed (including prologue fallback).", label);
     return std::unexpected(ResolveError::NoMatch);
 }
+
+bool DetourModKit::Scanner::is_likely_function_prologue(std::uintptr_t addr) noexcept
+{
+    if (addr == 0)
+    {
+        return false;
+    }
+
+    const auto *probe = reinterpret_cast<const void *>(addr);
+    if (!Memory::is_readable(probe, 1))
+    {
+        return false;
+    }
+
+    const auto b0 = *reinterpret_cast<const std::uint8_t *>(addr);
+    return b0 != 0x00 && b0 != 0xCC && b0 != 0xC2 && b0 != 0xC3;
+}

--- a/tests/test_scanner.cpp
+++ b/tests/test_scanner.cpp
@@ -1,7 +1,8 @@
 #include <gtest/gtest.h>
-#include <vector>
+#include <cstdint>
 #include <cstring>
 #include <span>
+#include <vector>
 
 #include "DetourModKit/scanner.hpp"
 #include "DetourModKit/memory.hpp"
@@ -2121,4 +2122,83 @@ TEST(ScannerCascade, PrologueFallbackRejectsExactlyTwoMatches)
 
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), Scanner::ResolveError::NoMatch);
+}
+
+TEST(ScannerPrologueTest, NullAddrReturnsFalse)
+{
+    EXPECT_FALSE(Scanner::is_likely_function_prologue(0));
+}
+
+TEST(ScannerPrologueTest, ZeroByteReturnsFalse)
+{
+    ExecBuffer buf(0x1000);
+    ASSERT_NE(buf.base, nullptr);
+    std::memset(buf.base, 0xCC, buf.size);
+    buf.base[0x100] = 0x00;
+    EXPECT_FALSE(Scanner::is_likely_function_prologue(
+        reinterpret_cast<std::uintptr_t>(buf.base + 0x100)));
+}
+
+TEST(ScannerPrologueTest, Int3PadReturnsFalse)
+{
+    ExecBuffer buf(0x1000);
+    ASSERT_NE(buf.base, nullptr);
+    std::memset(buf.base, 0xCC, buf.size);
+    EXPECT_FALSE(Scanner::is_likely_function_prologue(
+        reinterpret_cast<std::uintptr_t>(buf.base + 0x100)));
+}
+
+TEST(ScannerPrologueTest, BareRetC3ReturnsFalse)
+{
+    ExecBuffer buf(0x1000);
+    ASSERT_NE(buf.base, nullptr);
+    std::memset(buf.base, 0xCC, buf.size);
+    buf.base[0x100] = 0xC3;
+    EXPECT_FALSE(Scanner::is_likely_function_prologue(
+        reinterpret_cast<std::uintptr_t>(buf.base + 0x100)));
+}
+
+TEST(ScannerPrologueTest, BareRetC2ReturnsFalse)
+{
+    ExecBuffer buf(0x1000);
+    ASSERT_NE(buf.base, nullptr);
+    std::memset(buf.base, 0xCC, buf.size);
+    buf.base[0x100] = 0xC2;
+    EXPECT_FALSE(Scanner::is_likely_function_prologue(
+        reinterpret_cast<std::uintptr_t>(buf.base + 0x100)));
+}
+
+TEST(ScannerPrologueTest, PushRbpReturnsTrue)
+{
+    ExecBuffer buf(0x1000);
+    ASSERT_NE(buf.base, nullptr);
+    std::memset(buf.base, 0xCC, buf.size);
+    buf.base[0x100] = 0x55; // push rbp -- canonical x86-64 prologue
+    EXPECT_TRUE(Scanner::is_likely_function_prologue(
+        reinterpret_cast<std::uintptr_t>(buf.base + 0x100)));
+}
+
+// Load-bearing case: documents the no-interference-with-nested-hooks
+// contract. A target whose prologue has already been overwritten by
+// SafetyHook or MinHook starts with a JMP rel32 (0xE9); the helper must
+// still accept it so the resolver path stays usable when a sibling mod
+// hooked the same function first.
+TEST(ScannerPrologueTest, PatchedJmpE9ReturnsTrue)
+{
+    ExecBuffer buf(0x1000);
+    ASSERT_NE(buf.base, nullptr);
+    std::memset(buf.base, 0xCC, buf.size);
+    buf.base[0x100] = 0xE9;
+    EXPECT_TRUE(Scanner::is_likely_function_prologue(
+        reinterpret_cast<std::uintptr_t>(buf.base + 0x100)));
+}
+
+TEST(ScannerPrologueTest, UnreadableAddrReturnsFalse)
+{
+    void *na = VirtualAlloc(nullptr, 0x1000,
+                            MEM_COMMIT | MEM_RESERVE, PAGE_NOACCESS);
+    ASSERT_NE(na, nullptr);
+    EXPECT_FALSE(Scanner::is_likely_function_prologue(
+        reinterpret_cast<std::uintptr_t>(na)));
+    VirtualFree(na, 0, MEM_RELEASE);
 }


### PR DESCRIPTION
## Summary

Adds `Scanner::is_likely_function_prologue(addr)` for filtering scan poison after a cascade resolves. Cheap first-byte blacklist (`0x00`, `0xCC`, `0xC2`, `0xC3`) gated by `Memory::is_readable`, with a null-address short-circuit. Accepts `0xE9` / `0xEB` / `0xFF 0x25` so nested-hook scenarios (a sibling mod has already overwritten the prologue with a JMP trampoline) still resolve.

## Test plan

- [x] `ScannerPrologueTest` (8 cases) green: null, zero byte, int3 pad, both bare-RET forms, push rbp, patched JMP, `PAGE_NOACCESS`
- [x] Full local suite green (1083/1083 on MinGW debug)
- [x] CI green on MinGW + MSVC + ASan/UBSan presets

## Docs

README scanner bullet, `docs/misc/aob-signatures.md` 7.3 and troubleshooting row updated to point at the helper. Also wrapped the previously-loose "Config Hot-Reload" section in a `<details>` block so it matches the other feature panels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prologue-validation helper to scanner API for enhanced scanning accuracy.

* **Documentation**
  * Updated AOB Scanner guidance with prologue-detection methodology.
  * Reorganized Config hot-reload section into collapsible documentation blocks.

* **Tests**
  * Added test coverage for prologue-detection functionality across multiple memory scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tkhquang/DetourModKit/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->