### PR TITLE
chore: bump version to 3.2.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(DetourModKit VERSION 3.2.3 LANGUAGES CXX)
+project(DetourModKit VERSION 3.2.4 LANGUAGES CXX)
 
 # --- Standard and Compiler Options ---
 set(CMAKE_CXX_STANDARD 23)

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -10,23 +10,24 @@ namespace
     {
         EXPECT_EQ(DMK_VERSION_MAJOR, 3);
         EXPECT_EQ(DMK_VERSION_MINOR, 2);
-        EXPECT_EQ(DMK_VERSION_PATCH, 3);
+        EXPECT_EQ(DMK_VERSION_PATCH, 4);
     }
 
     TEST(VersionTest, VersionStringMatchesMacros)
     {
-        EXPECT_STREQ(DMK_VERSION_STRING, "3.2.3");
+        EXPECT_STREQ(DMK_VERSION_STRING, "3.2.4");
     }
 
     TEST(VersionTest, AtLeastComparisonsAreCorrect)
     {
+        EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 4));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 3));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 2));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 1));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 1, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(2, 0, 0));
-        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 2, 4));
+        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 2, 5));
         EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 3, 0));
         EXPECT_FALSE(DMK_VERSION_AT_LEAST(4, 0, 0));
     }


### PR DESCRIPTION
## Summary

Bumps the project version from 3.2.3 to 3.2.4 ahead of the v3.2.4 release.
