### PR TITLE
chore: bump version to 3.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(DetourModKit VERSION 3.2.4 LANGUAGES CXX)
+project(DetourModKit VERSION 3.3.0 LANGUAGES CXX)
 
 # --- Standard and Compiler Options ---
 set(CMAKE_CXX_STANDARD 23)

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -9,26 +9,24 @@ namespace
     TEST(VersionTest, MacrosMatchProjectVersion)
     {
         EXPECT_EQ(DMK_VERSION_MAJOR, 3);
-        EXPECT_EQ(DMK_VERSION_MINOR, 2);
-        EXPECT_EQ(DMK_VERSION_PATCH, 4);
+        EXPECT_EQ(DMK_VERSION_MINOR, 3);
+        EXPECT_EQ(DMK_VERSION_PATCH, 0);
     }
 
     TEST(VersionTest, VersionStringMatchesMacros)
     {
-        EXPECT_STREQ(DMK_VERSION_STRING, "3.2.4");
+        EXPECT_STREQ(DMK_VERSION_STRING, "3.3.0");
     }
 
     TEST(VersionTest, AtLeastComparisonsAreCorrect)
     {
+        EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 3, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 4));
-        EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 3));
-        EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 2));
-        EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 1));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 1, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(2, 0, 0));
-        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 2, 5));
-        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 3, 0));
+        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 3, 1));
+        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 4, 0));
         EXPECT_FALSE(DMK_VERSION_AT_LEAST(4, 0, 0));
     }
 


### PR DESCRIPTION
## Summary
- Bump project version from 3.2.4 to 3.3.0 in CMakeLists.txt
- Update version macro assertions and AT_LEAST boundary cases in tests/test_version.cpp

