### PR TITLE
feat(memory): add single-fault-guard pointer-chain read primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ PATH="/c/msys64/mingw64/bin:$PATH" cmake -S . -B build/mingw-release \
 # Available bench executables (standalone, no gtest runtime):
 #   DetourModKit_bench           -- EventDispatcher emit / subscribe throughput
 #   DetourModKit_bench_scanner   -- Scanner::find_pattern, rare-byte anchor vs naive
+#   DetourModKit_bench_memory    -- validation predicate vs direct SEH-guarded read / chain primitives (hot-path cost)
 
 PATH="/c/msys64/mingw64/bin:$PATH" cmake --build build/mingw-release \
     --target DetourModKit_bench_scanner --parallel
@@ -110,7 +111,7 @@ include/DetourModKit/    # Public headers -- one per module
   config_watcher.hpp     # Filesystem watcher (ReadDirectoryChangesW) for INI hot-reload
   input.hpp              # Input polling (keyboard/mouse/XInput)
   input_codes.hpp        # Unified InputCode type and named key tables
-  memory.hpp             # Memory read/write, sharded region cache, seh_read<T>, PE module range
+  memory.hpp             # Memory read/write, sharded region cache, seh_read<T>, seh_resolve_chain/seh_read_chain<T>, plausible_userspace_ptr, PE module range
   rtti.hpp               # MSVC RTTI walker (type_name_of, vtable_is_type, find_in_pointer_table)
   event_dispatcher.hpp   # Typed pub/sub with RAII subscriptions (header-only)
   profiler.hpp           # Opt-in scoped timing (zero-cost when disabled)
@@ -246,6 +247,7 @@ dispatcher.emit_safe(PlayerStateChanged{.health = player->health});
 - **Platform tests:** `tests/test_platform.cpp` tests internal loader-lock detection and module pinning utilities from `src/platform.hpp`.
 - **Decoder tests:** `tests/test_x86_decode.cpp` tests the internal header `src/x86_decode.hpp` (RIP-relative E9 / EB / FF25 resolvers consumed by `Scanner`). The test file adds `src/` to its include path and drives each decoder with hand-crafted byte buffers.
 - **Worker tests:** `tests/test_worker.cpp` covers the `StoppableWorker` RAII `std::jthread` wrapper, including the empty-body early return, swallowed `std::exception` and unknown-exception paths, and idempotent `request_stop()` / `shutdown()`. The loader-lock detach arm is untestable from user code (only reached under DllMain) and is accepted as such.
+- **Pointer-chain tests:** `tests/test_memory_chain.cpp` is a deliberate second suite for the public `memory.hpp` surface, kept separate from `test_memory.cpp` because the single-fault-frame pointer-chain primitives (`plausible_userspace_ptr`, `seh_resolve_chain`, `seh_read_chain`, `seh_read_chain_bytes`) walk in-process pointer chains and need no cache or game-memory state, whereas `test_memory.cpp` drives the sharded cache, read/write, and module-range paths. Both suites bind to the same header; this is the only same-module split and is intentional for state isolation.
 - **Test fixture pattern:** Each suite uses a `::testing::Test` subclass with `SetUp()`/`TearDown()` for temp file cleanup. Temp file paths must include the process ID (`_getpid()`) and a counter to avoid collisions when CTest runs tests in parallel as separate processes.
 - **VMT hook test lifetime:** GoogleTest destroys test-body locals *before* calling `TearDown()`. VMT tests must explicitly call `remove_all_vmt_hooks()` (or `remove_vmt_hook`) before target objects go out of scope. Do not rely on `TearDown()` for VMT cleanup when the hooked object is a test-body local.
 - **Coverage gate:** 80% minimum line coverage enforced in CI. All PRs must pass.
@@ -293,7 +295,7 @@ PATH="/c/msys64/mingw64/bin:$PATH" ./build/mingw-debug/tests/DetourModKit_tests.
 These are called at 60+ fps from game hook callbacks. Never add allocations, locks, or blocking I/O to them:
 
 - `InputPoller::is_binding_active(index)` -- single atomic load
-- `InputPoller::is_binding_active(name)` -- hash lookup + atomic load per binding (typically 1–3)
+- `InputPoller::is_binding_active(name)` -- hash lookup + atomic load per binding (typically 1-3)
 - `HookManager::with_inline_hook()` -- shared_lock read
 - `Logger::log()` level check -- single atomic load
 - `Logger::log()` async enqueue -- atomic shared_ptr load + lock-free queue push
@@ -302,6 +304,8 @@ These are called at 60+ fps from game hook callbacks. Never add allocations, loc
 - `Memory::read_ptr_unsafe()` -- SEH-protected raw dereference (MSVC), cache-accelerated with VirtualQuery fallback (MinGW)
 - `Memory::read_ptr_unchecked()` -- inline pointer dereference with source and result low-address guards, no SEH (caller must guarantee structural pointer validity)
 - `Memory::seh_read<T>()` / `seh_read_bytes()` -- typed and raw SEH-guarded reads; single `__try` frame on MSVC, VirtualQuery loop across regions on MinGW. Used by `Rtti` for chained RTTI walks
+- `Memory::seh_resolve_chain()` / `seh_read_chain<T>()` -- resolves or reads a whole multi-level pointer chain under one fault guard: one out-of-line call instead of N separate `seh_read` calls, with each intermediate link kept in a register and pre-screened by `plausible_userspace_ptr` (a faulting or implausible link aborts the walk and returns nullopt/false). VirtualQuery-guarded per link on MinGW
+- `Memory::plausible_userspace_ptr(p)` -- `inline constexpr` user-mode pointer plausibility test; pure arithmetic with no syscall and no memory access (early-rejects stale/sentinel/torn pointers before an SEH-guarded read)
 - `Memory::contains(range, p)` -- constexpr point-in-range test for module bounds checks
 - `Memory::own_module_range()` / `host_module_range()` -- magic-static cached, single atomic load on the fast path
 - `Rtti::vtable_is_type(vt, expected)` -- one batched COL read (24 bytes) plus `expected.size() + 1` bytes of name comparison; no allocation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ PATH="/c/msys64/mingw64/bin:$PATH" cmake --build build/mingw-release \
 
 Latest scanner bench numbers and methodology live in
 [docs/analysis/scanner_bench_v3.x/README.md](docs/analysis/scanner_bench_v3.x/README.md).
+Memory validation-vs-direct-read numbers live in
+[docs/analysis/memory_bench_v3.x/README.md](docs/analysis/memory_bench_v3.x/README.md).
 
 ### Sanitizers and coverage (MinGW only)
 

--- a/docs/analysis/memory_bench_v3.x/README.md
+++ b/docs/analysis/memory_bench_v3.x/README.md
@@ -1,0 +1,106 @@
+# Memory microbenchmark: validation predicate vs direct SEH-guarded read
+
+This directory captures a run of `tests/bench_memory.cpp` against the production `Memory` paths. The benchmark quantifies the per-call cost of each way to read game memory from a hot path, so a caller can choose between a validation predicate (`is_readable` / `is_writable`) and a direct SEH-guarded read (`seh_read`, `seh_read_chain`) with data rather than intuition. The guidance these numbers back is in [../../misc/hot-path-memory.md](../../misc/hot-path-memory.md).
+
+The benchmark measures:
+
+- **Per-call cost** of each primitive (validation warm-hit / cold-miss, raw `VirtualQuery`, `read_ptr_unchecked`, `seh_read`, direct load/store, `write_bytes`).
+- **VirtualQuery vs address-space size** (reserve N regions, re-time) to show whether a large VAD tree inflates the miss cost.
+- **`is_readable` tail latency** (p50/p99/max) under 1/2/4 threads forcing cache misses on a shared shard set. Tail latency, not average, is what a frame loop feels as a hitch.
+- **Probe model**: a hook that resolves an object and reads K dependent fields across a few distinct (cache-missing) objects, GATED (`is_readable` before every read) vs DIRECT (one fault guard, raw reads), reported per probe including the tail, plus a per-frame budget.
+- **Pointer chain**: a GATED per-link walk vs `seh_resolve_chain` / `seh_read_chain` (one fault guard for the whole walk).
+
+## Hardware / configuration
+
+- Build: MSVC 2022, Ninja, Release (`/O2`), `-DDMK_BUILD_BENCHMARKS=ON`
+- Toolchain: MSVC, where `seh_*` use real `__try` / `__except` (table-driven on x64, free on the no-fault path)
+- Iterations: 200,000 per sample (20,000 for `write_bytes`)
+- Samples: 15; median reported. Latency studies report p50/p99/max over the raw sample set
+- `DEFAULT_CACHE_EXPIRY_MS = 50`
+
+## Results
+
+```text
+[1] Validation MISS / uncached (cache off -> VirtualQuery branch)
+  raw VirtualQuery               217.78 ns/call
+  is_readable MISS               236.65 ns/call
+  is_writable MISS               227.87 ns/call
+
+[2] Validation WARM HIT (cache on, entry fresh within TTL)
+  is_readable HIT                 54.47 ns/call
+  is_writable HIT                 55.35 ns/call
+
+[3] Direct access primitives
+  direct volatile load             3.93 ns/call
+  read_ptr_unchecked               3.92 ns/call
+  seh_read<u64>                    7.42 ns/call
+  direct volatile store            0.45 ns/call
+  write_bytes(8)                5650.69 ns/call
+
+[4] raw VirtualQuery vs VAD-tree size (single fixed address)
+  +     0 reserved regions       237.48 ns/call
+  +  1000 reserved regions       218.41 ns/call
+  +  4000 reserved regions       220.93 ns/call
+  + 12000 reserved regions       224.38 ns/call
+
+[5] is_readable latency under contention (mostly-miss workload, 4096 pages)
+  1 thread(s):  p50  800 ns   p99  1700 ns   max  77600 ns
+  2 thread(s):  p50 1100 ns   p99  2400 ns   max 107000 ns
+  4 thread(s):  p50 1700 ns   p99  6100 ns   max  81500 ns
+
+[6] Per-probe cost: 8 reads across ~3 distinct (cache-missing) objects
+  GATED  (is_readable+read): p50  5900   p99 10500   max 152100   mean 6120 ns/probe
+  DIRECT (raw read)        : p50   100   p99   400   max   5100   mean   89 ns/probe
+  gated/direct mean ratio  : 68.7x
+
+[7] Per-frame budget (16.67 ms frame): cost = probes/frame x ns/probe
+  probes/fr      gated %frame   direct %frame
+  1                    0.04%          0.00%
+  8                    0.29%          0.00%
+  64                   2.35%          0.03%
+  256                  9.40%          0.14%
+  1024                37.60%          0.55%
+
+[8] Pointer chain (6 links, warm cache)
+  gated link walk                316.10 ns/call
+  seh_resolve_chain                9.14 ns/call
+  seh_read_chain<u64>             10.93 ns/call
+  gated/seh_read_chain ratio: 28.9x
+```
+
+## How to read this
+
+| Comparison | Numbers | Takeaway |
+|------------|---------|----------|
+| `seh_read<u64>` vs direct load | 7.4 ns vs 3.9 ns | A typed SEH-guarded read is within ~2x of a raw dereference, because the x64 `__try` is table-driven and free on the no-fault path. |
+| `is_readable` HIT vs `seh_read` | 54.5 ns vs 7.4 ns | Even a warm cache hit on the predicate costs ~7x a direct guarded read: it takes a shard reader lock and a cache lookup. |
+| `is_readable` MISS vs HIT | 236.7 ns vs 54.5 ns | A miss issues a `VirtualQuery` syscall and rebuilds the entry under an exclusive lock. When target addresses keep changing, almost every lookup misses. |
+| `seh_read_chain` vs gated per-link walk | 10.9 ns vs 316.1 ns | Resolving a 6-link chain under one fault guard is ~29x faster than calling `is_readable` before every dereference. |
+| Probe GATED vs DIRECT (mean) | 6120 ns vs 89 ns | Gating each of 8 dependent reads across cache-missing objects costs ~69x the direct cost per probe. |
+| Probe tail (p99 / max) | 10500 / 152100 ns vs 400 / 5100 ns | The gate hurts the tail far more than the mean. A single worst-case gated probe (152 us) is ~0.9% of a 16.67 ms frame on its own. |
+
+A few takeaways:
+
+1. **The predicate is the wrong tool on a hot path.** It is not free even on a cache hit (a lock plus a lookup), and on a cache miss it pays a `VirtualQuery` plus an exclusive-lock rebuild. The probe model, where each object is a fresh page, is miss-dominated, so the gate runs ~69x slower per probe than reading directly under one guard.
+2. **The cost scales with probes-per-frame, and the tail is the real hazard.** At a few probes per frame the gate is imperceptible. At a few hundred per frame (an apply path touching many bound objects) it climbs to a large fraction of the frame budget, and the p99/max tail can spike a frame on its own. A single average-per-call number hides this.
+3. **A single SEH-guarded read is nearly free on MSVC.** `seh_read` is within ~2x of a raw load, and the chain primitives keep that property across a whole multi-level walk: one guard for the walk instead of N predicate calls.
+4. **`VirtualQuery` cost is flat in address-space size.** Growing the VAD tree to 12,000 reserved regions does not move the per-call cost (the kernel walks a balanced tree), so the miss cost is intrinsic, not a function of how fragmented the process is.
+
+## Reproducing locally
+
+```bash
+# MSVC (Developer Command Prompt), from repo root
+cmake -S . -B build/msvc-release -G Ninja -DCMAKE_BUILD_TYPE=Release ^
+    -DDMK_BUILD_BENCHMARKS=ON -DDMK_BUILD_TESTS=OFF
+cmake --build build/msvc-release --target DetourModKit_bench_memory --parallel
+build\msvc-release\tests\DetourModKit_bench_memory.exe
+```
+
+The harness prints the human-readable tables above plus a `#TSV` block on stdout for machine parsing (`probe_gated_over_direct` is the headline gated-vs-direct ratio).
+
+## Caveats
+
+- Numbers are from a single development machine and are illustrative. The miss-path cost is dominated by `VirtualQuery` latency and shard-lock contention, so it varies by CPU, Windows build, and core count. Run the bench for your own target; the qualitative result (predicate expensive on the hot path, direct read cheap, chain cheap) holds across machines.
+- These are MSVC numbers, the shipping configuration. On MinGW there is no SEH, so `seh_read` / `seh_read_chain` fall back to a `VirtualQuery`-guarded read and pay a syscall per access; on that toolchain the gated walk can be faster than the chain primitives, which is why mod builds target MSVC and why `read_ptr_unchecked` is the recommended MinGW hot-path read (see [../../misc/hot-path-memory.md](../../misc/hot-path-memory.md)).
+- On MinGW the benchmark targets are built with the same Release LTO as the library (`INTERPROCEDURAL_OPTIMIZATION_RELEASE`, set in `tests/CMakeLists.txt` when IPO is supported), so each bench object and the LTO-only library archive form one LTO unit. This sidesteps a GCC linker-plugin bug where a mixed link (a non-LTO bench object against the LTO Release archive) re-emits libstdc++'s C++20-constrained `std::thread` / `std::tuple` linkonce symbol twice and fails with a spurious multiple-definition. No manual step is needed; do not force a non-LTO Release for the bench, since that mixed link is exactly what triggers the failure. The library and tests are unaffected.
+- The probe model uses synthetic page-per-object churn to force the miss path. A real hook whose objects share pages will miss less often and see a smaller gate penalty, but the structural point (the predicate adds a lock and a possible syscall the direct read does not) is independent of the hit rate.

--- a/docs/misc/hot-path-memory.md
+++ b/docs/misc/hot-path-memory.md
@@ -1,0 +1,171 @@
+# Reading Game Memory in Hot Paths
+
+This guide explains how to read and write game memory from code that runs at
+high frequency (per-frame render hooks, per-input-event detours, per-object
+apply loops) without paying the cost that the validation predicates carry. It is
+the reference for the `seh_*` and `read_ptr_*` primitives in
+[`memory.hpp`](../../include/DetourModKit/memory.hpp) and explains when to use
+each one.
+
+## The rule
+
+> Do not put `Memory::is_readable` or `Memory::is_writable` in front of every
+> dereference on a hot path. Read directly under a single SEH frame, optionally
+> pre-screened by a cheap arithmetic guard.
+
+`is_readable` / `is_writable` exist for one-shot setup validation and
+diagnostics. They are correct there and cheap when called a handful of times.
+They are the wrong tool for a path that runs hundreds or thousands of times per
+frame.
+
+## Why the predicate is the wrong tool on a hot path
+
+`is_readable(addr, size)` does two things that do not belong in a tight loop:
+
+1. **It is not free, even on a cache hit.** A hit takes a per-shard reader lock
+   and a cache lookup. A miss issues a `VirtualQuery` syscall and rebuilds the
+   cache entry under an exclusive lock. When the addresses you check keep
+   changing (a new game object each iteration), almost every lookup misses, so
+   the cost is dominated by syscalls and lock traffic.
+
+2. **It is a time-of-check to time-of-use illusion.** The page state it reports
+   can change between the check returning `true` and your dereference. A pointer
+   that passes the predicate can still fault, so you need a fault guard around
+   the read anyway. Once the read is inside a fault guard, the predicate adds no
+   safety, only cost.
+
+Concretely: a hook that resolves an object and reads eight dependent fields off
+it across a few distinct (cache-missing) objects can cost one to two orders of
+magnitude more per call when each read is gated than when the reads run directly
+under one fault guard. The multiplier is dominated by `VirtualQuery` latency on
+cache misses, the cache-miss rate, and shard-lock contention, so it varies by
+CPU, Windows build, and address-space size. At a few hundred such calls per
+frame that is the difference between imperceptible and a multi-millisecond frame
+spike. Build with `-DDMK_BUILD_BENCHMARKS=ON`, run the `DetourModKit_bench_memory`
+target (Phase 6 of `tests/bench_memory.cpp`), and read the
+`probe_gated_over_direct` value to measure it on your target.
+
+## The pattern
+
+Validate structure cheaply, read under one fault guard, sanity-check the result.
+
+```cpp
+namespace Mem = DetourModKit::Memory;
+
+// Cheap, syscall-free structural guards. Capture the module range once so the
+// per-call check is a branch comparison, not a GetModuleHandleEx lookup.
+static const Mem::ModuleRange g_host = Mem::host_module_range();
+
+bool probe_object(uintptr_t obj, ObjectFields &out) noexcept
+{
+    // 1. Reject obviously bad pointers with no memory access and no syscall.
+    if (!Mem::plausible_userspace_ptr(obj))
+    {
+        return false;
+    }
+
+    // 2. Read every field under a single SEH-guarded chain walk. On MSVC this
+    //    is one __try frame; on MinGW it is VirtualQuery-guarded. Either way a
+    //    fault anywhere in the walk returns nullopt instead of crashing.
+    const auto vtable = Mem::seh_read<uintptr_t>(obj);
+    if (!vtable || !Mem::contains(g_host, *vtable))
+    {
+        // 3. A live object's vtable points into the game image. A value that
+        //    does not is a stale or reallocated pointer; reject it.
+        return false;
+    }
+
+    const auto id = Mem::seh_read<uint32_t>(obj + k_offId);
+    if (!id)
+    {
+        return false;
+    }
+
+    out.vtable = *vtable;
+    out.id = *id;
+    return true;
+}
+```
+
+For a multi-level pointer chain, resolve the whole chain under one fault guard
+rather than calling `seh_read` once per link. The combined walk is one
+out-of-line call instead of N, keeps each link in a register instead of
+round-tripping it through `std::optional`, and validates its arguments once. (It
+does not save SEH-frame setup: on MSVC/x64 a `__try` success path is
+table-driven and free, so N of them cost nothing extra either.)
+
+```cpp
+// (*(*(base + 0x10) + 0x28)) + 0x8, read as a float, all under one guard.
+const auto value = Mem::seh_read_chain<float>(base, {0x10, 0x28, 0x8});
+if (value)
+{
+    use(*value);
+}
+```
+
+## Primitive selection
+
+| You have | You want | Use |
+|----------|----------|-----|
+| A pointer the hook was handed (the engine is using it now) | To read or write it | Direct access. It is live by definition. Wrap in `__try` (or `seh_read`) only if it may be stale by the time you run. |
+| A single address that may be stale or unmapped | One typed read that cannot fault | `seh_read<T>(addr)` |
+| A single address, a raw byte range | One range read that cannot fault | `seh_read_bytes(addr, out, n)` |
+| A multi-level pointer chain | The final address only | `seh_resolve_chain(base, {offsets...})` |
+| A multi-level pointer chain | A typed value at the end | `seh_read_chain<T>(base, {offsets...})` |
+| A pointer chain you can prove is structurally valid this frame | The fastest possible read, no syscall, no SEH | `read_ptr_unchecked(base, offset)` |
+| To screen a candidate pointer before any read | A pure arithmetic plausibility test | `plausible_userspace_ptr(p)` |
+| To confirm a pointer lives in a known module | A branch-only range test | `contains(own_module_range(), p)` (capture the range once) |
+| To validate an address once at setup | A readability or writability check | `is_readable` / `is_writable` |
+
+## Toolchain note
+
+The `seh_*` primitives use real `__try` / `__except` on MSVC, where the success
+path is table-driven and costs nothing extra. On MinGW (which has no SEH) they
+fall back to a `VirtualQuery`-guarded read, which is correct but pays a syscall;
+prefer `read_ptr_unchecked` on MinGW hot paths where you can guarantee
+structural validity. Shipping mod builds target MSVC, so the zero-cost path is
+the normal case.
+
+## Anti-patterns to remove
+
+```cpp
+// WRONG: predicate before every read on a hot path. Lock plus possible syscall
+// per field, and the page can still change before the dereference.
+if (Mem::is_readable(reinterpret_cast<void *>(addr), sizeof(uint64_t)))
+{
+    value = *reinterpret_cast<uint64_t *>(addr);
+}
+
+// WRONG: gating a write to a pointer the engine just wrote through. If the
+// engine could write it, it is writable; the predicate adds a lock for nothing.
+if (Mem::is_writable(positionPtr, sizeof(Vector3)))
+{
+    *positionPtr = newPosition;
+}
+
+// WRONG: module_range_for in a loop. Every call is a GetModuleHandleEx lookup,
+// even on a cache hit. Capture the range once and use contains().
+for (auto p : candidates)
+{
+    if (Mem::module_range_for(reinterpret_cast<void *>(p)))
+    {
+        ...
+    }
+}
+```
+
+```cpp
+// RIGHT: capture the range once, screen cheaply, read under one guard.
+static const Mem::ModuleRange host = Mem::host_module_range();
+for (auto p : candidates)
+{
+    if (Mem::plausible_userspace_ptr(p) && Mem::contains(host, p))
+    {
+        const auto v = Mem::seh_read<uint64_t>(p);
+        if (v)
+        {
+            use(*v);
+        }
+    }
+}
+```

--- a/docs/misc/hot-path-memory.md
+++ b/docs/misc/hot-path-memory.md
@@ -43,7 +43,8 @@ CPU, Windows build, and address-space size. At a few hundred such calls per
 frame that is the difference between imperceptible and a multi-millisecond frame
 spike. Build with `-DDMK_BUILD_BENCHMARKS=ON`, run the `DetourModKit_bench_memory`
 target (Phase 6 of `tests/bench_memory.cpp`), and read the
-`probe_gated_over_direct` value to measure it on your target.
+`probe_gated_over_direct` value to measure it on your target. Recorded numbers
+and methodology are in [the memory benchmark notes](../analysis/memory_bench_v3.x/README.md).
 
 ## The pattern
 

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -297,9 +297,13 @@ The decoder header lives under `src/` (not the public include tree), so the test
 
 ## Benchmark Harness
 
-`tests/bench_event_dispatcher.cpp` is a standalone microbenchmark executable. It is deliberately not a gtest binary so it can run under any build configuration (release, release+PGO, ASAN, etc.) without dragging in the gtest runtime.
+`DMK_BUILD_BENCHMARKS=ON` builds three standalone microbenchmark executables. Each is deliberately not a gtest binary, so it runs under any build configuration (release, release+PGO, ASan, etc.) without dragging in the gtest runtime, and each prints a tab-separated table on stdout:
 
-Build it by adding `-DDMK_BUILD_BENCHMARKS=ON` to the configure step:
+- `DetourModKit_bench` (`bench_event_dispatcher.cpp`) -- EventDispatcher emit / subscribe throughput.
+- `DetourModKit_bench_scanner` (`bench_scanner.cpp`) -- `Scanner::find_pattern`, rare-byte anchor vs a naive first-byte anchor.
+- `DetourModKit_bench_memory` (`bench_memory.cpp`) -- the cost of each way to read game memory from a hot path: validation predicate (warm hit / cold miss) vs direct SEH-guarded read vs the pointer-chain primitives, plus per-probe tail-latency and per-frame budget studies.
+
+The option is independent of `DMK_BUILD_TESTS`, so the benches build alone:
 
 ```bash
 PATH="/c/msys64/mingw64/bin:$PATH"
@@ -308,12 +312,14 @@ cmake --build build/mingw-release --parallel
 ./build/mingw-release/tests/DetourModKit_bench.exe > bench.tsv
 ```
 
-The option is independent of `DMK_BUILD_TESTS`, so you can build the bench alone. Output is a tab-separated table on stdout with columns `scenario, subscribers, iterations, median_ns_per_op, total_ms`. Covered scenarios:
+`DetourModKit_bench` output has columns `scenario, subscribers, iterations, median_ns_per_op, total_ms`. Covered scenarios:
 
 - `emit` / `emit_safe` at 0, 1, 8, 64 subscribers (the 0-subscriber rows measure the fast path).
 - `subscribe_unsub_roundtrip` (single-thread RAII churn).
 - `emit_concurrent_4_threads` (contention stress on the lock-free read path).
 - `reentrancy_rejection` (cost of the guard's reject-during-handler path).
+
+`DetourModKit_bench_memory` is documented in [../misc/hot-path-memory.md](../misc/hot-path-memory.md); read the `probe_gated_over_direct` TSV row for the gated-vs-direct multiplier on your machine.
 
 ## Project Structure
 
@@ -321,7 +327,9 @@ The option is independent of `DMK_BUILD_TESTS`, so you can build the bench alone
 tests/
 ├── CMakeLists.txt              # Test discovery, fixture DLL build, bench wiring
 ├── main.cpp                    # GoogleTest entry point
-├── bench_event_dispatcher.cpp  # Standalone microbench (DMK_BUILD_BENCHMARKS)
+├── bench_event_dispatcher.cpp  # EventDispatcher emit/subscribe microbench (DMK_BUILD_BENCHMARKS)
+├── bench_memory.cpp            # Hot-path memory bench: validation predicate vs SEH-guarded read / chain primitives (DMK_BUILD_BENCHMARKS)
+├── bench_scanner.cpp           # Scanner::find_pattern rare-byte-anchor bench (DMK_BUILD_BENCHMARKS)
 ├── fixtures/
 │   └── hook_target_lib.cpp     # Fixture DLL (exported functions for integration tests)
 ├── test_async_logger.cpp       # Async logger tests
@@ -336,7 +344,8 @@ tests/
 ├── test_input.cpp              # Input system and input code tests
 ├── test_logger.cpp             # Logger tests
 ├── test_math.cpp               # Math utilities tests
-├── test_memory.cpp             # Memory utilities tests
+├── test_memory.cpp             # Memory utilities tests (cache, read/write, SEH reads, module range)
+├── test_memory_chain.cpp       # Pointer-chain / plausibility primitives (seh_resolve_chain, seh_read_chain)
 ├── test_platform.cpp           # Platform detection and version macro tests
 ├── test_profiler.cpp           # Profiler tests
 ├── test_scanner.cpp            # AOB scanner tests

--- a/include/DetourModKit/memory.hpp
+++ b/include/DetourModKit/memory.hpp
@@ -5,7 +5,9 @@
 #include <cstdint>
 #include <cstring>
 #include <expected>
+#include <initializer_list>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -114,6 +116,19 @@ namespace DetourModKit
          * @param address Starting address of the memory region.
          * @param size Number of bytes in the memory region to check.
          * @return true if the entire region is readable, false otherwise.
+         * @warning Not a per-dereference gate for hot paths. A cache hit still
+         *          takes a shard reader lock and a cache miss issues a
+         *          VirtualQuery syscall; placing this in front of every field
+         *          read on a per-frame or per-object path multiplies that cost
+         *          by the read count and is dominated by cache misses when the
+         *          target addresses change. It is also a time-of-check to
+         *          time-of-use illusion: the page state can change between the
+         *          check and the access. For hot-path reads of game-owned
+         *          pointers, drop the predicate and read directly under a single
+         *          SEH frame (@ref seh_read, @ref seh_read_chain), optionally
+         *          pre-screened by @ref plausible_userspace_ptr and a module or
+         *          heap range check. Reserve is_readable for one-shot setup
+         *          validation and diagnostics.
          */
         bool is_readable(const void *address, size_t size);
 
@@ -154,6 +169,34 @@ namespace DetourModKit
          * @return The pointer-sized value at the address, or 0 if the read faults.
          */
         uintptr_t read_ptr_unsafe(uintptr_t base, ptrdiff_t offset) noexcept;
+
+        // Canonical x64 user-mode address window. The low 64 KiB is the
+        // reserved null-dereference region and is never a live pointer; mapped
+        // user addresses sit below the 47-bit canonical split at
+        // 0x0000'8000'0000'0000. A value outside this window cannot be a valid
+        // object pointer, so the bounds reject stale or sentinel values with no
+        // syscall and no memory access.
+        inline constexpr uintptr_t USERSPACE_PTR_MIN = 0x10000;
+        inline constexpr uintptr_t USERSPACE_PTR_MAX = 0x0000800000000000ULL;
+
+        /**
+         * @brief Structural plausibility test for an x64 user-mode pointer.
+         * @details Returns true only when @p p lies in
+         *          [@ref USERSPACE_PTR_MIN, @ref USERSPACE_PTR_MAX). This is a
+         *          pure arithmetic guard with no memory access and no syscall,
+         *          intended to terminate pointer-chain traversals early on
+         *          obviously bad values (null, small enum-shaped integers,
+         *          non-canonical addresses) before paying for an SEH-guarded
+         *          read. It does not prove the pointer is mapped or that the
+         *          target object is the expected type; pair it with a module or
+         *          heap range check and an SEH-guarded read for full validation.
+         * @param p The pointer value to test.
+         * @return true if @p p is a plausible user-mode pointer, false otherwise.
+         */
+        [[nodiscard]] inline constexpr bool plausible_userspace_ptr(uintptr_t p) noexcept
+        {
+            return p >= USERSPACE_PTR_MIN && p < USERSPACE_PTR_MAX;
+        }
 
         /**
          * @brief Fastest pointer dereference with low-address validity guards only.
@@ -196,6 +239,13 @@ namespace DetourModKit
          * @param address Starting address of the memory region.
          * @param size Number of bytes in the memory region to check.
          * @return true if the entire region is writable, false otherwise.
+         * @warning Carries the same hot-path cost and time-of-check to
+         *          time-of-use caveat as @ref is_readable. When a hook receives
+         *          a pointer the engine just wrote through, that pointer is
+         *          already writable; gating the store behind this predicate adds
+         *          a lock and a periodic VirtualQuery for no safety gain. Write
+         *          directly (under SEH if the address may be stale) and reserve
+         *          is_writable for one-shot setup validation.
          */
         bool is_writable(void *address, size_t size);
 
@@ -244,6 +294,11 @@ namespace DetourModKit
          *       host modules; consumers that load and free DLLs at runtime
          *       should treat cached entries for an unloaded module's HMODULE
          *       as stale.
+         * @note Every call issues a GetModuleHandleEx lookup even on a cache
+         *       hit. For a hot path that repeatedly checks whether a pointer
+         *       lives inside one known module, capture @ref own_module_range or
+         *       @ref host_module_range once and test with @ref contains, which
+         *       is a branch-only comparison with no syscall.
          * @param address Any address inside the target module. nullptr returns
          *                std::nullopt without a syscall.
          * @return The module's range, or std::nullopt if @p address does not
@@ -324,19 +379,131 @@ namespace DetourModKit
          *          On the success path the implementation collapses to a
          *          single memcpy of sizeof(T) bytes; on failure the optional
          *          carries no value and no T destructor is invoked.
-         * @tparam T A trivially copyable type. Required by C++23 concept.
+         * @tparam T A trivially copyable, default-constructible type. Trivial
+         *           copyability avoids the MSVC C2712 restriction described
+         *           above; default-constructibility is required because the
+         *           body declares a `T value;` to receive the copied bytes.
          * @param addr Source address. Values below 0x10000 are rejected
          *             without a read; see @ref seh_read_bytes.
          * @return The value on success, std::nullopt on any read fault.
          */
         template <typename T>
-            requires std::is_trivially_copyable_v<T>
+            requires (std::is_trivially_copyable_v<T> && std::is_default_constructible_v<T>)
         [[nodiscard]] std::optional<T> seh_read(uintptr_t addr) noexcept
         {
             T value;
             if (!seh_read_bytes(addr, &value, sizeof(T)))
                 return std::nullopt;
             return value;
+        }
+
+        /**
+         * @brief Resolves a multi-level pointer chain under a single fault guard.
+         * @details Walks Cheat-Engine-style pointer-chain semantics: starting at
+         *          @p base, every offset except the last is added and
+         *          dereferenced to obtain the next link, and the final offset is
+         *          added but not dereferenced, yielding the address of the target
+         *          field. With offsets {o0, o1, o2} the result is
+         *          (*(*(base + o0) + o1)) + o2.
+         *
+         *          The entire walk runs inside one fault guard. On x64 MSVC the
+         *          __try is table-driven (described by .pdata/.xdata emitted at
+         *          compile time) and adds no runtime setup on the no-fault path
+         *          whether the chain uses one guard or N, so the win over
+         *          calling @ref seh_read once per link is not SEH-frame setup:
+         *          it is one out-of-line call instead of N, each intermediate
+         *          link kept in a register instead of round-tripped through
+         *          std::optional, and a single argument validation. On MinGW
+         *          (no SEH) the saving is concrete: one guarded helper call
+         *          instead of N, each intermediate link read through
+         *          @ref read_ptr_unsafe (VirtualQuery-guarded) and the final
+         *          address computed without a read.
+         *
+         *          Each intermediate link is screened with
+         *          @ref plausible_userspace_ptr; a link that faults or yields an
+         *          implausible pointer aborts the walk and returns std::nullopt.
+         *          The returned address is not dereferenced and not range-checked
+         *          by this function; the caller reads it (typically via
+         *          @ref seh_read or @ref seh_read_chain).
+         * @param base Root address of the chain.
+         * @param offsets Byte offsets applied left to right. An empty span
+         *                returns @p base unchanged.
+         * @return The resolved target address, or std::nullopt if any
+         *         intermediate dereference faults or produces an implausible
+         *         pointer.
+         */
+        [[nodiscard]] std::optional<uintptr_t> seh_resolve_chain(
+            uintptr_t base, std::span<const ptrdiff_t> offsets) noexcept;
+
+        /**
+         * @brief Convenience overload accepting a braced offset list.
+         * @see seh_resolve_chain(uintptr_t, std::span<const ptrdiff_t>)
+         */
+        [[nodiscard]] inline std::optional<uintptr_t> seh_resolve_chain(
+            uintptr_t base, std::initializer_list<ptrdiff_t> offsets) noexcept
+        {
+            return seh_resolve_chain(base,
+                                     std::span<const ptrdiff_t>(offsets.begin(), offsets.size()));
+        }
+
+        /**
+         * @brief Resolves a pointer chain and reads a raw byte range at its end.
+         * @details Performs the same walk as @ref seh_resolve_chain and then
+         *          copies @p bytes from the resolved address into @p out under
+         *          one fault guard, so a fault anywhere in the resolve or the
+         *          terminal read takes the same failure path and cannot leave a
+         *          partially walked chain observable to the caller. On MinGW the
+         *          chain is resolved via @ref read_ptr_unsafe and the terminal
+         *          read uses @ref seh_read_bytes.
+         * @param base Root address of the chain.
+         * @param offsets Byte offsets applied left to right (see
+         *                @ref seh_resolve_chain). An empty span reads at @p base.
+         * @param out Destination buffer. nullptr returns false.
+         * @param bytes Number of bytes to copy. Zero returns true (no-op).
+         * @return true on a fully successful resolve and read; false if any
+         *         intermediate link faults or is implausible, or the terminal
+         *         read faults. On failure the contents of @p out are unspecified.
+         */
+        [[nodiscard]] bool seh_read_chain_bytes(uintptr_t base,
+                                                std::span<const ptrdiff_t> offsets,
+                                                void *out, size_t bytes) noexcept;
+
+        /**
+         * @brief Resolves a pointer chain and reads a typed value at its end.
+         * @details Forwards to @ref seh_read_chain_bytes, so the chain walk and
+         *          the typed read share a single fault guard. The value is
+         *          constructed by copying sizeof(T) bytes from the resolved
+         *          address into a local `T value;`.
+         * @tparam T A trivially copyable, default-constructible type (see
+         *           @ref seh_read for why both are required).
+         * @param base Root address of the chain.
+         * @param offsets Byte offsets applied left to right (see
+         *                @ref seh_resolve_chain).
+         * @return The value on success, std::nullopt if any link faults or is
+         *         implausible or the terminal read faults.
+         */
+        template <typename T>
+            requires (std::is_trivially_copyable_v<T> && std::is_default_constructible_v<T>)
+        [[nodiscard]] std::optional<T> seh_read_chain(
+            uintptr_t base, std::span<const ptrdiff_t> offsets) noexcept
+        {
+            T value;
+            if (!seh_read_chain_bytes(base, offsets, &value, sizeof(T)))
+                return std::nullopt;
+            return value;
+        }
+
+        /**
+         * @brief Convenience overload accepting a braced offset list.
+         * @see seh_read_chain(uintptr_t, std::span<const ptrdiff_t>)
+         */
+        template <typename T>
+            requires (std::is_trivially_copyable_v<T> && std::is_default_constructible_v<T>)
+        [[nodiscard]] std::optional<T> seh_read_chain(
+            uintptr_t base, std::initializer_list<ptrdiff_t> offsets) noexcept
+        {
+            return seh_read_chain<T>(base,
+                                     std::span<const ptrdiff_t>(offsets.begin(), offsets.size()));
         }
     } // namespace Memory
 } // namespace DetourModKit

--- a/include/DetourModKit/memory.hpp
+++ b/include/DetourModKit/memory.hpp
@@ -1,6 +1,8 @@
 #ifndef DETOURMODKIT_MEMORY_HPP
 #define DETOURMODKIT_MEMORY_HPP
 
+#include <array>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -368,33 +370,30 @@ namespace DetourModKit
 
         /**
          * @brief SEH-guarded typed read of a trivially copyable T at @p addr.
-         * @details Forwards to @ref seh_read_bytes so the underlying __try
-         *          frame lives in the translation unit that defines it. Local
-         *          variables with non-trivial destructors are not permitted in
-         *          functions that use __try (MSVC C2712); restricting T to
-         *          trivially copyable types avoids that restriction here and
-         *          keeps the value-construction free of any side effects that
-         *          would survive the failure path.
-         *
-         *          On the success path the implementation collapses to a
-         *          single memcpy of sizeof(T) bytes; on failure the optional
-         *          carries no value and no T destructor is invoked.
-         * @tparam T A trivially copyable, default-constructible type. Trivial
-         *           copyability avoids the MSVC C2712 restriction described
-         *           above; default-constructibility is required because the
-         *           body declares a `T value;` to receive the copied bytes.
+         * @details Forwards to @ref seh_read_bytes so the underlying __try frame
+         *          lives in the translation unit that defines it. The bytes are
+         *          read into untyped storage and reinterpreted with
+         *          std::bit_cast, so no T object is constructed and the failure
+         *          path runs no T constructor or destructor. On success the read
+         *          collapses to a single memcpy of sizeof(T) bytes followed by a
+         *          no-op bit_cast.
+         * @tparam T A trivially copyable type. Trivial copyability is what
+         *           std::bit_cast requires and what makes a raw byte copy a valid
+         *           reconstruction of the value. T need not be default
+         *           constructible, so non-default-constructible POD-like types
+         *           (e.g. structs with a deleted default constructor) can be read.
          * @param addr Source address. Values below 0x10000 are rejected
          *             without a read; see @ref seh_read_bytes.
          * @return The value on success, std::nullopt on any read fault.
          */
         template <typename T>
-            requires (std::is_trivially_copyable_v<T> && std::is_default_constructible_v<T>)
+            requires std::is_trivially_copyable_v<T>
         [[nodiscard]] std::optional<T> seh_read(uintptr_t addr) noexcept
         {
-            T value;
-            if (!seh_read_bytes(addr, &value, sizeof(T)))
+            std::array<std::byte, sizeof(T)> storage;
+            if (!seh_read_bytes(addr, storage.data(), sizeof(T)))
                 return std::nullopt;
-            return value;
+            return std::bit_cast<T>(storage);
         }
 
         /**
@@ -471,11 +470,11 @@ namespace DetourModKit
         /**
          * @brief Resolves a pointer chain and reads a typed value at its end.
          * @details Forwards to @ref seh_read_chain_bytes, so the chain walk and
-         *          the typed read share a single fault guard. The value is
-         *          constructed by copying sizeof(T) bytes from the resolved
-         *          address into a local `T value;`.
-         * @tparam T A trivially copyable, default-constructible type (see
-         *           @ref seh_read for why both are required).
+         *          the typed read share a single fault guard. The bytes are read
+         *          into untyped storage and reinterpreted with std::bit_cast, so
+         *          no T object is constructed on the failure path.
+         * @tparam T A trivially copyable type (see @ref seh_read; T need not be
+         *           default constructible).
          * @param base Root address of the chain.
          * @param offsets Byte offsets applied left to right (see
          *                @ref seh_resolve_chain).
@@ -483,14 +482,14 @@ namespace DetourModKit
          *         implausible or the terminal read faults.
          */
         template <typename T>
-            requires (std::is_trivially_copyable_v<T> && std::is_default_constructible_v<T>)
+            requires std::is_trivially_copyable_v<T>
         [[nodiscard]] std::optional<T> seh_read_chain(
             uintptr_t base, std::span<const ptrdiff_t> offsets) noexcept
         {
-            T value;
-            if (!seh_read_chain_bytes(base, offsets, &value, sizeof(T)))
+            std::array<std::byte, sizeof(T)> storage;
+            if (!seh_read_chain_bytes(base, offsets, storage.data(), sizeof(T)))
                 return std::nullopt;
-            return value;
+            return std::bit_cast<T>(storage);
         }
 
         /**
@@ -498,7 +497,7 @@ namespace DetourModKit
          * @see seh_read_chain(uintptr_t, std::span<const ptrdiff_t>)
          */
         template <typename T>
-            requires (std::is_trivially_copyable_v<T> && std::is_default_constructible_v<T>)
+            requires std::is_trivially_copyable_v<T>
         [[nodiscard]] std::optional<T> seh_read_chain(
             uintptr_t base, std::initializer_list<ptrdiff_t> offsets) noexcept
         {

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1458,6 +1458,133 @@ bool DetourModKit::Memory::seh_read_bytes(uintptr_t addr, void *out, size_t byte
 
 namespace
 {
+    // Walk a Cheat-Engine-style pointer chain inside a single fault guard.
+    // Every offset except the last is added and dereferenced to obtain the next
+    // link; the last offset is added but not dereferenced, yielding the target
+    // field address in out_addr. Each intermediate link is screened with
+    // plausible_userspace_ptr so a torn or sentinel pointer aborts the walk
+    // before the next dereference faults. Returns false on any fault or
+    // implausible intermediate link.
+    bool resolve_chain_guarded(uintptr_t base, const ptrdiff_t *offsets,
+                               size_t count, uintptr_t &out_addr) noexcept
+    {
+#ifdef _MSC_VER
+        __try
+        {
+            uintptr_t cur = base;
+            for (size_t i = 0; i + 1 < count; ++i)
+            {
+                uintptr_t next = 0;
+                std::memcpy(&next,
+                            reinterpret_cast<const void *>(cur + static_cast<uintptr_t>(offsets[i])),
+                            sizeof(next));
+                if (!Memory::plausible_userspace_ptr(next))
+                    return false;
+                cur = next;
+            }
+            out_addr = (count == 0)
+                           ? cur
+                           : cur + static_cast<uintptr_t>(offsets[count - 1]);
+            return true;
+        }
+        __except ((GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ||
+                   GetExceptionCode() == STATUS_GUARD_PAGE_VIOLATION)
+                      ? EXCEPTION_EXECUTE_HANDLER
+                      : EXCEPTION_CONTINUE_SEARCH)
+        {
+            return false;
+        }
+#else
+        // MinGW lacks __try/__except. Each intermediate link is read through
+        // read_ptr_unsafe (VirtualQuery-guarded, returns 0 on fault); the
+        // plausibility screen also rejects that 0.
+        uintptr_t cur = base;
+        for (size_t i = 0; i + 1 < count; ++i)
+        {
+            const uintptr_t next = Memory::read_ptr_unsafe(cur, offsets[i]);
+            if (!Memory::plausible_userspace_ptr(next))
+                return false;
+            cur = next;
+        }
+        out_addr = (count == 0)
+                       ? cur
+                       : cur + static_cast<uintptr_t>(offsets[count - 1]);
+        return true;
+#endif
+    }
+} // anonymous namespace (pointer-chain internals)
+
+std::optional<uintptr_t> DetourModKit::Memory::seh_resolve_chain(
+    uintptr_t base, std::span<const ptrdiff_t> offsets) noexcept
+{
+    uintptr_t addr = 0;
+    if (resolve_chain_guarded(base, offsets.data(), offsets.size(), addr))
+        return addr;
+    return std::nullopt;
+}
+
+bool DetourModKit::Memory::seh_read_chain_bytes(
+    uintptr_t base, std::span<const ptrdiff_t> offsets, void *out, size_t bytes) noexcept
+{
+    if (bytes == 0)
+        return true;
+    if (!out)
+        return false;
+
+#ifdef _MSC_VER
+    // The walk is inlined here rather than reusing resolve_chain_guarded so the
+    // resolve and the terminal read sit in one __try region. On x64 the __try
+    // is table-driven and free on the no-fault path, so this is a structural
+    // choice (one uniform failure path for the whole operation) and not a
+    // measurable saving over two adjacent guarded regions.
+    const ptrdiff_t *const offs = offsets.data();
+    const size_t count = offsets.size();
+    __try
+    {
+        uintptr_t cur = base;
+        for (size_t i = 0; i + 1 < count; ++i)
+        {
+            uintptr_t next = 0;
+            std::memcpy(&next,
+                        reinterpret_cast<const void *>(cur + static_cast<uintptr_t>(offs[i])),
+                        sizeof(next));
+            if (!Memory::plausible_userspace_ptr(next))
+                return false;
+            cur = next;
+        }
+        const uintptr_t final_addr = (count == 0)
+                                         ? cur
+                                         : cur + static_cast<uintptr_t>(offs[count - 1]);
+        // Apply seh_read_bytes' own prechecks on the terminal address so a low
+        // or wrapping final address fails identically on both toolchains. The
+        // MinGW branch below already routes through seh_read_bytes, which
+        // rejects these; matching here keeps a stale or sentinel final address
+        // from raising a (benign but debugger-visible) first-chance exception.
+        if (final_addr < SEH_READ_MIN_VALID_ADDR || final_addr + bytes < final_addr)
+            return false;
+        std::memcpy(out, reinterpret_cast<const void *>(final_addr), bytes);
+        return true;
+    }
+    __except ((GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ||
+               GetExceptionCode() == STATUS_GUARD_PAGE_VIOLATION)
+                  ? EXCEPTION_EXECUTE_HANDLER
+                  : EXCEPTION_CONTINUE_SEARCH)
+    {
+        return false;
+    }
+#else
+    // MinGW: resolve through the VirtualQuery-guarded helper, then read the
+    // terminal range with seh_read_bytes, which validates every region the
+    // read spans before copying.
+    uintptr_t final_addr = 0;
+    if (!resolve_chain_guarded(base, offsets.data(), offsets.size(), final_addr))
+        return false;
+    return Memory::seh_read_bytes(final_addr, out, bytes);
+#endif
+}
+
+namespace
+{
     // PE header layout for module range resolution. Pulled into an anonymous
     // namespace so the helper is internal to memory.cpp and shared between
     // module_range_for, own_module_range, and host_module_range.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,4 +133,15 @@ if(DMK_BUILD_BENCHMARKS)
   target_include_directories(DetourModKit_bench_memory PRIVATE
     ${CMAKE_SOURCE_DIR}/include
   )
+
+  # Build the benchmarks with the same Release LTO as the library so each bench
+  # and the library archive it links form one LTO unit. The default mixed link
+  # (a non-LTO bench object against the LTO-only Release archive) makes GCC's
+  # linker plugin re-emit libstdc++'s C++20-constrained std::thread/std::tuple
+  # linkonce symbol twice and fail with a spurious multiple-definition; keeping
+  # the benchmarks inside the same LTO unit avoids that path.
+  if(_ipo_supported)
+    set_target_properties(DetourModKit_bench DetourModKit_bench_scanner DetourModKit_bench_memory
+      PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+  endif()
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,4 +123,14 @@ if(DMK_BUILD_BENCHMARKS)
   target_include_directories(DetourModKit_bench_scanner PRIVATE
     ${CMAKE_SOURCE_DIR}/include
   )
+
+  add_executable(DetourModKit_bench_memory
+    "${CMAKE_CURRENT_SOURCE_DIR}/bench_memory.cpp"
+  )
+
+  target_link_libraries(DetourModKit_bench_memory PRIVATE DetourModKit)
+
+  target_include_directories(DetourModKit_bench_memory PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+  )
 endif()

--- a/tests/bench_memory.cpp
+++ b/tests/bench_memory.cpp
@@ -181,6 +181,16 @@ namespace
             if (p)
                 pool.push_back(p);
         }
+        // An empty pool would make run_contention and run_probe divide by /
+        // index past pool.size(); fail fast on a setup error rather than later
+        // crashing inside a timed loop.
+        if (pool.empty())
+        {
+            std::fprintf(stderr,
+                         "[bench] make_churn_pool: all %zu VirtualAlloc reservations failed (%lu)\n",
+                         pages, GetLastError());
+            std::exit(1);
+        }
         return pool;
     }
 

--- a/tests/bench_memory.cpp
+++ b/tests/bench_memory.cpp
@@ -1,0 +1,525 @@
+/**
+ * @file bench_memory.cpp
+ * @brief Standalone microbenchmark for the Memory validation and access paths.
+ *
+ * Quantifies the per-call cost of each way to read game memory from a hot path
+ * so callers can choose between a validation predicate and a direct SEH-guarded
+ * read with data rather than intuition. Measured on the shipping toolchain
+ * (MSVC, where the seh_* primitives use real __try/__except):
+ *
+ *   - is_readable / is_writable  WARM HIT   (cache on, entry fresh)
+ *   - is_readable / is_writable  COLD MISS  (cache off -> direct VirtualQuery)
+ *   - raw VirtualQuery                       (the syscall a cache miss pays)
+ *   - read_ptr_unchecked                     (inline guarded read, no syscall)
+ *   - seh_read<uint64_t>                     (SEH-guarded read)
+ *   - seh_resolve_chain / seh_read_chain     (one fault guard for a whole chain)
+ *   - direct volatile load / store           (floor)
+ *   - write_bytes (8 bytes)                  (VirtualProtect x2 + Flush + invalidate)
+ *
+ * Scenario studies (each letter is annotated with the [N] phase marker the
+ * program prints; the basic per-call cost tables are the unlettered phases
+ * [1]-[3], so the lettered scenario studies start at (D)):
+ *   (D) [Phase 4] VirtualQuery cost vs VAD-tree size (reserve N regions, then
+ *       re-time) to show whether process address-space size inflates the miss
+ *       cost.
+ *   (E) [Phase 5] is_readable latency p50/p99/max under 1/2/4 threads forcing
+ *       cache misses on a shared shard set. Tail latency, not average, is what a
+ *       frame loop feels as a hitch (the shared shard set models the render
+ *       thread racing the input and entity detours).
+ *   (F) [Phases 6-7] Probe model (the hot-path validation regression this
+ *       benchmark guards): a hook that runs many probes per frame, each doing K
+ *       dependent reads across a few DISTINCT (cache-missing) objects. Reports
+ *       per-probe p50/p99/max for GATED (is_readable before each read) vs DIRECT
+ *       (one __try, raw reads), then a per-frame budget vs probes-per-frame. The
+ *       gate cost scales with the read count and the miss rate, which a single
+ *       average-per-call number does not capture.
+ *   (G) [Phase 8] Pointer-chain primitives: a GATED per-link walk (is_readable
+ *       before each dereference) vs seh_resolve_chain / seh_read_chain (one
+ *       fault guard for the whole walk).
+ *
+ * Build with -DDMK_BUILD_BENCHMARKS=ON. Executable: DetourModKit_bench_memory
+ * Output: human-readable tables plus a TSV block on stdout.
+ */
+
+#include "DetourModKit/memory.hpp"
+#include "DetourModKit/logger.hpp"
+
+#include <windows.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <span>
+#include <thread>
+#include <vector>
+
+namespace
+{
+    using Clock = std::chrono::steady_clock;
+    namespace Mem = DetourModKit::Memory;
+
+    // Anti-dead-code sink: every measured op feeds this so the optimizer cannot
+    // observe an unused result and delete the work being timed.
+    std::atomic<std::uint64_t> g_sink{0};
+
+    inline void sink(std::uint64_t v) noexcept
+    {
+        g_sink.fetch_add(v, std::memory_order_relaxed);
+    }
+
+    // Amortized timing: run `op` `iters` times per sample, `samples` samples,
+    // return the median ns-per-call. Matches the bench_scanner.cpp idiom but
+    // reports nanoseconds because these ops are sub-microsecond.
+    template <typename Op>
+    double median_ns_per_call(std::size_t iters, std::size_t samples, Op &&op)
+    {
+        std::vector<double> per_call;
+        per_call.reserve(samples);
+        for (std::size_t s = 0; s < samples; ++s)
+        {
+            const auto start = Clock::now();
+            for (std::size_t i = 0; i < iters; ++i)
+            {
+                op();
+            }
+            const auto end = Clock::now();
+            const auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+            per_call.push_back(static_cast<double>(ns) / static_cast<double>(iters));
+        }
+        std::sort(per_call.begin(), per_call.end());
+        const std::size_t n = per_call.size();
+        return (n % 2 == 0) ? (per_call[n / 2 - 1] + per_call[n / 2]) / 2.0 : per_call[n / 2];
+    }
+
+    struct Row
+    {
+        const char *name;
+        double ns;
+    };
+    std::vector<Row> g_rows;
+
+    void report(const char *name, double ns)
+    {
+        g_rows.push_back({name, ns});
+        const double per_sec = ns > 0.0 ? 1.0e9 / ns : 0.0;
+        std::printf("  %-26s %10.2f ns/call   %14.0f calls/s\n", name, ns, per_sec);
+    }
+
+    // Allocate a single committed, readable+writable page to stand in for a
+    // "stable" game pose buffer. Seed it with a non-zero qword so the value-
+    // returning reads (read_ptr_unchecked) don't trip their low-address guard.
+    std::uint64_t *make_stable_page()
+    {
+        void *p = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if (!p)
+        {
+            std::fprintf(stderr, "[bench] VirtualAlloc failed: %lu\n", GetLastError());
+            std::exit(1);
+        }
+        auto *q = static_cast<std::uint64_t *>(p);
+        *q = 0x1122334455667788ull;
+        return q;
+    }
+
+    // Reserve (not commit) `count` regions to inflate the process VAD tree.
+    // Reserve-only keeps RAM cost near zero while still creating VAD nodes that
+    // VirtualQuery's tree lookup must traverse.
+    void grow_vad(std::size_t count)
+    {
+        for (std::size_t i = 0; i < count; ++i)
+        {
+            // 64 KiB allocation granularity => each call is its own VAD node.
+            (void)VirtualAlloc(nullptr, 4096, MEM_RESERVE, PAGE_NOACCESS);
+        }
+    }
+} // namespace
+
+// ---------------------------------------------------------------------------
+// (E) Contention study: p50/p99 latency of is_readable under N threads forcing
+// cache misses. Each thread round-robins over a large set of distinct committed
+// addresses so most lookups miss (256-entry cache vs thousands of addresses)
+// and take the per-shard EXCLUSIVE lock on the rebuild path -> cross-thread
+// serialization. This is the jitter source behind "framerate instability".
+// ---------------------------------------------------------------------------
+namespace
+{
+    struct LatencyResult
+    {
+        double p50_ns;
+        double p99_ns;
+        double max_ns;
+    };
+
+    LatencyResult percentiles(std::vector<double> &lat)
+    {
+        std::sort(lat.begin(), lat.end());
+        const std::size_t n = lat.size();
+        if (n == 0)
+            return {0, 0, 0};
+        auto pct = [&](double p) {
+            const std::size_t idx = std::min(n - 1, static_cast<std::size_t>(p * static_cast<double>(n)));
+            return lat[idx];
+        };
+        return {pct(0.50), pct(0.99), lat[n - 1]};
+    }
+
+    // Build a pool of committed RW pages whose addresses we round-robin to
+    // defeat the cache and force the miss path.
+    std::vector<void *> make_churn_pool(std::size_t pages)
+    {
+        std::vector<void *> pool;
+        pool.reserve(pages);
+        for (std::size_t i = 0; i < pages; ++i)
+        {
+            void *p = VirtualAlloc(nullptr, 4096, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+            if (p)
+                pool.push_back(p);
+        }
+        return pool;
+    }
+
+    LatencyResult run_contention(const std::vector<void *> &pool, unsigned threads, std::size_t ops_per_thread)
+    {
+        std::vector<std::vector<double>> per_thread(threads);
+        std::atomic<bool> go{false};
+        std::vector<std::thread> workers;
+        workers.reserve(threads);
+
+        for (unsigned t = 0; t < threads; ++t)
+        {
+            workers.emplace_back([&, t]() {
+                auto &lat = per_thread[t];
+                lat.reserve(ops_per_thread);
+                // Each thread starts at a different offset so they collide on
+                // shards rather than marching in lockstep over the same address.
+                std::size_t idx = (t * 1597u) % pool.size();
+                while (!go.load(std::memory_order_acquire))
+                {
+                }
+                for (std::size_t i = 0; i < ops_per_thread; ++i)
+                {
+                    void *addr = pool[idx];
+                    idx += 251u; // stride coprime-ish with pool size to spread
+                    if (idx >= pool.size())
+                        idx -= pool.size();
+                    const auto s = Clock::now();
+                    const bool r = Mem::is_readable(addr, 8);
+                    const auto e = Clock::now();
+                    sink(r ? 1u : 0u);
+                    lat.push_back(static_cast<double>(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(e - s).count()));
+                }
+            });
+        }
+
+        go.store(true, std::memory_order_release);
+        for (auto &w : workers)
+            w.join();
+
+        std::vector<double> all;
+        for (auto &v : per_thread)
+            all.insert(all.end(), v.begin(), v.end());
+        return percentiles(all);
+    }
+
+    // -----------------------------------------------------------------------
+    // Probe model: a hook resolves one object and reads K dependent fields off
+    // it, spanning a few distinct heap objects rather than a single page.
+    //
+    // GATED puts is_readable(addr, size) in front of every read. On a hot path
+    // that touches many distinct objects, those addresses are mostly cache
+    // misses (one new page per object thrashes the fixed-size cache), so each
+    // gated read pays a VirtualQuery plus a shard lock. DIRECT drops the
+    // predicate and reads under one __try per probe. This measures both,
+    // per-probe, including the tail.
+    //
+    // reads_per_obj models how many of the K reads land on the same page (same
+    // object) before the walk jumps to a new object: the first read of each
+    // object misses; the rest hit within the cache TTL. With K=8 and
+    // reads_per_obj=3 a probe pays about 3 misses and 5 hits when gated.
+    struct ProbeStats
+    {
+        double p50, p99, max, mean;
+    };
+
+    ProbeStats run_probe(const std::vector<void *> &pool, std::size_t probes,
+                         std::size_t k_reads, std::size_t reads_per_obj, bool gated)
+    {
+        std::vector<double> lat;
+        lat.reserve(probes);
+        std::size_t obj = 0;
+        for (std::size_t pr = 0; pr < probes; ++pr)
+        {
+            std::uintptr_t base = reinterpret_cast<std::uintptr_t>(pool[obj]);
+            const auto s = Clock::now();
+            std::uint64_t acc = 0;
+            std::size_t within = 0;
+            for (std::size_t r = 0; r < k_reads; ++r)
+            {
+                if (within >= reads_per_obj)
+                {
+                    // Chain jumps to a new distinct object -> new page -> miss.
+                    within = 0;
+                    obj += 977; // coprime-ish stride to spread across the pool
+                    if (obj >= pool.size())
+                        obj -= pool.size();
+                    base = reinterpret_cast<std::uintptr_t>(pool[obj]);
+                }
+                const std::uintptr_t a = base + within * 8; // same page, distinct field
+                ++within;
+                if (gated)
+                {
+                    if (Mem::is_readable(reinterpret_cast<void *>(a), 8))
+                        acc += *reinterpret_cast<volatile std::uint64_t *>(a);
+                }
+                else
+                {
+                    acc += *reinterpret_cast<volatile std::uint64_t *>(a);
+                }
+            }
+            const auto e = Clock::now();
+            sink(acc);
+            lat.push_back(static_cast<double>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(e - s).count()));
+            // Advance to a fresh starting object for the next probe.
+            obj += 977;
+            if (obj >= pool.size())
+                obj -= pool.size();
+        }
+        const LatencyResult pc = percentiles(lat);
+        double mean = 0.0;
+        for (double x : lat)
+            mean += x;
+        mean /= static_cast<double>(lat.empty() ? 1 : lat.size());
+        return {pc.p50_ns, pc.p99_ns, pc.max_ns, mean};
+    }
+} // namespace
+
+int main()
+{
+    // Silence write_bytes' success/debug logging so we time the memory work,
+    // not the log path. The level gate is an atomic check before any string
+    // formatting, so Error-level leaves the hot ops uninstrumented.
+    DetourModKit::Logger::get_instance().set_log_level(DetourModKit::LogLevel::Error);
+
+    constexpr std::size_t kIters = 200000;
+    constexpr std::size_t kSamples = 15;
+    constexpr std::size_t kWriteIters = 20000; // write_bytes is syscall-heavy
+
+    std::uint64_t *page = make_stable_page();
+    const auto addr = reinterpret_cast<std::uintptr_t>(page);
+    std::byte src[8];
+    std::memcpy(src, page, 8);
+
+    std::printf("DetourModKit Memory microbenchmark (toolchain: %s)\n",
+#ifdef _MSC_VER
+                "MSVC (seh_* use __try/__except)"
+#else
+                "non-MSVC (seh_* fall back to VirtualQuery)"
+#endif
+    );
+    std::printf("DEFAULT_CACHE_EXPIRY_MS = %u\n\n", static_cast<unsigned>(DetourModKit::DEFAULT_CACHE_EXPIRY_MS));
+
+    // --- Phase 1: cache OFF -> validators take the direct-VirtualQuery branch.
+    Mem::shutdown_cache(); // ensure uninitialized
+    std::printf("[1] Validation MISS / uncached (cache off -> VirtualQuery branch)\n");
+    const double ns_qry = median_ns_per_call(kIters, kSamples, [&]() {
+        MEMORY_BASIC_INFORMATION mbi;
+        sink(VirtualQuery(page, &mbi, sizeof(mbi)));
+    });
+    report("raw VirtualQuery", ns_qry);
+    const double ns_isr_miss = median_ns_per_call(kIters, kSamples, [&]() {
+        sink(Mem::is_readable(page, 8) ? 1u : 0u);
+    });
+    report("is_readable MISS", ns_isr_miss);
+    const double ns_isw_miss = median_ns_per_call(kIters, kSamples, [&]() {
+        sink(Mem::is_writable(page, 8) ? 1u : 0u);
+    });
+    report("is_writable MISS", ns_isw_miss);
+
+    // --- Phase 2: cache ON, warm -> validators hit the fresh entry.
+    if (!Mem::init_cache())
+    {
+        std::fprintf(stderr, "[bench] init_cache failed\n");
+        return 1;
+    }
+    sink(Mem::is_readable(page, 8) ? 1u : 0u); // warm the entry
+    sink(Mem::is_writable(page, 8) ? 1u : 0u);
+    std::printf("\n[2] Validation WARM HIT (cache on, entry fresh within TTL)\n");
+    const double ns_isr_hit = median_ns_per_call(kIters, kSamples, [&]() {
+        sink(Mem::is_readable(page, 8) ? 1u : 0u);
+    });
+    report("is_readable HIT", ns_isr_hit);
+    const double ns_isw_hit = median_ns_per_call(kIters, kSamples, [&]() {
+        sink(Mem::is_writable(page, 8) ? 1u : 0u);
+    });
+    report("is_writable HIT", ns_isw_hit);
+
+    // --- Phase 3: direct access primitives (no cache dependence).
+    std::printf("\n[3] Direct access primitives\n");
+    const double ns_dread = median_ns_per_call(kIters, kSamples, [&]() {
+        sink(*reinterpret_cast<volatile std::uint64_t *>(page));
+    });
+    report("direct volatile load", ns_dread);
+    const double ns_unchecked = median_ns_per_call(kIters, kSamples, [&]() {
+        sink(Mem::read_ptr_unchecked(addr, 0));
+    });
+    report("read_ptr_unchecked", ns_unchecked);
+    const double ns_sehread = median_ns_per_call(kIters, kSamples, [&]() {
+        auto v = Mem::seh_read<std::uint64_t>(addr);
+        sink(v ? *v : 0u);
+    });
+    report("seh_read<u64>", ns_sehread);
+    const double ns_dstore = median_ns_per_call(kIters, kSamples, [&]() {
+        *reinterpret_cast<volatile std::uint64_t *>(page) = g_sink.load(std::memory_order_relaxed);
+    });
+    report("direct volatile store", ns_dstore);
+    const double ns_wbytes = median_ns_per_call(kWriteIters, kSamples, [&]() {
+        (void)Mem::write_bytes(reinterpret_cast<std::byte *>(page), src, 8);
+    });
+    report("write_bytes(8)", ns_wbytes);
+
+    std::printf("\n  cache stats: %s\n", Mem::get_cache_stats().c_str());
+
+    // --- Phase 4: VirtualQuery cost vs VAD-tree size.
+    std::printf("\n[4] raw VirtualQuery vs VAD-tree size (single fixed address)\n");
+    const std::size_t vad_steps[] = {0, 1000, 4000, 12000};
+    std::size_t grown = 0;
+    for (std::size_t target : vad_steps)
+    {
+        if (target > grown)
+        {
+            grow_vad(target - grown);
+            grown = target;
+        }
+        const double ns = median_ns_per_call(kIters, kSamples, [&]() {
+            MEMORY_BASIC_INFORMATION mbi;
+            sink(VirtualQuery(page, &mbi, sizeof(mbi)));
+        });
+        std::printf("  +%6zu reserved regions   %10.2f ns/call\n", grown, ns);
+    }
+
+    // --- Phase 5: contention p50/p99 (the jitter mechanism).
+    std::printf("\n[5] is_readable latency under contention (mostly-miss workload)\n");
+    auto pool = make_churn_pool(4096); // 4096 addrs vs 256-entry cache => ~mostly miss
+    std::printf("  churn pool: %zu committed pages\n", pool.size());
+    for (unsigned threads : {1u, 2u, 4u})
+    {
+        auto r = run_contention(pool, threads, 50000);
+        std::printf("  %u thread(s):  p50 %8.0f ns   p99 %9.0f ns   max %10.0f ns\n",
+                    threads, r.p50_ns, r.p99_ns, r.max_ns);
+    }
+
+    // --- Phase 6: REALISTIC probe cost + tail. A probe = K dependent reads
+    // across a few distinct objects.
+    // GATED = is_readable() before each read (the per-read gated pattern).
+    // DIRECT = read inside one per-probe __try (the SEH fast path).
+    // Distinct objects per probe -> cache misses dominate (the real apply path).
+    constexpr std::size_t K_READS = 8;       // fields per probe (~5-8 typical)
+    constexpr std::size_t READS_PER_OBJ = 3; // ~3 distinct objects per probe
+    constexpr std::size_t PROBES = 30000;
+    std::printf("\n[6] Per-probe cost: %zu reads across ~%zu distinct (cache-missing) objects\n",
+                K_READS, (K_READS + READS_PER_OBJ - 1) / READS_PER_OBJ);
+    const ProbeStats gated = run_probe(pool, PROBES, K_READS, READS_PER_OBJ, true);
+    const ProbeStats direct = run_probe(pool, PROBES, K_READS, READS_PER_OBJ, false);
+    std::printf("  GATED  (is_readable+read): p50 %7.0f  p99 %8.0f  max %9.0f  mean %7.0f ns/probe\n",
+                gated.p50, gated.p99, gated.max, gated.mean);
+    std::printf("  DIRECT (raw read)        : p50 %7.0f  p99 %8.0f  max %9.0f  mean %7.0f ns/probe\n",
+                direct.p50, direct.p99, direct.max, direct.mean);
+    std::printf("  gated/direct mean ratio  : %.1fx   (added by the per-read gate: %.0f ns/probe)\n",
+                direct.mean > 0 ? gated.mean / direct.mean : 0.0, gated.mean - direct.mean);
+    std::printf("  cache stats after probes : %s\n", Mem::get_cache_stats().c_str());
+
+    // --- Phase 7: per-frame budget. A per-bind / apply hook fires P probes in
+    // a frame (one per material instance / bound object touched). Show what
+    // fraction of a 16.67 ms (60 FPS) frame the GATED vs DIRECT path consumes.
+    // This is the model that matters: cost scales with PROBES-PER-FRAME, which
+    // for an apply path touching many bound objects is large -- not "2/frame".
+    std::printf("\n[7] Per-frame budget (16.67 ms frame): cost = probes/frame x ns/probe\n");
+    std::printf("  %-12s %13s %9s %13s %9s\n",
+                "probes/fr", "gated ms/fr", "%frame", "direct ms/fr", "%frame");
+    for (std::size_t P : {1u, 8u, 64u, 256u, 1024u})
+    {
+        const double g_ms = static_cast<double>(P) * gated.mean / 1.0e6;
+        const double d_ms = static_cast<double>(P) * direct.mean / 1.0e6;
+        std::printf("  %-12zu %13.4f %8.2f%% %13.4f %8.2f%%\n",
+                    P, g_ms, 100.0 * g_ms / 16.667, d_ms, 100.0 * d_ms / 16.667);
+    }
+    std::printf("  (worst single GATED probe this run: %.0f ns = %.4f ms -> a one-probe frame\n"
+                "   can spike %.2f%% of budget from the tail alone)\n",
+                gated.max, gated.max / 1.0e6, 100.0 * (gated.max / 1.0e6) / 16.667);
+
+    // Contrast: the light case is a handful of validations per frame on a few
+    // stable (cached) addresses. With warm hits that is sub-microsecond per
+    // frame, which is why a low-frequency validated path is imperceptible while
+    // the high-frequency probe path above is not.
+    std::printf("  contrast (2 warm validations/frame): %.4f ms/frame\n",
+                (ns_isr_hit + ns_isw_hit) / 1.0e6);
+
+    // --- Phase 8: pointer-chain primitives. Walk a stable in-process chain
+    // (warm cache, the favorable case for the gated walk) three ways: a GATED
+    // per-link walk that calls is_readable before each dereference, vs
+    // seh_resolve_chain and seh_read_chain which guard the whole walk with one
+    // fault frame. Shows the per-link predicate cost stacking up even when every
+    // address is cached.
+    constexpr std::size_t CHAIN_CELLS = 6;
+    std::vector<std::uintptr_t> nodes(CHAIN_CELLS, 0);
+    nodes[CHAIN_CELLS - 1] = 0xABCDEF0123456789ull;
+    for (std::size_t i = 0; i + 1 < CHAIN_CELLS; ++i)
+        nodes[i] = reinterpret_cast<std::uintptr_t>(&nodes[i + 1]);
+    const std::uintptr_t chain_base = reinterpret_cast<std::uintptr_t>(&nodes[0]);
+    std::array<std::ptrdiff_t, CHAIN_CELLS> chain_offsets{}; // all zero
+    const std::span<const std::ptrdiff_t> chain_span{chain_offsets};
+
+    std::printf("\n[8] Pointer chain (%zu links, warm cache)\n", CHAIN_CELLS);
+    const double ns_gated_walk = median_ns_per_call(kIters, kSamples, [&]() {
+        std::uintptr_t cur = chain_base;
+        bool ok = true;
+        for (std::size_t i = 0; i + 1 < CHAIN_CELLS; ++i)
+        {
+            if (!Mem::is_readable(reinterpret_cast<void *>(cur), sizeof(std::uintptr_t)))
+            {
+                ok = false;
+                break;
+            }
+            cur = *reinterpret_cast<volatile std::uintptr_t *>(cur);
+        }
+        std::uint64_t v = 0;
+        if (ok && Mem::is_readable(reinterpret_cast<void *>(cur), sizeof(std::uint64_t)))
+            v = *reinterpret_cast<volatile std::uint64_t *>(cur);
+        sink(v);
+    });
+    report("gated link walk", ns_gated_walk);
+    const double ns_resolve_chain = median_ns_per_call(kIters, kSamples, [&]() {
+        const auto a = Mem::seh_resolve_chain(chain_base, chain_span);
+        sink(a ? *a : 0u);
+    });
+    report("seh_resolve_chain", ns_resolve_chain);
+    const double ns_read_chain = median_ns_per_call(kIters, kSamples, [&]() {
+        const auto v = Mem::seh_read_chain<std::uint64_t>(chain_base, chain_span);
+        sink(v ? *v : 0u);
+    });
+    report("seh_read_chain<u64>", ns_read_chain);
+    std::printf("  gated/seh_read_chain ratio: %.1fx\n",
+                ns_read_chain > 0 ? ns_gated_walk / ns_read_chain : 0.0);
+
+    // --- TSV block for machine parsing / pasting into the analysis doc.
+    std::printf("\n#TSV\tscenario\tns_per_call\n");
+    for (const auto &r : g_rows)
+        std::printf("#TSV\t%s\t%.2f\n", r.name, r.ns);
+    std::printf("#TSV\tprobe_gated_mean\t%.2f\n", gated.mean);
+    std::printf("#TSV\tprobe_gated_p99\t%.2f\n", gated.p99);
+    std::printf("#TSV\tprobe_gated_max\t%.2f\n", gated.max);
+    std::printf("#TSV\tprobe_direct_mean\t%.2f\n", direct.mean);
+    std::printf("#TSV\tprobe_gated_over_direct\t%.2f\n", direct.mean > 0 ? gated.mean / direct.mean : 0.0);
+
+    Mem::shutdown_cache();
+    std::printf("\n(sink=%llu)\n", static_cast<unsigned long long>(g_sink.load(std::memory_order_relaxed)));
+    return 0;
+}

--- a/tests/test_memory_chain.cpp
+++ b/tests/test_memory_chain.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <span>
+#include <type_traits>
 
 #include "DetourModKit/memory.hpp"
 
@@ -168,4 +169,30 @@ TEST(MemorySehReadChain, EmptyChainReadsAtBase)
         std::span<const ptrdiff_t>{}, &out, sizeof(out));
     EXPECT_TRUE(ok);
     EXPECT_EQ(out, 0xCAFEBABEu);
+}
+
+TEST(MemorySehReadChain, ReadsNonDefaultConstructibleType)
+{
+    // A trivially copyable type with a deleted default constructor: the read is
+    // a raw byte copy reinterpreted with std::bit_cast, so it must work without
+    // ever default-constructing T.
+    struct NoDefault
+    {
+        uint32_t a;
+        uint32_t b;
+        NoDefault() = delete;
+        constexpr NoDefault(uint32_t x, uint32_t y) noexcept : a(x), b(y) {}
+    };
+    static_assert(std::is_trivially_copyable_v<NoDefault>);
+    static_assert(!std::is_default_constructible_v<NoDefault>);
+
+    NoDefault src{0xAABBCCDDu, 0x11223344u};
+    uintptr_t holder = reinterpret_cast<uintptr_t>(&src);
+
+    // deref(&holder) -> &src, final offset 0 not dereferenced; read sizeof bytes.
+    const auto value = Memory::seh_read_chain<NoDefault>(
+        reinterpret_cast<uintptr_t>(&holder), {0, 0});
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(value->a, 0xAABBCCDDu);
+    EXPECT_EQ(value->b, 0x11223344u);
 }

--- a/tests/test_memory_chain.cpp
+++ b/tests/test_memory_chain.cpp
@@ -1,0 +1,171 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#include "DetourModKit/memory.hpp"
+
+using namespace DetourModKit;
+
+// Coverage for the pointer-validity guard and the single-fault-frame pointer
+// chain primitives (plausible_userspace_ptr, seh_resolve_chain, seh_read_chain,
+// seh_read_chain_bytes). These walk in-process pointer chains, so no game
+// memory or cache state is required; the cache is left in its default state.
+
+TEST(MemoryPlausiblePtr, RejectsLowAndNonCanonical)
+{
+    EXPECT_FALSE(Memory::plausible_userspace_ptr(0));
+    EXPECT_FALSE(Memory::plausible_userspace_ptr(0xFFFFu));
+    EXPECT_TRUE(Memory::plausible_userspace_ptr(Memory::USERSPACE_PTR_MIN));
+    EXPECT_TRUE(Memory::plausible_userspace_ptr(0x00007FFFFFFFFFFFull));
+    EXPECT_FALSE(Memory::plausible_userspace_ptr(Memory::USERSPACE_PTR_MAX));
+    EXPECT_FALSE(Memory::plausible_userspace_ptr(UINTPTR_MAX));
+}
+
+TEST(MemoryPlausiblePtr, IsConstexprEvaluable)
+{
+    // The guard is a pure arithmetic test, so it screens pointers at compile
+    // time as well as at run time.
+    static_assert(!Memory::plausible_userspace_ptr(0));
+    static_assert(Memory::plausible_userspace_ptr(Memory::USERSPACE_PTR_MIN));
+    static_assert(!Memory::plausible_userspace_ptr(Memory::USERSPACE_PTR_MAX));
+    SUCCEED();
+}
+
+TEST(MemorySehResolveChain, EmptyOffsetsReturnsBase)
+{
+    int x = 5;
+    const auto base = reinterpret_cast<uintptr_t>(&x);
+    const auto addr = Memory::seh_resolve_chain(base, std::span<const ptrdiff_t>{});
+    ASSERT_TRUE(addr.has_value());
+    EXPECT_EQ(*addr, base);
+}
+
+TEST(MemorySehResolveChain, TwoLevelResolvesFinalAddress)
+{
+    uint64_t target = 0x1122334455667788ull;
+    uintptr_t mid = reinterpret_cast<uintptr_t>(&target); // holds &target
+    uintptr_t root = reinterpret_cast<uintptr_t>(&mid);    // holds &mid
+
+    // deref(&root) -> &mid, deref(&mid) -> &target; final offset 0 not dereferenced.
+    const auto addr = Memory::seh_resolve_chain(reinterpret_cast<uintptr_t>(&root), {0, 0, 0});
+    ASSERT_TRUE(addr.has_value());
+    EXPECT_EQ(*addr, reinterpret_cast<uintptr_t>(&target));
+}
+
+TEST(MemorySehResolveChain, NonZeroFinalOffsetIsNotDereferenced)
+{
+    uint64_t cell = 0;
+    uintptr_t holder = reinterpret_cast<uintptr_t>(&cell);
+
+    // deref(&holder) -> &cell, then add 0x10 without dereferencing.
+    const auto addr = Memory::seh_resolve_chain(reinterpret_cast<uintptr_t>(&holder), {0, 0x10});
+    ASSERT_TRUE(addr.has_value());
+    EXPECT_EQ(*addr, reinterpret_cast<uintptr_t>(&cell) + 0x10);
+}
+
+TEST(MemorySehResolveChain, ImplausibleLinkReturnsNullopt)
+{
+    // The first dereference yields a null pointer, which fails the plausibility
+    // screen before any further dereference is attempted.
+    uintptr_t null_holder = 0;
+    const auto addr = Memory::seh_resolve_chain(
+        reinterpret_cast<uintptr_t>(&null_holder), {0, 0});
+    EXPECT_FALSE(addr.has_value());
+}
+
+TEST(MemorySehResolveChain, SingleOffsetIsAddedNotDereferenced)
+{
+    uint64_t cell = 0;
+    uintptr_t holder = reinterpret_cast<uintptr_t>(&cell);
+
+    // count==1 guards the `i + 1 < count` loop bound at the N==1 boundary: the
+    // dereference loop runs zero times and only the final-add branch executes,
+    // so the single offset is added to base without dereferencing *holder.
+    const auto addr = Memory::seh_resolve_chain(
+        reinterpret_cast<uintptr_t>(&holder), {0x10});
+    ASSERT_TRUE(addr.has_value());
+    EXPECT_EQ(*addr, reinterpret_cast<uintptr_t>(&holder) + 0x10);
+}
+
+TEST(MemorySehResolveChain, NegativeIntermediateOffsetSubtracts)
+{
+    struct Node
+    {
+        uintptr_t link;
+        uint64_t tail;
+    };
+    uint64_t target = 0x1122334455667788ull;
+    Node node{reinterpret_cast<uintptr_t>(&target), 0};
+
+    // A negative offset on a dereferenced (intermediate) link exercises the
+    // modular wrap of static_cast<uintptr_t>(ptrdiff_t): start one field past
+    // node.link, reach node.link by subtracting, then dereference it.
+    const ptrdiff_t back = -static_cast<ptrdiff_t>(offsetof(Node, tail));
+    uintptr_t root = reinterpret_cast<uintptr_t>(&node.tail);
+    const auto addr = Memory::seh_resolve_chain(
+        reinterpret_cast<uintptr_t>(&root), {0, back, 0});
+    ASSERT_TRUE(addr.has_value());
+    EXPECT_EQ(*addr, reinterpret_cast<uintptr_t>(&target));
+}
+
+TEST(MemorySehResolveChain, NegativeFinalOffsetSubtracts)
+{
+    uint64_t cell = 0;
+    uintptr_t holder = reinterpret_cast<uintptr_t>(&cell);
+
+    // A negative final offset exercises the wrap in the final-add branch, which
+    // is added to the resolved address but never dereferenced.
+    const ptrdiff_t neg = -0x10;
+    const auto addr = Memory::seh_resolve_chain(
+        reinterpret_cast<uintptr_t>(&holder), {0, neg});
+    ASSERT_TRUE(addr.has_value());
+    EXPECT_EQ(*addr, reinterpret_cast<uintptr_t>(&cell) - 0x10);
+}
+
+TEST(MemorySehReadChain, TwoLevelReadsTypedValue)
+{
+    uint64_t target = 0x1122334455667788ull;
+    uintptr_t mid = reinterpret_cast<uintptr_t>(&target);
+    uintptr_t root = reinterpret_cast<uintptr_t>(&mid);
+
+    const auto value = Memory::seh_read_chain<uint64_t>(
+        reinterpret_cast<uintptr_t>(&root), {0, 0, 0});
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(*value, target);
+}
+
+TEST(MemorySehReadChain, FaultReturnsNullopt)
+{
+    uintptr_t null_holder = 0;
+    const auto value = Memory::seh_read_chain<uint32_t>(
+        reinterpret_cast<uintptr_t>(&null_holder), {0, 0});
+    EXPECT_FALSE(value.has_value());
+}
+
+TEST(MemorySehReadChain, NullOutAndZeroBytes)
+{
+    uint64_t target = 0xCAFEBABEull;
+    const auto base = reinterpret_cast<uintptr_t>(&target);
+
+    // nullptr destination is rejected.
+    EXPECT_FALSE(Memory::seh_read_chain_bytes(base, std::span<const ptrdiff_t>{},
+                                              nullptr, sizeof(target)));
+
+    // Zero-byte read is a no-op success.
+    uint8_t scratch = 0;
+    EXPECT_TRUE(Memory::seh_read_chain_bytes(base, std::span<const ptrdiff_t>{},
+                                             &scratch, 0));
+}
+
+TEST(MemorySehReadChain, EmptyChainReadsAtBase)
+{
+    uint32_t target = 0xCAFEBABEu;
+    uint32_t out = 0;
+    const bool ok = Memory::seh_read_chain_bytes(
+        reinterpret_cast<uintptr_t>(&target),
+        std::span<const ptrdiff_t>{}, &out, sizeof(out));
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(out, 0xCAFEBABEu);
+}


### PR DESCRIPTION
## What

New `Memory` primitives for resolving and reading multi-level (Cheat-Engine-style) pointer chains under one fault guard:

- `plausible_userspace_ptr(p)` -- constexpr x64 user-mode pointer check (no syscall, no memory access)
- `seh_resolve_chain(base, {offsets...})` -- resolve a chain to its final address
- `seh_read_chain<T>(base, {offsets...})` -- resolve and read a typed value
- `seh_read_chain_bytes(base, {offsets...}, out, n)` -- resolve and read a raw range

The whole walk runs in one fault guard (a single `__try` on MSVC, VirtualQuery-guarded per link on MinGW). Intermediate links are plausibility-screened, so a faulting or implausible link aborts the walk and returns `nullopt`/`false`.

## Why

Gating every hot-path read with `is_readable` costs a lock plus a possible `VirtualQuery` per field and is a time-of-check/time-of-use illusion. These primitives read directly under one guard instead. Usage guidance in `docs/misc/hot-path-memory.md`.

## Benchmark

`tests/bench_memory.cpp`, MSVC 2022 release (`/O2`, `-DDMK_BUILD_BENCHMARKS=ON`), 200k iterations x 15 samples, median per call. One machine, illustrative; run it for your own target.

Per-call cost (warm cache where applicable):

| Operation | ns/call |
|-----------|--------:|
| direct volatile load | 3.9 |
| `read_ptr_unchecked` | 3.9 |
| `seh_read<u64>` | 7.4 |
| `is_readable` warm HIT | 54.5 |
| `is_readable` cold MISS (VirtualQuery) | 236.7 |

Pointer chain, 6 links, warm cache:

| Walk | ns/call |
|------|--------:|
| `seh_read_chain<u64>` (one guard) | 10.9 |
| gated per-link (`is_readable` before each) | 316.1 |

The chain primitive is ~29x faster than gating each link, and a single SEH-guarded read (7.4 ns) is within ~2x of a raw load because the MSVC `__try` is table-driven.

Hot-path probe model (8 reads across ~3 cache-missing objects), per probe:

| Path | mean | p99 | max |
|------|-----:|----:|----:|
| GATED (`is_readable` per read) | 6120 ns | 10500 ns | 152100 ns |
| DIRECT (one guard, raw reads) | 89 ns | 400 ns | 5100 ns |

Gating costs ~69x the mean and a much worse tail (p99 10500 ns vs 400 ns). At 256 such probes per frame that is 9.4% of a 16.67 ms frame gated vs 0.14% direct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pointer-chain resolution and guarded memory read helpers
  * User-space pointer plausibility checks and bounds constants
  * Added standalone memory microbenchmark executable

* **Documentation**
  * New hot-path guide for efficient memory access patterns
  * Benchmark analysis and updated test/benchmark docs

* **Tests**
  * New pointer-chain memory test suite
  * Memory performance benchmark with multi-scenario analysis

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tkhquang/DetourModKit/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->