### PR TITLE
refactor(memory): isolate predicate cost in hot-path benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ For detailed coverage analysis and test architecture, see the [Test Coverage Gui
 ## Guides
 
 * [AOB Signature Scanning Guide](docs/misc/aob-signatures.md) - Pattern syntax, RIP-relative resolution, and patch-proof signature practices
+* [MSVC RTTI Walker Guide](docs/misc/rtti-walker.md) - Recover concrete type names from runtime vtables across DLL boundaries without `typeid`/`dynamic_cast`
+* [Hot-Path Memory Guide](docs/misc/hot-path-memory.md) - Reading and writing game memory in per-frame hot paths with the `seh_*` and `read_ptr_*` primitives
 * [Hot-Reload Development Guide](docs/hot-reload/README.md) - Development workflow for iterating on hooks with live reload
 * [Config Hot-Reload Guide](docs/config-hot-reload/README.md) - INI filesystem watcher and hotkey-triggered `Config::reload()`
 * [Test Coverage Guide](docs/tests/README.md) - Coverage analysis, test architecture, and module-level breakdown

--- a/docs/analysis/memory_bench_v3.x/README.md
+++ b/docs/analysis/memory_bench_v3.x/README.md
@@ -7,7 +7,7 @@ The benchmark measures:
 - **Per-call cost** of each primitive (validation warm-hit / cold-miss, raw `VirtualQuery`, `read_ptr_unchecked`, `seh_read`, direct load/store, `write_bytes`).
 - **VirtualQuery vs address-space size** (reserve N regions, re-time) to show whether a large VAD tree inflates the miss cost.
 - **`is_readable` tail latency** (p50/p99/max) under 1/2/4 threads forcing cache misses on a shared shard set. Tail latency, not average, is what a frame loop feels as a hitch.
-- **Probe model**: a hook that resolves an object and reads K dependent fields across a few distinct (cache-missing) objects, GATED (`is_readable` before every read) vs DIRECT (one fault guard, raw reads), reported per probe including the tail, plus a per-frame budget.
+- **Probe model**: a hook that resolves an object and reads K dependent fields across a few distinct (cache-missing) objects, GATED (`is_readable` before every read) vs DIRECT (raw volatile reads, no predicate or guard), reported per probe including the tail, plus a per-frame budget.
 - **Pointer chain**: a GATED per-link walk vs `seh_resolve_chain` / `seh_read_chain` (one fault guard for the whole walk).
 
 ## Hardware / configuration
@@ -81,7 +81,7 @@ The benchmark measures:
 
 A few takeaways:
 
-1. **The predicate is the wrong tool on a hot path.** It is not free even on a cache hit (a lock plus a lookup), and on a cache miss it pays a `VirtualQuery` plus an exclusive-lock rebuild. The probe model, where each object is a fresh page, is miss-dominated, so the gate runs ~69x slower per probe than reading directly under one guard.
+1. **The predicate is the wrong tool on a hot path.** It is not free even on a cache hit (a lock plus a lookup), and on a cache miss it pays a `VirtualQuery` plus an exclusive-lock rebuild. The probe model, where each object is a fresh page, is miss-dominated, so the gate runs ~69x slower per probe than a direct read.
 2. **The cost scales with probes-per-frame, and the tail is the real hazard.** At a few probes per frame the gate is imperceptible. At a few hundred per frame (an apply path touching many bound objects) it climbs to a large fraction of the frame budget, and the p99/max tail can spike a frame on its own. A single average-per-call number hides this.
 3. **A single SEH-guarded read is nearly free on MSVC.** `seh_read` is within ~2x of a raw load, and the chain primitives keep that property across a whole multi-level walk: one guard for the walk instead of N predicate calls.
 4. **`VirtualQuery` cost is flat in address-space size.** Growing the VAD tree to 12,000 reserved regions does not move the per-call cost (the kernel walks a balanced tree), so the miss cost is intrinsic, not a function of how fragmented the process is.

--- a/include/DetourModKit/memory.hpp
+++ b/include/DetourModKit/memory.hpp
@@ -390,7 +390,7 @@ namespace DetourModKit
             requires std::is_trivially_copyable_v<T>
         [[nodiscard]] std::optional<T> seh_read(uintptr_t addr) noexcept
         {
-            std::array<std::byte, sizeof(T)> storage;
+            std::array<std::byte, sizeof(T)> storage{};
             if (!seh_read_bytes(addr, storage.data(), sizeof(T)))
                 return std::nullopt;
             return std::bit_cast<T>(storage);
@@ -486,7 +486,7 @@ namespace DetourModKit
         [[nodiscard]] std::optional<T> seh_read_chain(
             uintptr_t base, std::span<const ptrdiff_t> offsets) noexcept
         {
-            std::array<std::byte, sizeof(T)> storage;
+            std::array<std::byte, sizeof(T)> storage{};
             if (!seh_read_chain_bytes(base, offsets, storage.data(), sizeof(T)))
                 return std::nullopt;
             return std::bit_cast<T>(storage);

--- a/tests/bench_memory.cpp
+++ b/tests/bench_memory.cpp
@@ -30,7 +30,8 @@
  *       benchmark guards): a hook that runs many probes per frame, each doing K
  *       dependent reads across a few DISTINCT (cache-missing) objects. Reports
  *       per-probe p50/p99/max for GATED (is_readable before each read) vs DIRECT
- *       (one __try, raw reads), then a per-frame budget vs probes-per-frame. The
+ *       (raw volatile reads, no predicate or guard), then a per-frame budget vs
+ *       probes-per-frame. The
  *       gate cost scales with the read count and the miss rate, which a single
  *       average-per-call number does not capture.
  *   (G) [Phase 8] Pointer-chain primitives: a GATED per-link walk (is_readable
@@ -246,8 +247,11 @@ namespace
     // that touches many distinct objects, those addresses are mostly cache
     // misses (one new page per object thrashes the fixed-size cache), so each
     // gated read pays a VirtualQuery plus a shard lock. DIRECT drops the
-    // predicate and reads under one __try per probe. This measures both,
-    // per-probe, including the tail.
+    // predicate and does a raw volatile dereference per read (no seh_* call, no
+    // __try frame), which isolates the predicate cost. On MSVC a guarded direct
+    // read (seh_read) costs about the same, since the SEH frame is table-driven
+    // and free on the no-fault path (Phase 3). This measures both, per-probe,
+    // including the tail.
     //
     // reads_per_obj models how many of the K reads land on the same page (same
     // object) before the walk jumps to a new object: the first read of each
@@ -429,7 +433,8 @@ int main()
     // --- Phase 6: REALISTIC probe cost + tail. A probe = K dependent reads
     // across a few distinct objects.
     // GATED = is_readable() before each read (the per-read gated pattern).
-    // DIRECT = read inside one per-probe __try (the SEH fast path).
+    // DIRECT = raw volatile read, no predicate and no __try (the direct,
+    // unchecked access path; on MSVC a guarded read is about as cheap, Phase 3).
     // Distinct objects per probe -> cache misses dominate (the real apply path).
     constexpr std::size_t K_READS = 8;       // fields per probe (~5-8 typical)
     constexpr std::size_t READS_PER_OBJ = 3; // ~3 distinct objects per probe


### PR DESCRIPTION
## Summary

Refines the hot-path memory benchmark so the GATED vs DIRECT comparison measures only the validation-predicate overhead, plus a small library hardening and the new docs guides.

