### PR TITLE
fix: harden scan-path reads and loader-lock teardown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(DetourModKit VERSION 3.3.0 LANGUAGES CXX)
+project(DetourModKit VERSION 3.4.0 LANGUAGES CXX)
 
 # --- Standard and Compiler Options ---
 set(CMAKE_CXX_STANDARD 23)

--- a/include/DetourModKit/config.hpp
+++ b/include/DetourModKit/config.hpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <concepts>
 #include <functional>
 #include <memory>
 #include <string>
@@ -57,17 +58,17 @@ namespace DetourModKit
          *          Within a single combo, modifiers are separated by '+' and the last
          *          '+'-delimited token is the trigger key. Tokens can be human-readable
          *          names or hex VK codes:
-         *            - "F3"                   → keys=[F3], modifiers=[]
-         *            - "Ctrl+F3"              → keys=[F3], modifiers=[Ctrl]
-         *            - "Ctrl+Shift+F3"        → keys=[F3], modifiers=[Ctrl, Shift]
-         *            - "Mouse4"               → keys=[Mouse4], modifiers=[]
-         *            - "Gamepad_LB+Gamepad_A" → keys=[Gamepad_A], modifiers=[Gamepad_LB]
-         *            - "0x11+0x72"            → keys=[0x72], modifiers=[0x11] (hex fallback)
+         *            - "F3"                   -> keys=[F3], modifiers=[]
+         *            - "Ctrl+F3"              -> keys=[F3], modifiers=[Ctrl]
+         *            - "Ctrl+Shift+F3"        -> keys=[F3], modifiers=[Ctrl, Shift]
+         *            - "Mouse4"               -> keys=[Mouse4], modifiers=[]
+         *            - "Gamepad_LB+Gamepad_A" -> keys=[Gamepad_A], modifiers=[Gamepad_LB]
+         *            - "0x11+0x72"            -> keys=[0x72], modifiers=[0x11] (hex fallback)
          *
          *          Multiple combos are separated by commas in INI values, parsed into
          *          a KeyComboList. Each combo is independent (OR logic between combos):
-         *            - "F3,Gamepad_LT+Gamepad_B" → [{keys=[F3]}, {keys=[Gamepad_B], mods=[Gamepad_LT]}]
-         *            - "Ctrl+F3,Ctrl+F4"          → [{keys=[F3], mods=[Ctrl]}, {keys=[F4], mods=[Ctrl]}]
+         *            - "F3,Gamepad_LT+Gamepad_B" -> [{keys=[F3]}, {keys=[Gamepad_B], mods=[Gamepad_LT]}]
+         *            - "Ctrl+F3,Ctrl+F4"          -> [{keys=[F3], mods=[Ctrl]}, {keys=[F4], mods=[Ctrl]}]
          */
         struct KeyCombo
         {
@@ -194,39 +195,35 @@ namespace DetourModKit
          * @param out Atomic destination updated on every successful parse.
          * @param default_value Value applied when the INI key is missing.
          */
-        // Marked = delete so unsupported T (e.g. double, uint64_t) becomes a
-        // crisp compile error pointing at the call site rather than a mangled
-        // unresolved-symbol link error. The supported instantiations are the
-        // explicit specialisations below (int, bool, float).
+        // A single constrained template rather than explicit specializations:
+        // specializing a function template is discouraged (Core Guidelines
+        // T.144) and an in-class explicit specialization is non-standard. The
+        // requires-clause caps the supported set to int, bool, and float, so an
+        // unsupported T (e.g. double, uint64_t) is a crisp constraint error at
+        // the call site rather than a mangled unresolved-symbol link error.
         template <typename T>
+            requires(std::same_as<T, int> || std::same_as<T, bool> || std::same_as<T, float>)
         void register_atomic(std::string_view section, std::string_view ini_key,
-                             std::string_view log_key_name, std::atomic<T> &out, T default_value) = delete;
-
-        template <>
-        inline void register_atomic<int>(std::string_view section, std::string_view ini_key,
-                                         std::string_view log_key_name, std::atomic<int> &out, int default_value)
+                             std::string_view log_key_name, std::atomic<T> &out, T default_value)
         {
-            register_int(section, ini_key, log_key_name,
-                         [&out](int v) { out.store(v, std::memory_order_relaxed); },
-                         default_value);
-        }
-
-        template <>
-        inline void register_atomic<bool>(std::string_view section, std::string_view ini_key,
-                                          std::string_view log_key_name, std::atomic<bool> &out, bool default_value)
-        {
-            register_bool(section, ini_key, log_key_name,
-                          [&out](bool v) { out.store(v, std::memory_order_relaxed); },
-                          default_value);
-        }
-
-        template <>
-        inline void register_atomic<float>(std::string_view section, std::string_view ini_key,
-                                           std::string_view log_key_name, std::atomic<float> &out, float default_value)
-        {
-            register_float(section, ini_key, log_key_name,
-                           [&out](float v) { out.store(v, std::memory_order_relaxed); },
-                           default_value);
+            if constexpr (std::same_as<T, int>)
+            {
+                register_int(section, ini_key, log_key_name,
+                             [&out](int v) { out.store(v, std::memory_order_relaxed); },
+                             default_value);
+            }
+            else if constexpr (std::same_as<T, bool>)
+            {
+                register_bool(section, ini_key, log_key_name,
+                              [&out](bool v) { out.store(v, std::memory_order_relaxed); },
+                              default_value);
+            }
+            else
+            {
+                register_float(section, ini_key, log_key_name,
+                               [&out](float v) { out.store(v, std::memory_order_relaxed); },
+                               default_value);
+            }
         }
 
         /**

--- a/include/DetourModKit/logger.hpp
+++ b/include/DetourModKit/logger.hpp
@@ -119,7 +119,7 @@ namespace DetourModKit
          * @brief Checks if async logging mode is enabled.
          * @return true if async mode is enabled, false otherwise.
          */
-        bool is_async_mode_enabled() const;
+        bool is_async_mode_enabled() const noexcept;
 
         /**
          * @brief Flushes all pending log messages.
@@ -141,7 +141,7 @@ namespace DetourModKit
          * @brief Gets the current log level.
          * @return LogLevel The current minimum log level.
          */
-        LogLevel get_log_level() const
+        LogLevel get_log_level() const noexcept
         {
             return current_log_level_.load(std::memory_order_acquire);
         }
@@ -277,8 +277,8 @@ namespace DetourModKit
         static void set_static_config(std::shared_ptr<const StaticConfig> config);
 
         // Lock ordering (must be acquired in this order to prevent deadlock):
-        //   1. async_mutex_      — async logger lifecycle
-        //   2. *log_mutex_ptr_   — file stream I/O
+        //   1. async_mutex_      -- async logger lifecycle
+        //   2. *log_mutex_ptr_   -- file stream I/O
 
         std::string log_prefix_;
         std::string log_file_name_;

--- a/include/DetourModKit/logger.hpp
+++ b/include/DetourModKit/logger.hpp
@@ -119,7 +119,7 @@ namespace DetourModKit
          * @brief Checks if async logging mode is enabled.
          * @return true if async mode is enabled, false otherwise.
          */
-        bool is_async_mode_enabled() const noexcept;
+        [[nodiscard]] bool is_async_mode_enabled() const noexcept;
 
         /**
          * @brief Flushes all pending log messages.
@@ -141,7 +141,7 @@ namespace DetourModKit
          * @brief Gets the current log level.
          * @return LogLevel The current minimum log level.
          */
-        LogLevel get_log_level() const noexcept
+        [[nodiscard]] LogLevel get_log_level() const noexcept
         {
             return current_log_level_.load(std::memory_order_acquire);
         }
@@ -153,7 +153,7 @@ namespace DetourModKit
          * @param level The LogLevel to test.
          * @return true if a message at this level would pass the current filter.
          */
-        bool is_enabled(LogLevel level) const noexcept
+        [[nodiscard]] bool is_enabled(LogLevel level) const noexcept
         {
             return level >= current_log_level_.load(std::memory_order_acquire);
         }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -18,6 +18,7 @@
 #include <Xinput.h>
 #include <algorithm>
 #include <exception>
+#include <new>
 #include <unordered_set>
 
 using DetourModKit::detail::is_loader_lock_held;
@@ -1223,7 +1224,30 @@ namespace DetourModKit
 
         if (local_poller)
         {
+            // Read loader-lock ownership once; it is stable across this call
+            // because InputPoller::shutdown() re-checks it on the same thread with
+            // no intervening lock release, so both observe the same result.
+            const bool under_loader_lock = is_loader_lock_held();
             local_poller->shutdown();
+
+            if (under_loader_lock)
+            {
+                // Under the loader lock InputPoller::shutdown() detaches its poll
+                // thread instead of joining it (a join would deadlock the loader).
+                // The detached thread keeps reading InputPoller members (cv_,
+                // cv_mutex_, poll_interval_, bindings_) until it observes the stop
+                // request, so destroying the poller now would free those members
+                // mid-access: a use-after-free. Move the last reference into a
+                // nothrow-allocated heap cell that is never freed, so the object
+                // outlives the detached thread. The module is already pinned by
+                // InputPoller::shutdown(). This mirrors the leak-on-loader-lock
+                // discipline used for the Logger and ConfigWatcher teardown paths;
+                // nothrow keeps this noexcept path honest under OOM (the poller is
+                // then destroyed -- the pre-existing hazard -- rather than throwing).
+                auto *leaked = new (std::nothrow)
+                    std::shared_ptr<InputPoller>(std::move(local_poller));
+                (void)leaked;
+            }
         }
     }
 } // namespace DetourModKit

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -296,14 +296,24 @@ namespace DetourModKit
 
         if (is_loader_lock_held())
         {
+            // Under loader lock (FreeLibrary / process unload) the poll thread
+            // cannot be joined without deadlocking the loader, so it is detached
+            // after pinning the module. It is still running and will exit only
+            // once it observes the stop request, so we must NOT touch shared
+            // binding state or fire hold-release callbacks here: that would race
+            // the detached thread and run user callbacks under the loader lock
+            // (a callback that enters the loader -- LoadLibrary family or a peer
+            // DllMain mutex -- would deadlock). Mirrors clear_bindings(invoke_callbacks=false).
             pin_current_module();
             poll_thread_.detach();
-        }
-        else
-        {
-            poll_thread_.join();
+            running_.store(false, std::memory_order_release);
+            return;
         }
 
+        poll_thread_.join();
+
+        // The poll thread is provably stopped here, so releasing active holds
+        // and firing their on_state_change(false) callbacks is race-free.
         running_.store(false, std::memory_order_release);
         release_active_holds();
     }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -69,7 +69,7 @@ namespace DetourModKit
 
         Logger &instance = get_instance();
 
-        // configure() is the authoritative reset path — allow reconfiguration
+        // configure() is the authoritative reset path -- allow reconfiguration
         // even after shutdown to support reuse (e.g., test fixtures).
         instance.shutdown_called_.store(false, std::memory_order_release);
 
@@ -475,7 +475,7 @@ namespace DetourModKit
         }
     }
 
-    bool Logger::is_async_mode_enabled() const
+    bool Logger::is_async_mode_enabled() const noexcept
     {
         return async_mode_enabled_.load(std::memory_order_acquire);
     }

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -7,9 +7,21 @@ namespace DetourModKit::detail
 {
     /**
      * @brief Checks if the current thread holds the Windows loader lock.
-     * @details Uses the PEB LoaderLock critical section at a well-known offset
-     *          that has been stable across all Windows versions from XP through 11.
-     *          Thread joins are unsafe while the loader lock is held (DllMain context).
+     * @details Reads the loader-lock CRITICAL_SECTION pointer from the PEB at a
+     *          well-known offset (0x110 on x64, 0xA0 on x86) that has been stable
+     *          from Windows XP through 11, then compares its OwningThread to the
+     *          current thread id. Thread joins are unsafe while the loader lock is
+     *          held (DllMain context), so this gate decides detach-vs-join across
+     *          every subsystem teardown.
+     * @note The result is fail-safe. If the PEB or the loader-lock pointer cannot
+     *       be read, or the pointer does not resolve to committed, readable memory
+     *       (e.g. a future or foreign PEB layout shifted the offset), the function
+     *       assumes the lock IS held and returns true. A spurious true only leaks a
+     *       detached thread (bounded, with the module pinned); a spurious false
+     *       would join a thread under the loader lock and deadlock the host on
+     *       unload, so uncertainty must bias toward true.
+     * @return true if the current thread holds the loader lock, or if ownership
+     *         cannot be determined.
      */
     inline bool is_loader_lock_held() noexcept
     {
@@ -21,11 +33,26 @@ namespace DetourModKit::detail
         constexpr size_t kLoaderLockOffset = 0xA0;
 #endif
         if (!peb)
-            return false;
+            return true;
 
         auto *cs = *reinterpret_cast<PCRITICAL_SECTION *>(peb + kLoaderLockOffset);
         if (!cs)
-            return false;
+            return true;
+
+        // Confirm the critical section lives in committed, readable memory before
+        // dereferencing OwningThread. A wrong kLoaderLockOffset (foreign or future
+        // PEB layout) would otherwise read a bogus pointer and fault the host.
+        constexpr DWORD kReadableProtect =
+            PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |
+            PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+        MEMORY_BASIC_INFORMATION mbi{};
+        if (VirtualQuery(cs, &mbi, sizeof(mbi)) != sizeof(mbi) ||
+            mbi.State != MEM_COMMIT ||
+            (mbi.Protect & kReadableProtect) == 0 ||
+            (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) != 0)
+        {
+            return true;
+        }
 
         return cs->OwningThread ==
                reinterpret_cast<HANDLE>(static_cast<uintptr_t>(GetCurrentThreadId()));

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -564,13 +564,15 @@ std::expected<uintptr_t, DetourModKit::RipResolveError> DetourModKit::Scanner::r
     }
 
     const std::byte *disp_ptr = instruction_address + displacement_offset;
-    if (!Memory::is_readable(disp_ptr, sizeof(int32_t)))
+    // Read the displacement under a single SEH fault guard instead of
+    // is_readable + raw memcpy. is_readable is a time-of-check/time-of-use
+    // illusion -- the page can change protection or unmap between the check
+    // and the copy -- so an unguarded memcpy could fault the host.
+    const auto displacement = Memory::seh_read<int32_t>(reinterpret_cast<uintptr_t>(disp_ptr));
+    if (!displacement)
     {
         return std::unexpected(RipResolveError::UnreadableDisplacement);
     }
-
-    int32_t displacement;
-    std::memcpy(&displacement, disp_ptr, sizeof(int32_t));
 
     // Compute the target in unsigned modular arithmetic so the math stays
     // well-defined on every input, including kernel-range instruction
@@ -578,7 +580,7 @@ std::expected<uintptr_t, DetourModKit::RipResolveError> DetourModKit::Scanner::r
     // The displacement is sign-extended first so negative disp32 values wrap
     // to the correct 64-bit offset.
     const uintptr_t base = reinterpret_cast<uintptr_t>(instruction_address);
-    const uintptr_t disp_sext = static_cast<uintptr_t>(static_cast<int64_t>(displacement));
+    const uintptr_t disp_sext = static_cast<uintptr_t>(static_cast<int64_t>(*displacement));
     return base + instruction_length + disp_sext;
 }
 
@@ -776,15 +778,17 @@ namespace
             return match_addr + static_cast<std::uintptr_t>(c.disp_offset);
         }
         const auto disp_addr = match_addr + static_cast<std::uintptr_t>(c.disp_offset);
-        if (!DetourModKit::Memory::is_readable(reinterpret_cast<const void *>(disp_addr), sizeof(std::int32_t)))
+        // Fault-guarded read instead of is_readable + raw memcpy: the page can
+        // change between the check and the copy (TOCTOU), so an unguarded memcpy
+        // could fault the host process. seh_read returns nullopt on any fault.
+        const auto disp = DetourModKit::Memory::seh_read<std::int32_t>(disp_addr);
+        if (!disp)
         {
             return 0;
         }
-        std::int32_t disp = 0;
-        std::memcpy(&disp, reinterpret_cast<const void *>(disp_addr), sizeof(disp));
         return static_cast<std::uintptr_t>(
             static_cast<std::int64_t>(match_addr + static_cast<std::uintptr_t>(c.instr_end_offset)) +
-            disp);
+            *disp);
     }
 
     // Minimum number of literal (non-wildcard) bytes the tail of the pattern
@@ -1138,12 +1142,22 @@ bool DetourModKit::Scanner::is_likely_function_prologue(std::uintptr_t addr) noe
         return false;
     }
 
-    const auto *probe = reinterpret_cast<const void *>(addr);
-    if (!Memory::is_readable(probe, 1))
+    // Read the first opcode byte under a fault guard rather than is_readable +
+    // a raw dereference. is_readable is a TOCTOU illusion (the page can change
+    // or unmap between the check and the read), and the bare dereference would
+    // then fault the host. seh_read returns nullopt on any fault.
+    const auto b0 = Memory::seh_read<std::uint8_t>(addr);
+    if (!b0)
     {
         return false;
     }
 
-    const auto b0 = *reinterpret_cast<const std::uint8_t *>(addr);
-    return b0 != 0x00 && b0 != 0xCC && b0 != 0xC2 && b0 != 0xC3;
+    // Reject bytes that never begin a real function prologue, so an AOB match
+    // that landed in inter-function padding or past a function's end is filtered
+    // out instead of accepted as a target:
+    //   0x00 -- zero fill / uninitialized page (decodes as `add [rax], al`)
+    //   0xCC -- INT3, the alignment padding linkers insert between functions
+    //   0xC3 -- RET (near return): a function epilogue, not a prologue
+    //   0xC2 -- RET imm16: likewise a return, not a prologue
+    return *b0 != 0x00 && *b0 != 0xCC && *b0 != 0xC2 && *b0 != 0xC3;
 }

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -9,24 +9,26 @@ namespace
     TEST(VersionTest, MacrosMatchProjectVersion)
     {
         EXPECT_EQ(DMK_VERSION_MAJOR, 3);
-        EXPECT_EQ(DMK_VERSION_MINOR, 3);
+        EXPECT_EQ(DMK_VERSION_MINOR, 4);
         EXPECT_EQ(DMK_VERSION_PATCH, 0);
     }
 
     TEST(VersionTest, VersionStringMatchesMacros)
     {
-        EXPECT_STREQ(DMK_VERSION_STRING, "3.3.0");
+        EXPECT_STREQ(DMK_VERSION_STRING, "3.4.0");
     }
 
     TEST(VersionTest, AtLeastComparisonsAreCorrect)
     {
+        EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 4, 0));
+        EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 3, 1));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 3, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 4));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 1, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(2, 0, 0));
-        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 3, 1));
-        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 4, 0));
+        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 4, 1));
+        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 5, 0));
         EXPECT_FALSE(DMK_VERSION_AT_LEAST(4, 0, 0));
     }
 


### PR DESCRIPTION
## Summary

Hardening pass for the v3.4.0 cut. Strictly additive on v3.3.0; no public API breaks.

- **scanner**: RIP-relative displacement reads and `is_likely_function_prologue` now go through `Memory::seh_read` instead of `is_readable` + a raw dereference, closing a TOCTOU window where a page could unmap/reprotect between the check and the read and fault the host during a scan.
- **input**: on the loader-lock detach path, `shutdown()` no longer calls `release_active_holds()`, so user hold-release callbacks never fire under the loader lock (deadlock risk during `FreeLibrary`). The join path still releases, race-free.
- **platform**: `is_loader_lock_held()` validates the PEB loader-lock `CRITICAL_SECTION` pointer is committed/readable before dereferencing it, and fails safe to "held" on any uncertainty (a wrong `false` would deadlock the loader on unload).
- **config**: `register_atomic` is now a single constrained template (`requires` + `if constexpr`) instead of in-class explicit specializations; same `int`/`bool`/`float` support, standard-conforming.
- **logger**: `get_log_level()` and `is_async_mode_enabled()` are now `noexcept`.
- **release**: bump to `3.4.0` in `CMakeLists.txt` and retarget `tests/test_version.cpp`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Project version bumped to 3.4.0

* **Bug Fixes**
  * Improved application shutdown behavior under system-level lock conditions
  * Enhanced detection of system-level lock states with memory validation
  * Strengthened memory access safety during pattern scanning operations

* **Improvements**
  * Logger API methods now provide stronger exception-safety guarantees

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tkhquang/DetourModKit/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->