### PR TITLE
fix(input): close gamepad consume leading-edge race

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(DetourModKit VERSION 3.6.0 LANGUAGES CXX)
+project(DetourModKit VERSION 3.6.1 LANGUAGES CXX)
 
 # --- Standard and Compiler Options ---
 set(CMAKE_CXX_STANDARD 23)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -247,6 +247,83 @@ namespace DetourModKit
             return false;
         }
 
+        /// Builds the detour-evaluable consume rule list from the current bindings.
+        /// A rule is emitted for every consume binding whose masked triggers include
+        /// a digital gamepad button, but only when every known modifier (across all
+        /// bindings) is itself a digital gamepad button. The XInput detour sees only
+        /// XINPUT_GAMEPAD.wButtons, so it cannot observe a keyboard/mouse modifier or
+        /// an analog trigger/stick used as a modifier; if any such modifier exists,
+        /// the poll loop's strict-match decision is not reproducible in the detour,
+        /// so the whole list is dropped and the reactive (poll-published) mask alone
+        /// covers the held-modifier case. For an eligible binding the rule carries:
+        ///   modifier_mask  -- all of the chord's modifier bits,
+        ///   trigger_mask   -- the chord's digital gamepad trigger bits to clear,
+        ///   forbidden_mask -- every other known modifier bit, so holding a modifier
+        ///                     that belongs to a different chord rejects this one,
+        ///                     exactly as the poll loop's strict-match check does.
+        std::vector<detail::GamepadConsumeRule>
+        build_gamepad_consume_rules(const std::vector<InputBinding> &bindings,
+                                    const std::vector<InputCode> &known_modifiers) noexcept
+        {
+            const auto is_digital_gamepad = [](const InputCode &code) noexcept
+            {
+                return code.source == InputSource::Gamepad &&
+                       code.code > 0 && code.code < GamepadCode::LeftTrigger;
+            };
+
+            // The detour can only reproduce strict matching when every known modifier
+            // is a digital gamepad button it can read in wButtons. If any is not, emit
+            // no rules (the reactive path still handles the held-modifier case).
+            uint16_t known_mod_mask = 0;
+            for (const auto &mod : known_modifiers)
+            {
+                if (!is_digital_gamepad(mod))
+                {
+                    return {};
+                }
+                known_mod_mask = static_cast<uint16_t>(known_mod_mask |
+                                                       static_cast<uint16_t>(mod.code));
+            }
+
+            std::vector<detail::GamepadConsumeRule> rules;
+            for (const auto &binding : bindings)
+            {
+                if (!binding.consume)
+                {
+                    continue;
+                }
+                uint16_t trigger_mask = 0;
+                for (const auto &key : binding.keys)
+                {
+                    if (is_digital_gamepad(key))
+                    {
+                        trigger_mask = static_cast<uint16_t>(trigger_mask |
+                                                             static_cast<uint16_t>(key.code));
+                    }
+                }
+                if (trigger_mask == 0)
+                {
+                    // No digital gamepad trigger to clear (e.g. a wheel or analog
+                    // consume binding); nothing here for the detour to mask.
+                    continue;
+                }
+                // Every modifier is a digital gamepad button here: the gate above
+                // returned an empty list if any known modifier was not, and a chord's
+                // modifiers are a subset of the known modifiers.
+                uint16_t modifier_mask = 0;
+                for (const auto &mod : binding.modifiers)
+                {
+                    modifier_mask = static_cast<uint16_t>(modifier_mask |
+                                                          static_cast<uint16_t>(mod.code));
+                }
+                const uint16_t forbidden_mask =
+                    static_cast<uint16_t>(known_mod_mask & static_cast<uint16_t>(~modifier_mask));
+                rules.push_back(
+                    detail::GamepadConsumeRule{modifier_mask, forbidden_mask, trigger_mask});
+            }
+            return rules;
+        }
+
         // Release grace for gamepad consume-until-release. Long enough to absorb
         // the modifier-released-before-trigger window (the player relaxing the
         // bumper a frame or two before the thumb leaves the D-pad) without
@@ -295,6 +372,15 @@ namespace DetourModKit
                                             std::memory_order_relaxed);
         has_wheel_consume_bindings_.store(scan_for_wheel_consume_bindings(bindings_),
                                           std::memory_order_relaxed);
+
+        // Publish the detour-side consume rule list. The XInput detour evaluates
+        // these against the exact snapshot the game reads, closing the leading-edge
+        // window the poll-published mask leaves for a modifier and trigger pressed
+        // inside one poll interval. Built from the same bindings and known modifiers
+        // as the reactive path so the two masking paths never disagree.
+        const std::vector<detail::GamepadConsumeRule> consume_rules =
+            build_gamepad_consume_rules(bindings_, known_modifiers_);
+        detail::publish_gamepad_consume_rules(consume_rules.data(), consume_rules.size());
     }
 
     InputPoller::~InputPoller() noexcept
@@ -607,23 +693,39 @@ namespace DetourModKit
                         {
                             for (const auto &key : binding.keys)
                             {
-                                if (!is_code_pressed(key, gamepad_state, gamepad_connected, trigger_thresh, stick_thresh, wheel_pulse_mask))
-                                {
-                                    continue;
-                                }
-                                any_pressed = true;
+                                const bool key_pressed = is_code_pressed(key, gamepad_state, gamepad_connected, trigger_thresh, stick_thresh, wheel_pulse_mask);
 
-                                // A consume binding claims its pressed digital
-                                // gamepad triggers so they can be masked from the
-                                // game. Keep scanning the remaining keys to collect
-                                // every owned bit; a plain (non-consume) binding
-                                // needs only one hit and stops at the first.
+                                // Pre-arm the consume bit while the binding's modifiers
+                                // are held, before the trigger button itself is pressed.
+                                // The suppression mask is published one poll cycle behind
+                                // the physical state, so claiming the bit only once the
+                                // trigger reads as pressed lets the game's own XInput poll
+                                // (an independent clock, usually faster than this loop)
+                                // catch the trigger's leading edge before the mask catches
+                                // up -- a one-frame leak of an otherwise-suppressed press.
+                                // Holding the claim to the modifier keeps the mask up
+                                // before the trigger arrives. Masking a bit whose physical
+                                // button is still up is a no-op: apply_suppress ANDs ~mask
+                                // into wButtons, and clearing an already-zero bit changes
+                                // nothing. The consume-until-release latch still trails the
+                                // trigger, so the trailing edge is unchanged. Keep scanning
+                                // the remaining keys so every owned bit is collected.
                                 if (binding.consume && key.source == InputSource::Gamepad &&
                                     key.code > 0 && key.code < GamepadCode::LeftTrigger)
                                 {
                                     gamepad_owned = static_cast<uint16_t>(gamepad_owned |
                                                                           static_cast<uint16_t>(key.code));
                                 }
+
+                                // Activation still keys off the real press: a non-consume
+                                // binding fires on the first pressed key and stops, while a
+                                // consume binding keeps scanning so the pre-arm above sees
+                                // every owned bit.
+                                if (!key_pressed)
+                                {
+                                    continue;
+                                }
+                                any_pressed = true;
                                 if (!binding.consume)
                                 {
                                     break;
@@ -673,11 +775,19 @@ namespace DetourModKit
                         gp_suppress, gamepad_owned, gamepad_state.Gamepad.wButtons,
                         GetTickCount64(), s_gamepad_suppress_grace_ms);
                     detail::publish_gamepad_suppress(suppress);
+                    // Enable the detour's rule masking only while focused and
+                    // connected. The published rule list and its time-to-live survive
+                    // focus changes, so the detour needs this explicit gate to stop
+                    // masking the foreground game's input once the mod is backgrounded,
+                    // exactly as the reactive mask is cleared below and as the
+                    // wheel-consume flag is gated.
+                    detail::set_gamepad_rule_suppress_enabled(true);
                 }
                 else
                 {
                     gp_suppress = detail::GamepadSuppressState{};
                     detail::publish_gamepad_suppress(0);
+                    detail::set_gamepad_rule_suppress_enabled(false);
                 }
             }
 
@@ -1027,6 +1137,7 @@ namespace DetourModKit
             has_wheel_bindings_.store(false, std::memory_order_relaxed);
             has_consume_gamepad_bindings_.store(false, std::memory_order_relaxed);
             has_wheel_consume_bindings_.store(false, std::memory_order_relaxed);
+            detail::publish_gamepad_consume_rules(nullptr, 0);
             active_states_ = std::make_unique<std::atomic<uint8_t>[]>(0);
         }
 

--- a/src/input_intercept.cpp
+++ b/src/input_intercept.cpp
@@ -50,6 +50,49 @@ namespace DetourModKit::detail
         std::atomic<uint16_t> s_suppress_mask{0};
         std::atomic<uint64_t> s_suppress_deadline_ms{0};
 
+        // --- Consume rule list (detour-side chord evaluation) ---
+        //
+        // A binding rebuild publishes one rule per detour-evaluable consume chord;
+        // the XInput detour reads the list against the exact button snapshot the
+        // game is about to read. Each rule is packed into a single atomic word so a
+        // reader never sees a torn rule, and the array plus its count sit behind a
+        // seqlock (s_consume_rules_seq: even = stable, odd = mid-update) so the
+        // detour gets an all-or-nothing snapshot of the whole list without locking.
+        // Single writer: whichever thread mutates the bindings, serialized by
+        // InputPoller::bindings_rw_mutex_ held in write mode while
+        // recompute_modifier_caches_locked / clear_bindings publish. This is not the
+        // poll thread, which only takes a shared lock and never writes or reads this
+        // list. Many readers: the game's XInput caller threads via the detour.
+        std::array<std::atomic<uint64_t>, MAX_GAMEPAD_CONSUME_RULES> s_consume_rules{};
+        std::atomic<uint32_t> s_consume_rule_count{0};
+        std::atomic<uint32_t> s_consume_rules_seq{0};
+
+        // Gate for detour-side rule masking, driven every poll cycle. The published
+        // rule list and its time-to-live survive focus changes, so without this gate
+        // apply_suppress would keep masking the foreground game's input while the mod
+        // is unfocused. The poll loop sets it true only while focused and connected,
+        // mirroring how the reactive mask is cleared and how s_wheel_consume is gated.
+        std::atomic<bool> s_rule_suppress_enabled{false};
+
+        /// Packs a rule into one word: modifier (bits 0-15), forbidden (16-31),
+        /// trigger (32-47). Three 16-bit masks fit a uint64 with room to spare, so a
+        /// rule is published and read as a single atomic store/load.
+        constexpr uint64_t pack_consume_rule(const GamepadConsumeRule &rule) noexcept
+        {
+            return static_cast<uint64_t>(rule.modifier_mask) |
+                   (static_cast<uint64_t>(rule.forbidden_mask) << 16) |
+                   (static_cast<uint64_t>(rule.trigger_mask) << 32);
+        }
+
+        /// Inverse of pack_consume_rule.
+        constexpr GamepadConsumeRule unpack_consume_rule(uint64_t packed) noexcept
+        {
+            return GamepadConsumeRule{
+                static_cast<uint16_t>(packed & 0xFFFFu),
+                static_cast<uint16_t>((packed >> 16) & 0xFFFFu),
+                static_cast<uint16_t>((packed >> 32) & 0xFFFFu)};
+        }
+
         // --- Mouse-wheel capture state ---
 
         std::array<std::atomic<int>, 4> s_wheel_count{};
@@ -60,11 +103,16 @@ namespace DetourModKit::detail
 
         /**
          * @brief Clears the suppressed button bits from a game-bound XINPUT_STATE.
-         * @details Only the bound controller index is masked. dwPacketNumber and
-         *          the success return are left untouched so the game still sees a
-         *          connected, advancing controller (faking a disconnect would
-         *          trigger pause/reconnect UI). A time-to-live guard drops the mask
-         *          if the poll thread stopped refreshing it.
+         * @details Only the bound controller index is masked. dwPacketNumber and the
+         *          success return are left untouched so the game still sees a
+         *          connected, advancing controller (faking a disconnect would trigger
+         *          pause/reconnect UI). The cleared bits are the union of two sources:
+         *          the reactive mask the poll thread publishes (which carries the
+         *          trailing-edge consume-until-release latch) and the consume rules
+         *          evaluated here against the exact buttons the game is about to read
+         *          (which close the leading-edge window the poll-published mask trails
+         *          by up to one cycle). A time-to-live guard drops all masking if the
+         *          poll thread stopped refreshing it.
          */
         void apply_suppress(XINPUT_STATE *state, DWORD user_index) noexcept
         {
@@ -76,22 +124,42 @@ namespace DetourModKit::detail
             {
                 return;
             }
-            const uint16_t mask = s_suppress_mask.load(std::memory_order_acquire);
+            // Acquire the reactive mask first. This load also orders the relaxed
+            // deadline read below: publish_gamepad_suppress writes the deadline before
+            // the release store on s_suppress_mask, so the acquire here establishes the
+            // happens-before even when the mask reads as 0.
+            const uint16_t reactive = s_suppress_mask.load(std::memory_order_acquire);
+
+            // raw is the true, unmasked state: this detour runs after the trampoline
+            // call. Evaluating the published chord rules against it masks a chord
+            // whose modifier and trigger were pressed inside one poll interval on the
+            // very frame the game reads it, rather than a cycle later. The focus gate
+            // suppresses this evaluation when the host window is unfocused or the
+            // controller is gone: the rule list and its deadline both survive those
+            // transitions, so the detour must not keep masking the foreground game's
+            // input (the reactive mask is already cleared by the poll loop on focus
+            // loss).
+            const uint16_t raw = state->Gamepad.wButtons;
+            const uint16_t rule_mask =
+                s_rule_suppress_enabled.load(std::memory_order_relaxed)
+                    ? evaluate_published_consume_rules(raw)
+                    : 0;
+            const uint16_t mask = static_cast<uint16_t>(reactive | rule_mask);
             if (mask == 0)
             {
                 return;
             }
-            // Relaxed is sufficient for the deadline read: publish_gamepad_suppress
-            // writes it before the release store on s_suppress_mask, so the acquire
-            // load of the mask above already established the happens-before. A
-            // non-zero mask is therefore never paired with a stale (pre-refresh)
-            // deadline.
+            // The reactive mask and the rule list are both refreshed only while the
+            // poll thread is alive: rules exist only when consume gamepad bindings do,
+            // and that is exactly when publish_gamepad_suppress refreshes this deadline
+            // every cycle. A stalled poll thread therefore lets the deadline lapse and
+            // all masking stops, so the game regains its input rather than latching off.
             if (GetTickCount64() >= s_suppress_deadline_ms.load(std::memory_order_relaxed))
             {
                 return;
             }
             state->Gamepad.wButtons =
-                static_cast<WORD>(state->Gamepad.wButtons & static_cast<WORD>(~mask));
+                static_cast<WORD>(raw & static_cast<WORD>(~mask));
         }
 
         DWORD WINAPI xinput_get_state_detour(DWORD user_index, XINPUT_STATE *state) noexcept
@@ -342,6 +410,92 @@ namespace DetourModKit::detail
         return mask;
     }
 
+    uint16_t evaluate_consume_rules(uint16_t true_buttons,
+                                    const GamepadConsumeRule *rules,
+                                    std::size_t count) noexcept
+    {
+        uint16_t mask = 0;
+        for (std::size_t i = 0; i < count; ++i)
+        {
+            const GamepadConsumeRule &rule = rules[i];
+            // Every modifier bit held and no forbidden bit held: the exact decision
+            // the poll loop makes (chord modifiers satisfied and the strict-match
+            // check passes), evaluated against the snapshot the game is about to
+            // read. A forbidden bit is a known modifier that belongs to a different
+            // chord, so holding one means this chord is not the active gesture.
+            if ((true_buttons & rule.modifier_mask) == rule.modifier_mask &&
+                (true_buttons & rule.forbidden_mask) == 0)
+            {
+                mask = static_cast<uint16_t>(mask | rule.trigger_mask);
+            }
+        }
+        return mask;
+    }
+
+    void publish_gamepad_consume_rules(const GamepadConsumeRule *rules, std::size_t count) noexcept
+    {
+        // A list larger than the detour can hold publishes nothing rather than a
+        // silent subset: the reactive mask still covers the held-modifier case, so
+        // only the simultaneous-press protection is dropped for that (pathological)
+        // binding set, and the detour never evaluates a partial list.
+        if (count > MAX_GAMEPAD_CONSUME_RULES)
+        {
+            count = 0;
+        }
+        // Seqlock write (single writer). The odd sequence brackets the update so a
+        // concurrent detour read sees the whole new list or skips the frame. The
+        // release fence after the odd store keeps the rule stores from being observed
+        // before the bracket opens; the release store of the even sequence publishes
+        // the finished list to the detour's acquire load.
+        const uint32_t seq = s_consume_rules_seq.load(std::memory_order_relaxed);
+        s_consume_rules_seq.store(seq + 1, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_release);
+        for (std::size_t i = 0; i < count; ++i)
+        {
+            s_consume_rules[i].store(pack_consume_rule(rules[i]), std::memory_order_relaxed);
+        }
+        s_consume_rule_count.store(static_cast<uint32_t>(count), std::memory_order_relaxed);
+        s_consume_rules_seq.store(seq + 2, std::memory_order_release);
+    }
+
+    uint16_t evaluate_published_consume_rules(uint16_t true_buttons) noexcept
+    {
+        // Seqlock read, single attempt (no spin): an odd sequence means the writer is
+        // mid-update, and a change across the copy means the snapshot tore. In either
+        // case skip rule masking for this frame (the reactive mask still applies); the
+        // next game poll, microseconds later, gets the settled list. Rules change only
+        // on a binding rebuild, so a torn read is rare and never coincides with steady
+        // gameplay input.
+        const uint32_t seq_before = s_consume_rules_seq.load(std::memory_order_acquire);
+        if ((seq_before & 1u) != 0)
+        {
+            return 0;
+        }
+        uint32_t count = s_consume_rule_count.load(std::memory_order_relaxed);
+        if (count > MAX_GAMEPAD_CONSUME_RULES)
+        {
+            count = MAX_GAMEPAD_CONSUME_RULES;
+        }
+        std::array<GamepadConsumeRule, MAX_GAMEPAD_CONSUME_RULES> snapshot{};
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            snapshot[i] = unpack_consume_rule(s_consume_rules[i].load(std::memory_order_relaxed));
+        }
+        // Order the rule loads above before the sequence re-read below, so a writer
+        // that updated mid-copy is always detected.
+        std::atomic_thread_fence(std::memory_order_acquire);
+        if (s_consume_rules_seq.load(std::memory_order_relaxed) != seq_before)
+        {
+            return 0;
+        }
+        return evaluate_consume_rules(true_buttons, snapshot.data(), count);
+    }
+
+    void set_gamepad_rule_suppress_enabled(bool enabled) noexcept
+    {
+        s_rule_suppress_enabled.store(enabled, std::memory_order_relaxed);
+    }
+
     bool install_xinput(int user_index) noexcept
     {
         s_bound_user_index.store(user_index, std::memory_order_relaxed);
@@ -511,9 +665,17 @@ namespace DetourModKit::detail
 
     void uninstall() noexcept
     {
-        // Stop masking before removing the hooks. The poll thread is already
-        // stopped when this runs, so no further publishes can occur.
+        // Stop masking before removing the hooks, with single-atomic stores only.
+        // Clearing the reactive mask stops reactive masking and clearing the rule
+        // gate stops rule masking. Do NOT seqlock-publish an empty rule list here:
+        // that is a multi-step write, and a concurrent binding mutation (set_consume
+        // / add_binding, serialized on InputPoller::bindings_rw_mutex_) is a
+        // documented thread-safe call that could race a second writer and tear the
+        // list. The published list is left as is; it is inert once the hooks are
+        // gone and the gate is false, the binding-clear path already empties it
+        // under the lock, and a later install republishes before re-enabling the gate.
         s_suppress_mask.store(0, std::memory_order_release);
+        s_rule_suppress_enabled.store(false, std::memory_order_relaxed);
         s_wheel_consume.store(false, std::memory_order_relaxed);
 
         uninstall_wndproc();

--- a/src/input_intercept.hpp
+++ b/src/input_intercept.hpp
@@ -37,6 +37,7 @@
 #include <Xinput.h>
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 namespace DetourModKit::detail
@@ -100,6 +101,95 @@ namespace DetourModKit::detail
                                                  uint16_t true_buttons,
                                                  uint64_t now_ms,
                                                  uint64_t grace_ms) noexcept;
+
+    /**
+     * @struct GamepadConsumeRule
+     * @brief A consume chord reduced to the XInput button bits the detour can
+     *        evaluate without the poll thread.
+     * @details The reactive (poll-published) mask trails the physical state by up to
+     *          one poll cycle, which leaves a leading-edge window: a modifier and
+     *          trigger pressed inside one poll interval can be read by the game
+     *          before the mask catches up. A rule lets the detour mask the trigger
+     *          against the exact snapshot the game is about to read, closing that
+     *          window. Built only from chords whose modifiers and masked triggers
+     *          are all digital gamepad buttons (the detour sees only
+     *          XINPUT_GAMEPAD.wButtons), so the decision is fully reproducible there.
+     */
+    struct GamepadConsumeRule
+    {
+        uint16_t modifier_mask{0};  ///< Digital button bits that must all be held.
+        uint16_t forbidden_mask{0}; ///< Known-modifier bits outside this chord; any held rejects it (strict match).
+        uint16_t trigger_mask{0};   ///< Digital button bits to clear when the chord matches.
+    };
+
+    /**
+     * @brief Maximum number of consume rules the detour evaluates.
+     * @details A binding set that would exceed this publishes no rules at all (the
+     *          reactive mask still covers the held-modifier case), so the detour
+     *          never silently evaluates a subset.
+     */
+    inline constexpr std::size_t MAX_GAMEPAD_CONSUME_RULES = 32;
+
+    /**
+     * @brief Evaluates consume rules against a raw button snapshot.
+     * @details Pure helper shared by the XInput detour and its tests. A rule
+     *          contributes its @ref GamepadConsumeRule::trigger_mask when every
+     *          @ref GamepadConsumeRule::modifier_mask bit is present in
+     *          @p true_buttons and no @ref GamepadConsumeRule::forbidden_mask bit
+     *          is. Masking a trigger bit that is not currently down is a no-op
+     *          against the game's state, so a rule may match before its trigger is
+     *          pressed without observable effect.
+     * @param true_buttons The unmasked XINPUT_GAMEPAD.wButtons the game will read.
+     * @param rules Pointer to @p count contiguous rules (may be nullptr if 0).
+     * @param count Number of rules.
+     * @return Button bits to clear from the game's state.
+     */
+    [[nodiscard]] uint16_t evaluate_consume_rules(uint16_t true_buttons,
+                                                  const GamepadConsumeRule *rules,
+                                                  std::size_t count) noexcept;
+
+    /**
+     * @brief Publishes the consume rule list read by the XInput detour.
+     * @details Single-writer: the binding-mutation thread, serialized by
+     *          InputPoller::bindings_rw_mutex_ (not the poll thread). Copies up
+     *          to @ref MAX_GAMEPAD_CONSUME_RULES rules behind a seqlock so a detour
+     *          on a game thread reads a consistent snapshot without locking; a
+     *          @p count above the cap publishes an empty list rather than a
+     *          truncated one. Rule masking shares the reactive mask's time-to-live
+     *          (rules exist only while consume gamepad bindings do, which is exactly
+     *          when publish_gamepad_suppress refreshes the deadline), so a stalled
+     *          poll thread stops rule masking too.
+     * @param rules Pointer to @p count contiguous rules (may be nullptr if 0).
+     * @param count Number of rules to publish.
+     */
+    void publish_gamepad_consume_rules(const GamepadConsumeRule *rules, std::size_t count) noexcept;
+
+    /**
+     * @brief Reads the published consume rule list and evaluates it against a raw
+     *        button snapshot.
+     * @details The XInput detour's rule-read side, exported for testing. Reads the
+     *          seqlock-guarded rule list in a single attempt (a torn or mid-update
+     *          snapshot yields 0) and returns evaluate_consume_rules over it. This is
+     *          independent of the focus gate (see set_gamepad_rule_suppress_enabled),
+     *          which the detour applies separately.
+     * @param true_buttons The unmasked XINPUT_GAMEPAD.wButtons the game will read.
+     * @return Button bits the currently published rules would clear.
+     */
+    [[nodiscard]] uint16_t evaluate_published_consume_rules(uint16_t true_buttons) noexcept;
+
+    /**
+     * @brief Enables or disables detour-side consume-rule masking.
+     * @details Gates whether the XInput detour evaluates the published rule list. The
+     *          poll thread drives this every cycle so rule masking stops the instant
+     *          the host window loses focus or the controller disconnects, matching the
+     *          reactive mask (which the poll loop clears to 0 on focus loss) and the
+     *          mouse-wheel consume flag. Without it the detour would keep masking the
+     *          foreground game's gamepad input while the mod is in the background,
+     *          because the published rule list and its time-to-live both stay alive
+     *          across focus changes.
+     * @param enabled True to evaluate rules, false to skip them.
+     */
+    void set_gamepad_rule_suppress_enabled(bool enabled) noexcept;
 
     // --- XInput interception (gamepad passthrough suppression) ---
 

--- a/tests/test_input_intercept.cpp
+++ b/tests/test_input_intercept.cpp
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "input_intercept.hpp"
@@ -11,9 +13,14 @@
 #include "DetourModKit/input_codes.hpp"
 
 using namespace DetourModKit;
+using DetourModKit::detail::evaluate_consume_rules;
+using DetourModKit::detail::evaluate_published_consume_rules;
+using DetourModKit::detail::GamepadConsumeRule;
 using DetourModKit::detail::GamepadSuppressState;
 using DetourModKit::detail::install_wndproc;
 using DetourModKit::detail::install_xinput;
+using DetourModKit::detail::MAX_GAMEPAD_CONSUME_RULES;
+using DetourModKit::detail::publish_gamepad_consume_rules;
 using DetourModKit::detail::publish_gamepad_suppress;
 using DetourModKit::detail::set_wheel_consume;
 using DetourModKit::detail::step_gamepad_suppress;
@@ -34,6 +41,19 @@ namespace
     constexpr uint8_t kWheelRightBit = 1u << 3;
 
     constexpr uint64_t kGraceMs = 80;
+
+    // Builds a consume chord binding for the rule-publishing tests.
+    InputBinding make_consume_chord(std::vector<InputCode> modifiers,
+                                    std::vector<InputCode> keys)
+    {
+        InputBinding binding;
+        binding.name = "chord";
+        binding.modifiers = std::move(modifiers);
+        binding.keys = std::move(keys);
+        binding.consume = true;
+        binding.mode = InputMode::Hold;
+        return binding;
+    }
 } // namespace
 
 // --- Control API safe to call without an installed hook ---
@@ -173,6 +193,242 @@ TEST(GamepadSuppressTest, RepressDuringGraceReHolds)
     // Released again; grace restarts from this release.
     EXPECT_EQ(step_gamepad_suppress(state, 0, 0, 1060, kGraceMs), dpad);
     EXPECT_EQ(step_gamepad_suppress(state, 0, 0, 1200, kGraceMs), 0u);
+}
+
+TEST(GamepadSuppressTest, PreArmedTriggerSuppressedAtLeadingEdge)
+{
+    GamepadSuppressState state;
+    const uint16_t dpad = static_cast<uint16_t>(GamepadCode::DpadUp);
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+
+    // Pre-arm: the poll loop claims the consume trigger as soon as the chord's
+    // modifier is held, so owned_now carries the D-pad bit a cycle before the
+    // D-pad is physically down (true_buttons has LB only). The returned mask must
+    // already include the trigger so the game's independent, usually faster XInput
+    // poll cannot read the trigger's leading edge before the mask catches up.
+    // Masking a bit that is not yet down is a no-op for the game, but it closes
+    // the race.
+    EXPECT_EQ(step_gamepad_suppress(state, dpad, lb, 1000, kGraceMs), dpad);
+
+    // Trigger now goes down with the modifier still held: the leading edge is
+    // already covered, so it stays masked.
+    EXPECT_EQ(step_gamepad_suppress(state, dpad, static_cast<uint16_t>(lb | dpad), 1016, kGraceMs), dpad);
+}
+
+TEST(GamepadSuppressTest, PreArmAbandonedWithoutPressDisarmsAfterGrace)
+{
+    GamepadSuppressState state;
+    const uint16_t dpad = static_cast<uint16_t>(GamepadCode::DpadUp);
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+
+    // Modifier held, trigger pre-armed but never pressed (true_buttons has LB
+    // only): the bit is armed and masked (a no-op against the up button).
+    EXPECT_EQ(step_gamepad_suppress(state, dpad, lb, 1000, kGraceMs), dpad);
+    // Modifier released without the trigger ever being pressed: the latch must not
+    // stick. It runs the same release grace and then disarms, so a pre-arm the
+    // user abandons leaves no residual mask.
+    EXPECT_EQ(step_gamepad_suppress(state, 0, 0, 1040, kGraceMs), dpad);
+    EXPECT_EQ(step_gamepad_suppress(state, 0, 0, 1200, kGraceMs), 0u);
+}
+
+// --- evaluate_consume_rules: detour-side chord evaluation ---
+
+TEST(ConsumeRuleTest, EmptyListMasksNothing)
+{
+    const uint16_t buttons =
+        static_cast<uint16_t>(GamepadCode::LeftBumper | GamepadCode::DpadUp);
+    EXPECT_EQ(evaluate_consume_rules(buttons, nullptr, 0), 0u);
+}
+
+TEST(ConsumeRuleTest, ChordMaskedOnTheSameFrameAsASimultaneousPress)
+{
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+    const uint16_t dpad = static_cast<uint16_t>(GamepadCode::DpadUp);
+    const GamepadConsumeRule rule{lb, 0, dpad};
+
+    // Modifier and trigger arrive in the same snapshot (the sub-poll-interval
+    // simultaneous press the reactive pre-arm cannot cover): the rule masks the
+    // trigger on the exact frame the game reads it.
+    EXPECT_EQ(evaluate_consume_rules(static_cast<uint16_t>(lb | dpad), &rule, 1), dpad);
+
+    // Modifier held, trigger not yet down: the rule still matches and returns the
+    // bit. Masking an up button is a no-op against the game, but it keeps the mask
+    // continuous so no leading edge slips through.
+    EXPECT_EQ(evaluate_consume_rules(lb, &rule, 1), dpad);
+
+    // Trigger without the modifier: a bare press must reach the game.
+    EXPECT_EQ(evaluate_consume_rules(dpad, &rule, 1), 0u);
+}
+
+TEST(ConsumeRuleTest, ForbiddenModifierRejectsChord)
+{
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+    const uint16_t rb = static_cast<uint16_t>(GamepadCode::RightBumper);
+    const uint16_t dpad = static_cast<uint16_t>(GamepadCode::DpadUp);
+    // LB + D-pad is the chord; RB is a known modifier owned by a different chord.
+    const GamepadConsumeRule rule{lb, rb, dpad};
+
+    // LB + D-pad alone: masked.
+    EXPECT_EQ(evaluate_consume_rules(static_cast<uint16_t>(lb | dpad), &rule, 1), dpad);
+    // LB + RB + D-pad: RB (a forbidden modifier) is held, so this chord is not the
+    // active gesture and the trigger reaches the game -- the same decision the poll
+    // loop's strict-match check makes.
+    EXPECT_EQ(evaluate_consume_rules(static_cast<uint16_t>(lb | rb | dpad), &rule, 1), 0u);
+}
+
+TEST(ConsumeRuleTest, BareTriggerRuleGatedByForbiddenModifiers)
+{
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+    const uint16_t dpad = static_cast<uint16_t>(GamepadCode::DpadUp);
+    // A no-modifier consume binding (modifier_mask 0) while LB is a known modifier
+    // of some other binding, so forbidden_mask carries LB.
+    const GamepadConsumeRule rule{0, lb, dpad};
+
+    // No known modifier held: the bare trigger is masked.
+    EXPECT_EQ(evaluate_consume_rules(dpad, &rule, 1), dpad);
+    // A known modifier (LB) held: strict matching rejects the bare-trigger chord.
+    EXPECT_EQ(evaluate_consume_rules(static_cast<uint16_t>(lb | dpad), &rule, 1), 0u);
+}
+
+TEST(ConsumeRuleTest, MultipleRulesAccumulateMatchingTriggers)
+{
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+    const uint16_t rb = static_cast<uint16_t>(GamepadCode::RightBumper);
+    const uint16_t up = static_cast<uint16_t>(GamepadCode::DpadUp);
+    const uint16_t down = static_cast<uint16_t>(GamepadCode::DpadDown);
+    // Two independent chords with distinct modifiers: LB + Up and RB + Down.
+    const std::array<GamepadConsumeRule, 2> rules{
+        GamepadConsumeRule{lb, 0, up},
+        GamepadConsumeRule{rb, 0, down}};
+
+    // Both modifiers held: both rules match and their trigger masks union.
+    EXPECT_EQ(
+        evaluate_consume_rules(static_cast<uint16_t>(lb | rb | up | down), rules.data(), rules.size()),
+        static_cast<uint16_t>(up | down));
+    // Only LB held: only the LB rule contributes; the RB rule does not match.
+    EXPECT_EQ(evaluate_consume_rules(static_cast<uint16_t>(lb | up), rules.data(), rules.size()), up);
+    // Only RB held: only the RB rule contributes.
+    EXPECT_EQ(evaluate_consume_rules(static_cast<uint16_t>(rb | down), rules.data(), rules.size()), down);
+}
+
+// --- publish_gamepad_consume_rules / evaluate_published_consume_rules: seqlock ---
+
+class ConsumeRulePublishTest : public ::testing::Test
+{
+protected:
+    // The rule list is process-global; isolate each case from neighbours and from
+    // any poller-constructing test that ran earlier in the same process.
+    void SetUp() override { publish_gamepad_consume_rules(nullptr, 0); }
+    void TearDown() override { publish_gamepad_consume_rules(nullptr, 0); }
+};
+
+TEST_F(ConsumeRulePublishTest, RoundTripMatchesDirectEvaluation)
+{
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+    const uint16_t rb = static_cast<uint16_t>(GamepadCode::RightBumper);
+    const uint16_t up = static_cast<uint16_t>(GamepadCode::DpadUp);
+    const uint16_t down = static_cast<uint16_t>(GamepadCode::DpadDown);
+    const std::array<GamepadConsumeRule, 2> rules{
+        GamepadConsumeRule{lb, rb, up},
+        GamepadConsumeRule{rb, lb, down}};
+    publish_gamepad_consume_rules(rules.data(), rules.size());
+
+    // The packed, seqlock-guarded list must evaluate identically to the same rules
+    // read directly: this exercises pack/unpack of all three 16-bit masks and a
+    // consistent seqlock snapshot.
+    for (const uint16_t buttons : {static_cast<uint16_t>(0u),
+                                   lb,
+                                   static_cast<uint16_t>(lb | up),
+                                   static_cast<uint16_t>(lb | rb | up | down),
+                                   static_cast<uint16_t>(rb | down)})
+    {
+        EXPECT_EQ(evaluate_published_consume_rules(buttons),
+                  evaluate_consume_rules(buttons, rules.data(), rules.size()))
+            << "buttons=" << buttons;
+    }
+}
+
+TEST_F(ConsumeRulePublishTest, OverCapPublishesEmpty)
+{
+    const uint16_t up = static_cast<uint16_t>(GamepadCode::DpadUp);
+    // One past the cap, every rule a no-modifier match. If the cap truncated instead
+    // of emptying, at least one such rule would survive and mask Up.
+    std::array<GamepadConsumeRule, MAX_GAMEPAD_CONSUME_RULES + 1> rules{};
+    for (auto &rule : rules)
+    {
+        rule = GamepadConsumeRule{0, 0, up};
+    }
+    publish_gamepad_consume_rules(rules.data(), rules.size());
+    EXPECT_EQ(evaluate_published_consume_rules(up), 0u);
+}
+
+TEST_F(ConsumeRulePublishTest, ClearPublishesEmpty)
+{
+    const uint16_t up = static_cast<uint16_t>(GamepadCode::DpadUp);
+    const GamepadConsumeRule rule{0, 0, up};
+    publish_gamepad_consume_rules(&rule, 1);
+    ASSERT_EQ(evaluate_published_consume_rules(up), up);
+    publish_gamepad_consume_rules(nullptr, 0);
+    EXPECT_EQ(evaluate_published_consume_rules(up), 0u);
+}
+
+// --- build_gamepad_consume_rules, via the InputPoller build+publish path ---
+
+class ConsumeRuleBuildTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { publish_gamepad_consume_rules(nullptr, 0); }
+    void TearDown() override { publish_gamepad_consume_rules(nullptr, 0); }
+};
+
+TEST_F(ConsumeRuleBuildTest, GamepadChordPublishesMaskableRule)
+{
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+    const uint16_t up = static_cast<uint16_t>(GamepadCode::DpadUp);
+    // Constructing the poller runs the same build+publish path the poll thread uses.
+    InputPoller poller({make_consume_chord({gamepad_button(GamepadCode::LeftBumper)},
+                                           {gamepad_button(GamepadCode::DpadUp)})});
+    EXPECT_EQ(evaluate_published_consume_rules(static_cast<uint16_t>(lb | up)), up);
+    EXPECT_EQ(evaluate_published_consume_rules(up), 0u); // modifier not held
+}
+
+TEST_F(ConsumeRuleBuildTest, OverlappingChordsGetCrossForbiddenMasks)
+{
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+    const uint16_t rb = static_cast<uint16_t>(GamepadCode::RightBumper);
+    const uint16_t up = static_cast<uint16_t>(GamepadCode::DpadUp);
+    const uint16_t down = static_cast<uint16_t>(GamepadCode::DpadDown);
+    InputPoller poller({
+        make_consume_chord({gamepad_button(GamepadCode::LeftBumper)},
+                           {gamepad_button(GamepadCode::DpadUp)}),
+        make_consume_chord({gamepad_button(GamepadCode::RightBumper)},
+                           {gamepad_button(GamepadCode::DpadDown)}),
+    });
+    // Each chord's modifier becomes the other's forbidden bit (strict-match parity).
+    EXPECT_EQ(evaluate_published_consume_rules(static_cast<uint16_t>(lb | up)), up);
+    EXPECT_EQ(evaluate_published_consume_rules(static_cast<uint16_t>(rb | down)), down);
+    // Holding both modifiers rejects both single-modifier chords.
+    EXPECT_EQ(evaluate_published_consume_rules(static_cast<uint16_t>(lb | rb | up | down)), 0u);
+}
+
+TEST_F(ConsumeRuleBuildTest, KeyboardModifierDisablesAllRules)
+{
+    const uint16_t up = static_cast<uint16_t>(GamepadCode::DpadUp);
+    // A keyboard modifier is invisible to the detour, so the eligibility gate drops
+    // the whole rule list and the reactive pre-arm path covers the chord instead.
+    InputPoller poller({make_consume_chord({keyboard_key(VK_CONTROL)},
+                                           {gamepad_button(GamepadCode::DpadUp)})});
+    EXPECT_EQ(evaluate_published_consume_rules(up), 0u);
+}
+
+TEST_F(ConsumeRuleBuildTest, AnalogTriggerProducesNoRule)
+{
+    const uint16_t lb = static_cast<uint16_t>(GamepadCode::LeftBumper);
+    // LeftTrigger is analog (not an XINPUT_GAMEPAD.wButtons bit), so there is no
+    // digital trigger to mask and no rule is emitted.
+    InputPoller poller({make_consume_chord({gamepad_button(GamepadCode::LeftBumper)},
+                                           {gamepad_button(GamepadCode::LeftTrigger)})});
+    EXPECT_EQ(evaluate_published_consume_rules(lb), 0u);
 }
 
 // --- Live-hook lifecycle: window-procedure subclass and XInput inline hook ---

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -10,16 +10,17 @@ namespace
     {
         EXPECT_EQ(DMK_VERSION_MAJOR, 3);
         EXPECT_EQ(DMK_VERSION_MINOR, 6);
-        EXPECT_EQ(DMK_VERSION_PATCH, 0);
+        EXPECT_EQ(DMK_VERSION_PATCH, 1);
     }
 
     TEST(VersionTest, VersionStringMatchesMacros)
     {
-        EXPECT_STREQ(DMK_VERSION_STRING, "3.6.0");
+        EXPECT_STREQ(DMK_VERSION_STRING, "3.6.1");
     }
 
     TEST(VersionTest, AtLeastComparisonsAreCorrect)
     {
+        EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 6, 1));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 6, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 5, 1));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 5, 0));
@@ -29,7 +30,6 @@ namespace
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 2, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(3, 1, 0));
         EXPECT_TRUE(DMK_VERSION_AT_LEAST(2, 0, 0));
-        EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 6, 1));
         EXPECT_FALSE(DMK_VERSION_AT_LEAST(3, 7, 0));
         EXPECT_FALSE(DMK_VERSION_AT_LEAST(4, 0, 0));
     }


### PR DESCRIPTION
## Summary
- Close the gamepad consume leading-edge race: pre-arm the suppression mask while a chord's modifiers are held, before the trigger is pressed.
- Add a seqlock-backed consume rule list the XInput detour evaluates against the exact buttons the game is about to read, covering a same-snapshot modifier+trigger press.
- Both paths share the existing focus gate and time-to-live, so a stalled or backgrounded poll thread stops all masking.
- No public API changes (internal active-input layer only); bump version to 3.6.1.
- Full test suite green (1276/1276).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gamepad consume rules system for enhanced input suppression and binding control.

* **Bug Fixes**
  * Improved trigger edge detection with pre-arming logic when modifiers are held.
  * Better focus and connection state management for input masking.

* **Chores**
  * Version bumped to 3.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->