### PR TITLE
ci(asan): run the sanitizer probe under MSVC

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,9 +10,10 @@ permissions:
   contents: read
 
 # Both jobs are advisory and non-blocking. clang-format stays red until a planned
-# repo-wide reformat; the sanitizer job runs on an MSYS2 toolchain that ships the
-# ASan/UBSan runtimes (the runner's default MinGW does not). The blocking gate
-# (build, tests, coverage) lives in pr-check.yml and is untouched here.
+# repo-wide reformat. The sanitizer job runs under the MSYS2 CLANG64 toolchain,
+# whose compiler-rt ships the ASan/UBSan runtimes (mingw-w64 GCC does not, so the
+# preset uses clang there). The blocking gate (build, tests, coverage) lives in
+# pr-check.yml and is untouched here.
 
 jobs:
   format-check:
@@ -50,20 +51,21 @@ jobs:
           submodules: "recursive"
           persist-credentials: false
 
-      - name: Set up MSYS2 MinGW toolchain (ships libasan/libubsan)
+      - name: Set up MSYS2 CLANG64 toolchain (compiler-rt ships ASan/UBSan)
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: CLANG64
           install: >-
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ninja
+            mingw-w64-clang-x86_64-clang
+            mingw-w64-clang-x86_64-compiler-rt
+            mingw-w64-clang-x86_64-cmake
+            mingw-w64-clang-x86_64-ninja
 
-      - name: Configure (Debug + Sanitizers)
-        run: cmake --preset mingw-debug-asan
+      - name: Configure (Clang Debug + Sanitizers)
+        run: cmake --preset clang-debug-asan
 
       - name: Build
-        run: cmake --build --preset mingw-debug-asan --parallel
+        run: cmake --build --preset clang-debug-asan --parallel
 
       - name: Run tests under sanitizers
-        run: ctest --preset mingw-debug-asan
+        run: ctest --preset clang-debug-asan

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,9 +10,10 @@ permissions:
   contents: read
 
 # Both jobs are advisory and non-blocking. clang-format stays red until a planned
-# repo-wide reformat. The sanitizer job runs under the MSYS2 CLANG64 toolchain,
-# whose compiler-rt ships the ASan/UBSan runtimes (mingw-w64 GCC does not, so the
-# preset uses clang there). The blocking gate (build, tests, coverage) lives in
+# repo-wide reformat. The sanitizer job uses MSVC AddressSanitizer -- the only
+# sanitizer that works on Windows (GCC and Clang on mingw-w64 ship no ASan/UBSan
+# runtime for the Windows target, so the build links only under MSVC, and ASan is
+# the only sanitizer there). The blocking gate (build, tests, coverage) lives in
 # pr-check.yml and is untouched here.
 
 jobs:
@@ -38,12 +39,9 @@ jobs:
         shell: bash
 
   sanitizers:
-    name: ASan + UBSan probe (advisory)
+    name: AddressSanitizer probe (MSVC, advisory)
     runs-on: windows-latest
     continue-on-error: true
-    defaults:
-      run:
-        shell: msys2 {0}
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -51,21 +49,19 @@ jobs:
           submodules: "recursive"
           persist-credentials: false
 
-      - name: Set up MSYS2 CLANG64 toolchain (compiler-rt ships ASan/UBSan)
-        uses: msys2/setup-msys2@v2
+      - name: Set up MSVC (x64) -- puts cl and the ASan runtime on PATH
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
-          msystem: CLANG64
-          install: >-
-            mingw-w64-clang-x86_64-clang
-            mingw-w64-clang-x86_64-compiler-rt
-            mingw-w64-clang-x86_64-cmake
-            mingw-w64-clang-x86_64-ninja
+          arch: x64
 
-      - name: Configure (Clang Debug + Sanitizers)
-        run: cmake --preset clang-debug-asan
+      - name: Configure (MSVC Debug + ASan)
+        run: cmake --preset msvc-debug-asan
+        shell: pwsh
 
       - name: Build
-        run: cmake --build --preset clang-debug-asan --parallel
+        run: cmake --build --preset msvc-debug-asan --parallel
+        shell: pwsh
 
-      - name: Run tests under sanitizers
-        run: ctest --preset clang-debug-asan
+      - name: Run tests under ASan
+        run: ctest --preset msvc-debug-asan --output-on-failure
+        shell: pwsh

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -50,7 +50,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up MSVC (x64) -- puts cl and the ASan runtime on PATH
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+        uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,31 +92,32 @@ Latest scanner bench numbers and methodology live in
 Memory validation-vs-direct-read numbers live in
 [docs/analysis/memory_bench_v3.x/README.md](docs/analysis/memory_bench_v3.x/README.md).
 
-### Sanitizers and coverage (MinGW only)
+### Sanitizers (MSVC) and coverage (MinGW)
 
 ```bash
-# Dedicated sanitizer preset (ASan + UBSan)
-cmake --preset mingw-debug-asan
-cmake --build --preset mingw-debug-asan --parallel
-ctest --preset mingw-debug-asan
+# AddressSanitizer -- MSVC only. Run from a Developer Command Prompt / VS DevShell.
+cmake --preset msvc-debug-asan
+cmake --build --preset msvc-debug-asan --parallel
+ctest --preset msvc-debug-asan
 
-# Dedicated coverage preset (gcov instrumentation)
+# Coverage (gcov instrumentation) -- MinGW GCC.
 cmake --preset mingw-debug-coverage
 cmake --build --preset mingw-debug-coverage --parallel
 ctest --preset mingw-debug-coverage
 
-# Or enable either flag on top of mingw-debug manually
-cmake --preset mingw-debug -DDMK_ENABLE_SANITIZERS=ON
+# Or enable either flag on its matching debug preset manually
+cmake --preset msvc-debug -DDMK_ENABLE_SANITIZERS=ON
 cmake --preset mingw-debug -DDMK_ENABLE_COVERAGE=ON
 ```
 
-The ASan/UBSan runtimes ship inside the MinGW GCC package itself
-(`mingw-w64-x86_64-gcc` on MSYS2). If a sanitizer build fails to link with a
-missing `libasan` / `libubsan`, reinstall or update that package
-(`pacman -S mingw-w64-x86_64-gcc`). A non-blocking CI probe in
-`.github/workflows/quality.yml` builds and runs the sanitizer preset (alongside
-an advisory clang-format check) so regressions in that wiring surface without
-gating PRs.
+AddressSanitizer is the only sanitizer that links on Windows: GCC and Clang on
+mingw-w64 ship no ASan/UBSan runtime for the Windows target, so the sanitizer
+build links only under MSVC, and ASan is the only sanitizer there (no UBSan or
+LSan). MSVC ASan needs `clang_rt.asan_dynamic-x86_64.dll` on `PATH` at run time;
+a Developer Command Prompt provides it. Coverage is separate and works on MinGW
+via gcov. A non-blocking CI probe in `.github/workflows/quality.yml` builds and
+runs the MSVC ASan preset (alongside an advisory clang-format check) so
+regressions in that wiring surface without gating PRs.
 
 ### Makefile wrapper
 
@@ -169,7 +170,7 @@ tests/                   # GoogleTest suites (one test_*.cpp per module)
   package_smoke/         # Minimal installed-package consumer used by release CI
 external/                # Git submodules (safetyhook, DirectXMath, simpleini)
 CMakeLists.txt           # Single CMakeLists -- static library target
-CMakePresets.json        # Build presets (mingw-debug/release, mingw-debug-asan, msvc-debug/release)
+CMakePresets.json        # Build presets (mingw-debug/release/coverage, msvc-debug/release/asan)
 ```
 
 ## Code style

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,13 +310,15 @@ if(WIN32)
   # configure time. Release packages are compiler-specific, and add_subdirectory
   # consumers share the same toolchain that configured this target.
   set(_dmk_uses_msvc_linker_frontend OFF)
+
   if(MSVC OR "${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
     set(_dmk_uses_msvc_linker_frontend ON)
   endif()
 
   set(_dmk_uses_gnu_linker_frontend OFF)
+
   if(MINGW OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
-      (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT _dmk_uses_msvc_linker_frontend))
+    (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT _dmk_uses_msvc_linker_frontend))
     set(_dmk_uses_gnu_linker_frontend ON)
   endif()
 
@@ -347,10 +349,12 @@ set(DETOURMODKIT_DOCS_COMPONENT docs) # For documentation (LICENSE, README)
 # Order matters: a dependent precedes its dependency for single-pass linkers.
 set(_dmk_dep_archives "")
 set(_DMK_DEP_ARCHIVE_NAMES "")
+
 foreach(_dep IN ITEMS ${SAFETYHOOK_LIBRARY_TARGET_NAME} Zydis Zycore)
   if(TARGET ${_dep})
     get_target_property(_dep_aliased ${_dep} ALIASED_TARGET)
     get_target_property(_dep_imported ${_dep} IMPORTED)
+
     if(NOT _dep_aliased AND NOT _dep_imported)
       list(APPEND _dmk_dep_archives "$<TARGET_FILE:${_dep}>")
       list(APPEND _DMK_DEP_ARCHIVE_NAMES
@@ -514,12 +518,36 @@ if(DMK_ENABLE_PROFILING)
 endif()
 
 # --- Sanitizers ---
-option(DMK_ENABLE_SANITIZERS "Enable ASan and UBSan (GCC/Clang only)" OFF)
+option(DMK_ENABLE_SANITIZERS "Enable AddressSanitizer (and UBSan on GCC/Clang)" OFF)
 
-if(DMK_ENABLE_SANITIZERS AND NOT MSVC)
-  add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
-  add_link_options(-fsanitize=address,undefined)
-  message(STATUS "Sanitizers enabled: ASan + UBSan")
+if(DMK_ENABLE_SANITIZERS)
+  if(MSVC)
+    # AddressSanitizer is the only sanitizer available on Windows: UBSan is
+    # GCC/Clang-only, and mingw-w64 ships no sanitizer runtime at all (only the
+    # MSVC target has one). /fsanitize=address is incompatible with the /RTC
+    # runtime checks CMake's Debug config injects and with incremental linking,
+    # so strip /RTC* (globally, which also reaches the library target defined
+    # earlier) and force non-incremental linking.
+    string(REGEX REPLACE "/RTC[1csu]+" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    string(REGEX REPLACE "/RTC[1csu]+" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
+    # The vendored SafetyHook is not instrumented, so the MSVC STL ASan container
+    # annotations (annotate_string / annotate_vector) would differ across the link
+    # and fail with LNK2038. Disable those annotations on every instrumented target
+    # so all objects agree (value 0); the core ASan checks (heap/stack/use-after-
+    # free) stay on. The library is instrumented explicitly because it was created
+    # before this block; the tests (added afterwards) pick up the directory options.
+    target_compile_options(DetourModKit PRIVATE /fsanitize=address)
+    target_compile_definitions(DetourModKit PRIVATE _DISABLE_STRING_ANNOTATION=1 _DISABLE_VECTOR_ANNOTATION=1)
+    add_compile_options(/fsanitize=address)
+    add_compile_definitions(_DISABLE_STRING_ANNOTATION=1 _DISABLE_VECTOR_ANNOTATION=1)
+    add_link_options(/INCREMENTAL:NO)
+    message(STATUS "Sanitizers enabled: ASan (MSVC)")
+  else()
+    add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=address,undefined)
+    message(STATUS "Sanitizers enabled: ASan + UBSan")
+  endif()
 endif()
 
 # --- Link-Time Optimization ---

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,6 +45,18 @@
       }
     },
     {
+      "name": "clang-debug-asan",
+      "inherits": "base",
+      "displayName": "Clang Debug + Sanitizers",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "DMK_BUILD_TESTS": "ON",
+        "DMK_ENABLE_SANITIZERS": "ON",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
       "name": "mingw-release",
       "inherits": "base",
       "displayName": "MinGW Release",
@@ -96,6 +108,10 @@
       "configurePreset": "mingw-debug-coverage"
     },
     {
+      "name": "clang-debug-asan",
+      "configurePreset": "clang-debug-asan"
+    },
+    {
       "name": "msvc-debug",
       "configurePreset": "msvc-debug"
     },
@@ -122,6 +138,13 @@
     {
       "name": "mingw-debug-coverage",
       "configurePreset": "mingw-debug-coverage",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "clang-debug-asan",
+      "configurePreset": "clang-debug-asan",
       "output": {
         "outputOnFailure": true
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,14 +29,6 @@
       }
     },
     {
-      "name": "mingw-debug-asan",
-      "inherits": "mingw-debug",
-      "displayName": "MinGW Debug + Sanitizers",
-      "cacheVariables": {
-        "DMK_ENABLE_SANITIZERS": "ON"
-      }
-    },
-    {
       "name": "mingw-debug-coverage",
       "inherits": "mingw-debug",
       "displayName": "MinGW Debug + Coverage",
@@ -45,15 +37,11 @@
       }
     },
     {
-      "name": "clang-debug-asan",
-      "inherits": "base",
-      "displayName": "Clang Debug + Sanitizers",
+      "name": "msvc-debug-asan",
+      "inherits": "msvc-debug",
+      "displayName": "MSVC Debug + ASan",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "DMK_BUILD_TESTS": "ON",
-        "DMK_ENABLE_SANITIZERS": "ON",
-        "CMAKE_C_COMPILER": "clang",
-        "CMAKE_CXX_COMPILER": "clang++"
+        "DMK_ENABLE_SANITIZERS": "ON"
       }
     },
     {
@@ -100,16 +88,12 @@
       "configurePreset": "mingw-release"
     },
     {
-      "name": "mingw-debug-asan",
-      "configurePreset": "mingw-debug-asan"
-    },
-    {
       "name": "mingw-debug-coverage",
       "configurePreset": "mingw-debug-coverage"
     },
     {
-      "name": "clang-debug-asan",
-      "configurePreset": "clang-debug-asan"
+      "name": "msvc-debug-asan",
+      "configurePreset": "msvc-debug-asan"
     },
     {
       "name": "msvc-debug",
@@ -129,13 +113,6 @@
       }
     },
     {
-      "name": "mingw-debug-asan",
-      "configurePreset": "mingw-debug-asan",
-      "output": {
-        "outputOnFailure": true
-      }
-    },
-    {
       "name": "mingw-debug-coverage",
       "configurePreset": "mingw-debug-coverage",
       "output": {
@@ -143,8 +120,8 @@
       }
     },
     {
-      "name": "clang-debug-asan",
-      "configurePreset": "clang-debug-asan",
+      "name": "msvc-debug-asan",
+      "configurePreset": "msvc-debug-asan",
       "output": {
         "outputOnFailure": true
       }

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PRESET ?= mingw-release
 TEST_PRESET ?= mingw-debug
 JOBS ?= $(shell nproc 2>/dev/null || echo 4)
 
-.PHONY: all configure build install test test_mingw test_msvc clean distclean help
+.PHONY: all configure build install test test_mingw test_msvc test_asan clean distclean help
 
 # --- Build Targets ---
 all: build
@@ -32,10 +32,16 @@ test_mingw:
 test_msvc:
 	$(MAKE) test TEST_PRESET=msvc-debug
 
+# AddressSanitizer build + tests. MSVC only: GCC and Clang on mingw-w64 ship no
+# ASan/UBSan runtime for the Windows target, so the sanitizer build links only
+# under MSVC (ASan only). Run from a Visual Studio Developer Command Prompt.
+test_asan:
+	$(MAKE) test TEST_PRESET=msvc-debug-asan
+
 # --- Housekeeping ---
 clean:
 	@echo "Cleaning preset build directories..."
-	rm -rf build/mingw-debug build/mingw-release build/msvc-debug build/msvc-release
+	rm -rf build/mingw-debug build/mingw-release build/msvc-debug build/msvc-release build/mingw-debug-coverage build/msvc-debug-asan
 
 distclean:
 	@echo "Full clean (entire build directory)..."
@@ -51,6 +57,7 @@ help:
 	@echo "  make test         - Build and run tests (TEST_PRESET=$(TEST_PRESET))"
 	@echo "  make test_mingw   - Run tests with MinGW (Ninja)"
 	@echo "  make test_msvc    - Run tests with MSVC (Ninja, requires VS dev shell)"
+	@echo "  make test_asan    - Run tests under MSVC AddressSanitizer (VS dev shell)"
 	@echo "  make clean        - Remove preset build directories"
 	@echo "  make distclean    - Remove entire build/"
 	@echo ""
@@ -61,4 +68,5 @@ help:
 	@echo "  mingw-debug       MinGW + Debug + Tests"
 	@echo "  mingw-release     MinGW + Release (default)"
 	@echo "  msvc-debug        MSVC + Debug + Tests"
+	@echo "  msvc-debug-asan   MSVC + Debug + AddressSanitizer"
 	@echo "  msvc-release      MSVC + Release"

--- a/README.md
+++ b/README.md
@@ -407,9 +407,10 @@ This project uses CMake with [CMake Presets](https://cmake.org/cmake/help/latest
     | Preset | Compiler | Build Type | Tests | Notes |
     | --- | --- | --- | --- | --- |
     | `mingw-debug` | GCC (MinGW) | Debug | ON | |
-    | `mingw-debug-asan` | GCC (MinGW) | Debug | ON | ASan + UBSan enabled |
+    | `mingw-debug-coverage` | GCC (MinGW) | Debug | ON | gcov coverage |
     | `mingw-release` | GCC (MinGW) | Release | OFF | |
     | `msvc-debug` | MSVC (cl) | Debug | ON | |
+    | `msvc-debug-asan` | MSVC (cl) | Debug | ON | AddressSanitizer (the only sanitizer on Windows) |
     | `msvc-release` | MSVC (cl) | Release | OFF | |
 
    ### Installed package smoke test
@@ -547,22 +548,23 @@ When `DMK_ENABLE_PROFILING` is OFF (the default), all profiling macros expand to
 
 ### Enabling Sanitizers
 
-To enable AddressSanitizer and UndefinedBehaviorSanitizer (requires GCC/Clang):
+AddressSanitizer is available on Windows through **MSVC only**. GCC and Clang on
+mingw-w64 ship no ASan/UBSan runtime for the Windows target, so a MinGW sanitizer
+build cannot link here; UndefinedBehaviorSanitizer is not available on Windows.
 
 ```bash
-# Using the dedicated preset
-cmake --preset mingw-debug-asan
-cmake --build --preset mingw-debug-asan --parallel
-
-# Or manually with any debug preset
-cmake --preset mingw-debug -DDMK_ENABLE_SANITIZERS=ON
-cmake --build --preset mingw-debug --parallel
+# AddressSanitizer via MSVC -- run from a Developer Command Prompt.
+cmake --preset msvc-debug-asan
+cmake --build --preset msvc-debug-asan --parallel
+ctest --preset msvc-debug-asan
 ```
 
 > [!NOTE]
-> Sanitizer support on MinGW requires `libasan` and `libubsan` runtime libraries.
-> Not all MSYS2 MinGW GCC builds ship these. If linking fails with
-> `cannot find -lasan`, install the sanitizer package or use Clang instead.
+> MSVC ASan needs `clang_rt.asan_dynamic-x86_64.dll` on `PATH` at run time; a
+> Developer Command Prompt (or `Enter-VsDevShell`) provides it. ASan only -- there
+> is no UBSan or LeakSanitizer on MSVC. The GCC/Clang `-fsanitize=address,undefined`
+> path only links where the runtimes exist (a Linux toolchain), which does not
+> apply to this Windows-only library.
 
 ### Enabling Code Coverage
 

--- a/tests/test_profiler.cpp
+++ b/tests/test_profiler.cpp
@@ -341,12 +341,19 @@ TEST_F(ProfilerRecordTest, ConcurrentRecordAndExport_NoTornReads)
         });
     }
 
-    // Reader thread: export while writers are active
+    // Reader thread: export while writers are active. Loop until the window
+    // closes AND at least one export has completed. A full 65536-sample buffer
+    // serializes to a multi-megabyte string, so on a loaded runner a single
+    // export can outlast the 50 ms window; keying the exit on a completed export
+    // (not on wall-clock alone) keeps export_count deterministic instead of
+    // letting it flake at 0.
     std::thread reader([&profiler, &stop, &export_count]() {
-        while (!stop.load(std::memory_order_relaxed))
+        while (!stop.load(std::memory_order_relaxed) ||
+               export_count.load(std::memory_order_relaxed) == 0)
         {
             const std::string json = profiler.export_chrome_json();
-            // Verify the JSON is well-formed (starts with [, ends with ])
+            // The export wraps a seqlock snapshot, so a well-formed result starts
+            // with '[' and ends with ']' even while writers overwrite slots.
             if (!json.empty())
             {
                 EXPECT_EQ(json.front(), '[');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AddressSanitizer support added on Windows (MSVC-based)
  * New `make test_asan` target for running sanitizer tests
  * New `msvc-debug-asan` CMake preset for MSVC sanitizer builds
  * New `mingw-debug-coverage` CMake preset for MinGW coverage

* **Bug Fixes**
  * Improved test determinism for concurrent export scenarios

* **Documentation**
  * Updated sanitizer setup guidance and CMake preset documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->