### PR TITLE
style: format sources and normalize comment conventions

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,8 +9,9 @@ on:
 permissions:
   contents: read
 
-# Both jobs are advisory and non-blocking. clang-format stays red until a planned
-# repo-wide reformat. The sanitizer job uses MSVC AddressSanitizer -- the only
+# Both jobs are advisory and non-blocking. The clang-format job verifies the tracked
+# project sources stay formatted against the root .clang-format (clang-format 18, the
+# version pinned below). The sanitizer job uses MSVC AddressSanitizer -- the only
 # sanitizer that works on Windows (GCC and Clang on mingw-w64 ship no ASan/UBSan
 # runtime for the Windows target, so the build links only under MSVC, and ASan is
 # the only sanitizer there). The blocking gate (build, tests, coverage) lives in
@@ -36,6 +37,12 @@ jobs:
           # git ls-files lists only this repo's tracked files, so submodule
           # sources under external/ are never formatted.
           git ls-files '*.cpp' '*.hpp' | xargs clang-format --dry-run --Werror
+        shell: bash
+
+      - name: Check comment-marker conventions
+        # Runs even if the formatting step above reported violations.
+        if: ${{ !cancelled() }}
+        run: python scripts/check_comment_style.py
         shell: bash
 
   sanitizers:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ CMakeUserPresets.json
 # Coverage reports (generated into docs/tests/coverage/)
 docs/tests/coverage/
 !docs/tests/coverage/.gitignore
+.claude/*
+
+# Python bytecode cache (scripts/)
+__pycache__/
+*.pyc

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,16 +1,37 @@
 {
   "configurations": [
     {
-      "name": "windows-gcc-x64",
+      "name": "windows-msvc-x64",
+      "compileCommands": "${workspaceFolder}/build/msvc-debug/compile_commands.json",
       "includePath": [
+        "${workspaceFolder}/include",
+        "${workspaceFolder}/src",
         "${workspaceFolder}/external/DirectXMath/Inc",
-        "${workspaceFolder}/**"
+        "${workspaceFolder}/external/simpleini",
+        "${workspaceFolder}/external/safetyhook/include",
+        "${workspaceFolder}/build/msvc-debug/generated",
+        "${workspaceFolder}/build/msvc-debug/_deps/zydis-src/include",
+        "${workspaceFolder}/build/msvc-debug/_deps/zydis-build",
+        "${workspaceFolder}/build/msvc-debug/_deps/zydis-src/dependencies/zycore/include",
+        "${workspaceFolder}/build/msvc-debug/_deps/zydis-build/zycore"
       ],
-      "defines": ["_DEBUG", "UNICODE", "_UNICODE"],
-      "compilerPath": "C:\\msys64\\mingw64\\bin\\gcc.exe",
+      "defines": [
+        "_DEBUG",
+        "UNICODE",
+        "_UNICODE",
+        "WIN32",
+        "_WINDOWS",
+        "NOMINMAX",
+        "SAFETYHOOK_NO_DLL",
+        "WINVER=0x0A00",
+        "_WIN32_WINNT=0x0A00",
+        "ZYCORE_STATIC_BUILD",
+        "ZYDIS_STATIC_BUILD"
+      ],
+      "compilerPath": "cl.exe",
       "cStandard": "c23",
       "cppStandard": "c++23",
-      "intelliSenseMode": "windows-gcc-x64"
+      "intelliSenseMode": "windows-msvc-x64"
     }
   ],
   "version": 4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,7 @@ ctest --preset msvc-debug
 
 ### Installed package smoke test
 
-After installing either release preset, verify the exported CMake package with
-the checked-in consumer smoke project:
+After installing either release preset, verify the exported CMake package with the checked-in consumer smoke project:
 
 ```bash
 cmake -S tests/package_smoke -B build/package-smoke-mingw -G Ninja \
@@ -87,10 +86,7 @@ PATH="/c/msys64/mingw64/bin:$PATH" cmake --build build/mingw-release \
 ./build/mingw-release/tests/DetourModKit_bench_scanner.exe
 ```
 
-Latest scanner bench numbers and methodology live in
-[docs/analysis/scanner_bench_v3.x/README.md](docs/analysis/scanner_bench_v3.x/README.md).
-Memory validation-vs-direct-read numbers live in
-[docs/analysis/memory_bench_v3.x/README.md](docs/analysis/memory_bench_v3.x/README.md).
+Latest scanner bench numbers and methodology live in [docs/analysis/scanner_bench_v3.x/README.md](docs/analysis/scanner_bench_v3.x/README.md). Memory validation-vs-direct-read numbers live in [docs/analysis/memory_bench_v3.x/README.md](docs/analysis/memory_bench_v3.x/README.md).
 
 ### Sanitizers (MSVC) and coverage (MinGW)
 
@@ -110,21 +106,9 @@ cmake --preset msvc-debug -DDMK_ENABLE_SANITIZERS=ON
 cmake --preset mingw-debug -DDMK_ENABLE_COVERAGE=ON
 ```
 
-AddressSanitizer is the only sanitizer that links on Windows: GCC and Clang on
-mingw-w64 ship no ASan/UBSan runtime for the Windows target, so the sanitizer
-build links only under MSVC, and ASan is the only sanitizer there (no UBSan or
-LSan). MSVC ASan needs `clang_rt.asan_dynamic-x86_64.dll` on `PATH` at run time;
-a Developer Command Prompt provides it. Coverage is separate and works on MinGW
-via gcov. A non-blocking CI probe in `.github/workflows/quality.yml` builds and
-runs the MSVC ASan preset (alongside an advisory clang-format check) so
-regressions in that wiring surface without gating PRs.
+AddressSanitizer is the only sanitizer that links on Windows: GCC and Clang on mingw-w64 ship no ASan/UBSan runtime for the Windows target, so the sanitizer build links only under MSVC, and ASan is the only sanitizer there (no UBSan or LSan). MSVC ASan needs `clang_rt.asan_dynamic-x86_64.dll` on `PATH` at run time; a Developer Command Prompt provides it. Coverage is separate and works on MinGW via gcov. A non-blocking CI probe in `.github/workflows/quality.yml` builds and runs the MSVC ASan preset (alongside an advisory clang-format check) so regressions in that wiring surface without gating PRs.
 
-The AOB scanner and the SEH-guarded probe read deliberately read arbitrary mapped
-process memory, which ASan reports as false-positive overflows when it scans this
-process's own poisoned shadow. They are excluded from ASan entirely under
-`#if defined(__SANITIZE_ADDRESS__)`, so release builds are byte-for-byte
-unchanged; see [docs/misc/asan-memory-scanner.md](docs/misc/asan-memory-scanner.md)
-for the mechanism and the pattern for any new foreign-memory primitive.
+The AOB scanner and the SEH-guarded probe read deliberately read arbitrary mapped process memory, which ASan reports as false-positive overflows when it scans this process's own poisoned shadow. They are excluded from ASan entirely under `#if defined(__SANITIZE_ADDRESS__)`, so release builds are byte-for-byte unchanged; see [docs/misc/asan-memory-scanner.md](docs/misc/asan-memory-scanner.md) for the mechanism and the pattern for any new foreign-memory primitive.
 
 ### Makefile wrapper
 
@@ -178,6 +162,7 @@ tests/                   # GoogleTest suites (one test_*.cpp per module)
 external/                # Git submodules (safetyhook, DirectXMath, simpleini)
 CMakeLists.txt           # Single CMakeLists -- static library target
 CMakePresets.json        # Build presets (mingw-debug/release/coverage, msvc-debug/release/asan)
+scripts/                 # Repo tooling (check_comment_style.py: advisory comment-marker lint)
 ```
 
 ## Code style
@@ -201,9 +186,9 @@ CMakePresets.json        # Build presets (mingw-debug/release/coverage, msvc-deb
 
 ### Comment conventions
 
-Two comment styles are used, each for a distinct purpose:
+Three comment markers are used, each for a distinct purpose. The choice is by *what* is being commented, not by length: `/** */` and `///` document a declaration; `//` explains implementation. Put another way, document the interface and comment the implementation -- a documented or public declaration's contract uses `///` or `/** */` (Doxygen extracts it), while a private or implementation-only member carries at most a plain `//` rationale (ownership, alignment, immutability) and is not given a `///`. A trailing `///<` is never used.
 
-**Doxygen doc-blocks (`/** */`):** Required on all public class/struct/function/method declarations in headers. Always include `@brief`. Add `@details` when behavior is non-trivial. Add `@param`, `@return`, `@note`, `@warning` as applicable. Indent continuation lines with `*` aligned to the first `*`.
+**Doxygen doc-blocks (`/** */`):** The doc-comment form for declarations. Required on all public class/struct/function/method/enum declarations in headers, and used for any documented internal helper, constant, or anonymous-namespace function in `.cpp` files. Always include `@brief`. Add `@details` when behavior is non-trivial. Add `@param`, `@return`, `@note`, `@warning` as applicable. Use a `/** */` block whenever the documentation spans more than one line or carries any structural Doxygen tag. Indent continuation lines with `*` aligned to the first `*`.
 
 ```cpp
 /**
@@ -216,22 +201,28 @@ Two comment styles are used, each for a distinct purpose:
  */
 ```
 
-**Single-line `///` exception:** Permitted only for trivial self-evident members where a full `/** */` block would be noise (e.g. simple getters, size queries). Must still be a complete sentence. Use sparingly. A `///` line must not carry Doxygen tags (`@param`, `@return`, `@note`, `@brief`, `@details`); the moment a tag is needed, switch to a `/** */` block.
+**Single-line `///` exception:** A shorthand for a one-line `/** @brief */`, permitted only for a trivial self-evident declaration where a full block would be noise (e.g. simple getters, size queries, a single named constant). It must be exactly one line -- two consecutive `///` lines are a multi-line doc and belong in a `/** */` block -- and a complete sentence. It may carry inline Doxygen markup that is a link rather than structure (`@ref`, `@c`, `@p`, `@a`), but must not carry a structural/block tag (`@brief`, `@param`, `@return`, `@retval`, `@note`, `@warning`, `@details`, `@throws`, `@name`, `@{`, `@}`); the moment one is needed, switch to a `/** */` block. Place it on the line above the declaration.
 
 ```cpp
 /// Returns the approximate number of items in the queue.
 size_t size() const noexcept;
 ```
 
-If the member needs `@param`, `@return`, `@note`, or multi-line description, use `/** */` instead.
+**No trailing `///<`:** Member documentation goes on the line(s) above the member as a `///` line or a `/** */` block, never as a trailing `///<` on the same line. Trailing docs run lines past a comfortable width and read inconsistently next to above-the-member docs.
 
-**Inline comments (`//`):** Used inside function bodies to explain *why*, not *what*. Place on the line above the code they describe. Multi-line explanations use consecutive `//` lines.
+**Inline comments (`//`):** Used inside function bodies and implementation logic to explain *why*, not *what*. This is the only non-documentation marker: a `//` never documents a declaration (use `///` or `/** */` for that). Place on the line above the code it describes. Multi-line explanations use consecutive `//` lines.
 
 ```cpp
 // Increment before push so flush cannot observe zero while a message
 // is already in the queue but not yet counted.
 m_pending_messages.fetch_add(1, std::memory_order_acq_rel);
 ```
+
+### Formatting and tooling
+
+C++ formatting is codified in the root `.clang-format` (LLVM base, Allman braces for functions/classes, 4-space indent, east-side pointers, includes never reordered). Run clang-format over the changed `*.cpp`/`*.hpp` before committing. CI runs an advisory check in `.github/workflows/quality.yml` (clang-format 18, the version pinned there) over the tracked project sources; submodules under `external/` are never formatted. There is no hard column limit (`ColumnLimit: 0`): long Doxygen and log lines may run past 120, so the formatter never reflows on width. Because width is not enforced, do not chase an 80-column limit -- keep a member's documentation on the line(s) above it (per the comment conventions) instead of letting a trailing comment push the line out. The comment-marker rules above are guarded by an advisory CI step, `scripts/check_comment_style.py` (no trailing `///<`, no multi-line `///`, no block tag on a `///` line).
+
+Markdown files (`*.md`) are **not** hard-wrapped at 80 columns. Write one logical line per paragraph, list item, and blockquote line and let editors soft-wrap; do not insert manual line breaks mid-paragraph. Fenced code blocks, tables, and any line indented four or more spaces (indented code, nested list sub-paragraphs) are kept verbatim. As in code, use `--` rather than an em-dash or en-dash.
 
 ### Type safety and const-correctness
 
@@ -301,13 +292,7 @@ dispatcher.emit_safe(PlayerStateChanged{.health = player->health});
 
 ### Memory access in hook callbacks
 
-Do not add `Memory::is_readable()` or `Memory::is_writable()` before every
-field read in hook callbacks. Use those predicates for setup validation and
-diagnostics. Use `seh_read_chain` for unstable live game pointers, and use
-`read_ptr_unchecked` only when the caller can prove the pointer chain is live
-for the current frame. The full pattern -- worked examples, the primitive
-selection table, and the anti-patterns to remove -- lives in
-[docs/misc/hot-path-memory.md](docs/misc/hot-path-memory.md).
+Do not add `Memory::is_readable()` or `Memory::is_writable()` before every field read in hook callbacks. Use those predicates for setup validation and diagnostics. Use `seh_read_chain` for unstable live game pointers, and use `read_ptr_unchecked` only when the caller can prove the pointer chain is live for the current frame. The full pattern -- worked examples, the primitive selection table, and the anti-patterns to remove -- lives in [docs/misc/hot-path-memory.md](docs/misc/hot-path-memory.md).
 
 ## Testing
 
@@ -401,8 +386,7 @@ These are called at 60+ fps from game hook callbacks. Never add allocations, exc
 - **Do not break** the lock ordering documented in class headers.
 - **Do not weaken** atomic memory orderings without proving correctness.
 - **Do not skip** running the test suite before committing.
-- **Do not publish** release packages before debug tests, release builds, and
-  installed-package smoke tests pass for both MinGW and MSVC.
+- **Do not publish** release packages before debug tests, release builds, and installed-package smoke tests pass for both MinGW and MSVC.
 - **Do not add** Windows API calls without `#ifdef _WIN32` guards in headers (implementation files are Windows-only, but headers should remain clean).
 - **Do not commit** build artifacts, `.exe`, `.a`, `.lib`, `.obj`, or `.pdb` files.
 - **Do not remove** or weaken existing tests. Add new tests for new code.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # DetourModKit
 
-[![Coverage Report ≥ 80%](https://github.com/tkhquang/DetourModKit/actions/workflows/coverage-pages.yml/badge.svg)](https://tkhquang.github.io/DetourModKit/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Coverage Report ≥ 80%](https://github.com/tkhquang/DetourModKit/actions/workflows/coverage-pages.yml/badge.svg)](https://tkhquang.github.io/DetourModKit/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 [Features](#features) | [Building](#building-detourmodkit-static-library-via-cmake) | [Testing](#running-unit-tests) | [Guides](#guides) | [Integration](#using-detourmodkit-in-your-mod-project) | [Example](#code-example)
 
@@ -548,9 +547,7 @@ When `DMK_ENABLE_PROFILING` is OFF (the default), all profiling macros expand to
 
 ### Enabling Sanitizers
 
-AddressSanitizer is available on Windows through **MSVC only**. GCC and Clang on
-mingw-w64 ship no ASan/UBSan runtime for the Windows target, so a MinGW sanitizer
-build cannot link here; UndefinedBehaviorSanitizer is not available on Windows.
+AddressSanitizer is available on Windows through **MSVC only**. GCC and Clang on mingw-w64 ship no ASan/UBSan runtime for the Windows target, so a MinGW sanitizer build cannot link here; UndefinedBehaviorSanitizer is not available on Windows.
 
 ```bash
 # AddressSanitizer via MSVC -- run from a Developer Command Prompt.

--- a/docs/analysis/event_dispatcher_bench_v3.1.0/README.md
+++ b/docs/analysis/event_dispatcher_bench_v3.1.0/README.md
@@ -1,11 +1,6 @@
 # EventDispatcher Bench, v3.1.0
 
-Before/after numbers for the lock-free COW snapshot `emit()` landed in v3.1.0.
-The previous implementation used `std::shared_mutex` for `emit()` / `emit_safe()`
-and an exclusive lock for `subscribe()` / `unsubscribe()`. The new implementation
-stores handlers in a `std::atomic<std::shared_ptr<const std::vector<Entry>>>`
-snapshot published on mutation, with a lock-free atomic handler-count fast
-path for the zero-subscriber case.
+Before/after numbers for the lock-free COW snapshot `emit()` landed in v3.1.0. The previous implementation used `std::shared_mutex` for `emit()` / `emit_safe()` and an exclusive lock for `subscribe()` / `unsubscribe()`. The new implementation stores handlers in a `std::atomic<std::shared_ptr<const std::vector<Entry>>>` snapshot published on mutation, with a lock-free atomic handler-count fast path for the zero-subscriber case.
 
 ## Results (median of 5 runs per side)
 
@@ -29,58 +24,30 @@ Verdict key:
 - **NOISE**: median delta is smaller than the run-to-run spread; cannot be distinguished from measurement jitter.
 - **marginal**: delta is larger than spread but smaller than 1.5x spread.
 
-Run-to-run coefficient of variation was 1% to 5% per scenario. Full per-run
-TSVs live in [runs/](runs/) (5 OLD + 5 NEW).
+Run-to-run coefficient of variation was 1% to 5% per scenario. Full per-run TSVs live in [runs/](runs/) (5 OLD + 5 NEW).
 
 ## Interpretation
 
-**Zero-subscriber fast path.** The atomic handler-count short-circuit in
-`emit()` / `emit_safe()` collapses a `shared_mutex` acquire/release plus
-iteration setup into a single `memory_order_acquire` load of an 8-byte counter.
-The 17x factor is the cost of an uncontended `shared_mutex` acquire/release
-on Windows SRWLOCK relative to a naked atomic load, and it is the dominant
-result for dispatchers that are wired up at init but rarely subscribed to.
+**Zero-subscriber fast path.** The atomic handler-count short-circuit in `emit()` / `emit_safe()` collapses a `shared_mutex` acquire/release plus iteration setup into a single `memory_order_acquire` load of an 8-byte counter. The 17x factor is the cost of an uncontended `shared_mutex` acquire/release on Windows SRWLOCK relative to a naked atomic load, and it is the dominant result for dispatchers that are wired up at init but rarely subscribed to.
 
-**1 to 8 subscriber uncontended emit.** Consistent wins (6% to 21%) from
-removing the reader lock. The snapshot load is a release-acquire atomic plus
-a `shared_ptr` refcount bump, which is cheaper than touching a mutex's state
-word unconditionally.
+**1 to 8 subscriber uncontended emit.** Consistent wins (6% to 21%) from removing the reader lock. The snapshot load is a release-acquire atomic plus a `shared_ptr` refcount bump, which is cheaper than touching a mutex's state word unconditionally.
 
-**Concurrent emit (4 threads, 8 subs).** 2.1x throughput. No reader lock
-means no cache-line contention on the mutex state, so all four threads make
-progress in parallel instead of serializing on the SRWLOCK read side.
+**Concurrent emit (4 threads, 8 subs).** 2.1x throughput. No reader lock means no cache-line contention on the mutex state, so all four threads make progress in parallel instead of serializing on the SRWLOCK read side.
 
-**64 subscriber emit.** Within noise on both `emit` (-1.0%) and `emit_safe`
-(+1.2%). An earlier single-run measurement suggested an 18% regression; that
-was a statistical outlier. Across 5 runs per side the two implementations
-are indistinguishable at this subscriber count: the per-handler iteration
-cost dominates and both paths reach the same `std::vector<Entry>` buffer
-layout through one extra dereference either way.
+**64 subscriber emit.** Within noise on both `emit` (-1.0%) and `emit_safe` (+1.2%). An earlier single-run measurement suggested an 18% regression; that was a statistical outlier. Across 5 runs per side the two implementations are indistinguishable at this subscriber count: the per-handler iteration cost dominates and both paths reach the same `std::vector<Entry>` buffer layout through one extra dereference either way.
 
-**Subscribe / unsubscribe round-trip.** 2.6x slower (446 ns to 1150 ns).
-Each mutation allocates a fresh handler vector, appends or removes the
-entry, and publishes via atomic store. This is documented in the header
-and is the accepted tradeoff for lock-free reads. Subscribe is not on a
-hot path in any realistic mod workload.
+**Subscribe / unsubscribe round-trip.** 2.6x slower (446 ns to 1150 ns). Each mutation allocates a fresh handler vector, appends or removes the entry, and publishes via atomic store. This is documented in the header and is the accepted tradeoff for lock-free reads. Subscribe is not on a hot path in any realistic mod workload.
 
-**Reentrancy rejection.** Marginal improvement (within 1.5x spread). Not a
-meaningful claim; effectively unchanged.
+**Reentrancy rejection.** Marginal improvement (within 1.5x spread). Not a meaningful claim; effectively unchanged.
 
 ## Methodology
 
 - Host: Windows 11, MinGW `mingw-release` preset (GCC 13, libstdc++, -O3 LTO).
 - CMake: `cmake --preset mingw-release -DDMK_BUILD_BENCHMARKS=ON -DDMK_BUILD_TESTS=OFF`.
 - Build: `DetourModKit_bench` target only. No gtest linkage, no other test deps.
-- Each sample runs N iterations of the scenario inside a single
-  `steady_clock::now()` pair. Reported value is the median per-op cost across
-  11 samples inside one process invocation. Iteration counts are chosen so
-  each sample takes roughly the same wall time.
-- 5 process invocations per side (OLD vs NEW), back-to-back, same machine,
-  same thermal state. Tables above report the median across those 5 runs
-  for each scenario.
-- Verdicts use run-to-run spread (max minus min across the 5 runs) as the
-  noise floor. A claim is "REAL" only when the median delta exceeds 1.5x
-  that noise floor on both sides.
+- Each sample runs N iterations of the scenario inside a single `steady_clock::now()` pair. Reported value is the median per-op cost across 11 samples inside one process invocation. Iteration counts are chosen so each sample takes roughly the same wall time.
+- 5 process invocations per side (OLD vs NEW), back-to-back, same machine, same thermal state. Tables above report the median across those 5 runs for each scenario.
+- Verdicts use run-to-run spread (max minus min across the 5 runs) as the noise floor. A claim is "REAL" only when the median delta exceeds 1.5x that noise floor on both sides.
 
 ## Reproduce
 
@@ -90,18 +57,8 @@ PATH="/c/msys64/mingw64/bin:$PATH" cmake --build build/mingw-release --target De
 PATH="/c/msys64/mingw64/bin:$PATH" ./build/mingw-release/tests/DetourModKit_bench.exe > run.tsv
 ```
 
-For a clean before/after comparison, bench the new implementation first,
-copy the header aside, `git checkout main -- include/DetourModKit/event_dispatcher.hpp`
-(or any pre-change commit) to restore the baseline header, rebuild the
-`DetourModKit_bench` target, run again into the baseline TSV, then restore
-the new header. Repeat N times per side and compare medians with an explicit
-noise-floor check.
+For a clean before/after comparison, bench the new implementation first, copy the header aside, `git checkout main -- include/DetourModKit/event_dispatcher.hpp` (or any pre-change commit) to restore the baseline header, rebuild the `DetourModKit_bench` target, run again into the baseline TSV, then restore the new header. Repeat N times per side and compare medians with an explicit noise-floor check.
 
 ## Caveat on committed TSVs
 
-The TSVs in this directory are raw artifacts from a specific host and
-compiler version. They are not a stable baseline. Treat them as evidence
-for the claims in this document, not as a regression gate. Future bench
-runs should regenerate their own numbers and compare against the structure
-of the results (17x fast-path win, 2x concurrent win, COW subscribe cost)
-rather than the absolute nanosecond values.
+The TSVs in this directory are raw artifacts from a specific host and compiler version. They are not a stable baseline. Treat them as evidence for the claims in this document, not as a regression gate. Future bench runs should regenerate their own numbers and compare against the structure of the results (17x fast-path win, 2x concurrent win, COW subscribe cost) rather than the absolute nanosecond values.

--- a/docs/hot-reload/README.md
+++ b/docs/hot-reload/README.md
@@ -666,17 +666,13 @@ With this setup, the workflow is always **build, then press reload key**. The po
 
 **Every `FreeLibrary` + `LoadLibrary` cycle resets all global/static variables** in the logic DLL. This is usually desirable (clean slate), but be aware:
 
-**Global variables in logic DLL:**
-Reset to initial values on reload. This is expected - design for it.
+**Global variables in logic DLL:** Reset to initial values on reload. This is expected - design for it.
 
-**DMK singletons (Logger, HookManager, etc.):**
-**Destroyed** during `FreeLibrary` (static-local destructors run), then **reconstructed** on first `get_instance()` call after `LoadLibrary`. The new instance starts with default state. `Init()` must re-configure them (e.g., `Logger::configure()`, `set_log_level()`). `Shutdown()` must be called *before* `FreeLibrary` so destruction order is controlled, not random.
+**DMK singletons (Logger, HookManager, etc.):** **Destroyed** during `FreeLibrary` (static-local destructors run), then **reconstructed** on first `get_instance()` call after `LoadLibrary`. The new instance starts with default state. `Init()` must re-configure them (e.g., `Logger::configure()`, `set_log_level()`). `Shutdown()` must be called *before* `FreeLibrary` so destruction order is controlled, not random.
 
-**Game memory (patched bytes, written values):**
-**Persists** - the game doesn't know about reload. Hooks restore original bytes via SafetyHook; direct `Memory::write_bytes()` patches must be manually reverted in `Shutdown()`.
+**Game memory (patched bytes, written values):** **Persists** - the game doesn't know about reload. Hooks restore original bytes via SafetyHook; direct `Memory::write_bytes()` patches must be manually reverted in `Shutdown()`.
 
-**Config file on disk:**
-**Persists** across reloads. Edit the INI, press reload, and new values take effect.
+**Config file on disk:** **Persists** across reloads. Edit the INI, press reload, and new values take effect.
 
 **Profiler ring buffer:** The `Profiler` stores timing samples in a ring buffer that lives in the logic DLL's memory. This data is lost when `FreeLibrary` unloads the DLL. If you need the profiling data, call `Profiler::get_instance().export_to_file("profile.json")` or `Profiler::get_instance().export_chrome_json()` before calling `Shutdown()`.
 
@@ -949,26 +945,19 @@ This prevents double-initialization (once from `DllMain`, once from the loader's
 
 ### Common Crashes and Their Causes
 
-**Crash on reload (access violation at 0x00000000):**
-`GetProcAddress` returned null - export name mismatch. Verify `extern "C"` on exports, check with `dumpbin /exports mod_logic.dll`.
+**Crash on reload (access violation at 0x00000000):** `GetProcAddress` returned null - export name mismatch. Verify `extern "C"` on exports, check with `dumpbin /exports mod_logic.dll`.
 
-**Crash during hook callback after reload:**
-Old function pointer stored somewhere. Ensure all hook callbacks reference only data within mod_logic.dll.
+**Crash during hook callback after reload:** Old function pointer stored somewhere. Ensure all hook callbacks reference only data within mod_logic.dll.
 
-**Crash on `FreeLibrary`:**
-Thread still executing code in mod_logic.dll. Increase `CALLBACK_DRAIN_MS` after `Shutdown()`.
+**Crash on `FreeLibrary`:** Thread still executing code in mod_logic.dll. Increase `CALLBACK_DRAIN_MS` after `Shutdown()`.
 
-**Hang on reload:**
-Deadlock in `DMK_Shutdown` (Logger waiting for async thread). Ensure no logging calls are in-flight during shutdown.
+**Hang on reload:** Deadlock in `DMK_Shutdown` (Logger waiting for async thread). Ensure no logging calls are in-flight during shutdown.
 
-**Hooks don't take effect after reload:**
-AOB pattern scan finds wrong address. Game may have moved memory; verify base address hasn't changed.
+**Hooks don't take effect after reload:** AOB pattern scan finds wrong address. Game may have moved memory; verify base address hasn't changed.
 
-**Config values reset unexpectedly:**
-Global state reset on DLL reload. Use persistent state in loader (see Section 2 above).
+**Config values reset unexpectedly:** Global state reset on DLL reload. Use persistent state in loader (see Section 2 above).
 
-**Build fails: "cannot open mod_logic.dll for writing":**
-Game still has DLL loaded. Use the staging directory pattern from Step 4 to avoid this entirely. Without staging: unload first (Numpad 0), then build.
+**Build fails: "cannot open mod_logic.dll for writing":** Game still has DLL loaded. Use the staging directory pattern from Step 4 to avoid this entirely. Without staging: unload first (Numpad 0), then build.
 
 ### Diagnostic Tools
 
@@ -1147,23 +1136,17 @@ Each DLL exports its own `Init()` / `Shutdown()` pair. The loader manages them a
 
 ## FAQ
 
-**Q: Can I hot-reload the loader ASI itself?**
-A: No. The ASI is loaded by the game's ASI loader at startup and cannot be unloaded. But you should rarely need to change the loader - it's just a thin stub.
+**Q: Can I hot-reload the loader ASI itself?** A: No. The ASI is loaded by the game's ASI loader at startup and cannot be unloaded. But you should rarely need to change the loader - it's just a thin stub.
 
-**Q: What if the game crashes during reload?**
-A: Attach a debugger (x64dbg) and check the crash address. If it's in unmapped memory (the old logic DLL's address space), a callback was still executing during `FreeLibrary`. Increase the sleep duration or add a reference-counting mechanism to wait for all callbacks to complete.
+**Q: What if the game crashes during reload?** A: Attach a debugger (x64dbg) and check the crash address. If it's in unmapped memory (the old logic DLL's address space), a callback was still executing during `FreeLibrary`. Increase the sleep duration or add a reference-counting mechanism to wait for all callbacks to complete.
 
-**Q: Can I use this with ASI loaders like Ultimate ASI Loader?**
-A: Yes. The ASI loader loads `mod_loader.asi` normally. The loader then manages `mod_logic.dll` via `LoadLibrary`/`FreeLibrary`. The ASI loader is not involved in the reload cycle.
+**Q: Can I use this with ASI loaders like Ultimate ASI Loader?** A: Yes. The ASI loader loads `mod_loader.asi` normally. The loader then manages `mod_logic.dll` via `LoadLibrary`/`FreeLibrary`. The ASI loader is not involved in the reload cycle.
 
-**Q: Does this work with anti-cheat?**
-A: If the game has anti-cheat that monitors `LoadLibrary` calls, hot-reload may trigger detection. This approach is intended for single-player modding and development environments only.
+**Q: Does this work with anti-cheat?** A: If the game has anti-cheat that monitors `LoadLibrary` calls, hot-reload may trigger detection. This approach is intended for single-player modding and development environments only.
 
-**Q: Can I reload while a game menu/pause screen is open?**
-A: Yes - this is actually the safest time to reload, since fewer game systems are actively calling hooked functions. The pause screen reduces the chance of a callback being mid-execution during teardown.
+**Q: Can I reload while a game menu/pause screen is open?** A: Yes - this is actually the safest time to reload, since fewer game systems are actively calling hooked functions. The pause screen reduces the chance of a callback being mid-execution during teardown.
 
-**Q: What about C++ exceptions thrown during Init()?**
-A: If `Init()` throws, the loader catches nothing (C functions shouldn't throw across DLL boundaries). Use `try/catch` inside `Init()` and return `false` on failure. The loader will log the error and leave the logic DLL unloaded until the next reload attempt.
+**Q: What about C++ exceptions thrown during Init()?** A: If `Init()` throws, the loader catches nothing (C functions shouldn't throw across DLL boundaries). Use `try/catch` inside `Init()` and return `false` on failure. The loader will log the error and leave the logic DLL unloaded until the next reload attempt.
 
 ---
 

--- a/docs/misc/asan-memory-scanner.md
+++ b/docs/misc/asan-memory-scanner.md
@@ -2,141 +2,69 @@
 
 ## Summary
 
-DetourModKit's AOB scanner and SEH-guarded probe read deliberately read arbitrary
-mapped process memory. Under MSVC AddressSanitizer (the `msvc-debug-asan` preset)
-those reads land on memory ASan has poisoned for its own bookkeeping and are
-reported as buffer overflows -- even though every read is in bounds of a
-committed, readable page and never faults in a release build. They are false
-positives intrinsic to running a whole-process memory scanner inside an
-ASan-instrumented process.
+DetourModKit's AOB scanner and SEH-guarded probe read deliberately read arbitrary mapped process memory. Under MSVC AddressSanitizer (the `msvc-debug-asan` preset) those reads land on memory ASan has poisoned for its own bookkeeping and are reported as buffer overflows -- even though every read is in bounds of a committed, readable page and never faults in a release build. They are false positives intrinsic to running a whole-process memory scanner inside an ASan-instrumented process.
 
-The fix excludes only the deliberate foreign-memory readers from ASan, entirely
-under `#if defined(__SANITIZE_ADDRESS__)`, so release and non-ASan builds are
-byte-for-byte unchanged and the full test suite still runs -- and passes -- under
-ASan with the scanner exercised.
+The fix excludes only the deliberate foreign-memory readers from ASan, entirely under `#if defined(__SANITIZE_ADDRESS__)`, so release and non-ASan builds are byte-for-byte unchanged and the full test suite still runs -- and passes -- under ASan with the scanner exercised.
 
 ## What ASan reports
 
 Building the suite under `msvc-debug-asan` without the fix produces reports like:
 
-- `stack-buffer-underflow` / `global-buffer-overflow` in `find_pattern_raw`
-  (`src/scanner.cpp`), reached via `scan_readable_regions` ->
-  `scan_regions_filtered`. ASan attributes the address to `find_pattern_raw`'s
-  own stack frame, or to an instrumented global.
-- `global-buffer-overflow` in `seh_read_bytes` (`src/memory.cpp`), reached via
-  the RTTI host-module section walk.
+- `stack-buffer-underflow` / `global-buffer-overflow` in `find_pattern_raw` (`src/scanner.cpp`), reached via `scan_readable_regions` -> `scan_regions_filtered`. ASan attributes the address to `find_pattern_raw`'s own stack frame, or to an instrumented global.
+- `global-buffer-overflow` in `seh_read_bytes` (`src/memory.cpp`), reached via the RTTI host-module section walk.
 
 ## Root cause
 
-`scan_readable_regions` enumerates every committed, readable region in the
-current process with `VirtualQuery` and scans each one for the pattern. Among
-those regions are the running thread's own stack and the module's data segments
--- both of which, under ASan, carry poisoned shadow, because ASan surrounds stack
-locals and instrumented globals with redzones.
+`scan_readable_regions` enumerates every committed, readable region in the current process with `VirtualQuery` and scans each one for the pattern. Among those regions are the running thread's own stack and the module's data segments -- both of which, under ASan, carry poisoned shadow, because ASan surrounds stack locals and instrumented globals with redzones.
 
-The scanner's reads stay strictly in bounds of the regions `VirtualQuery`
-reported as readable: the arithmetic in `find_pattern_raw` keeps every access
-inside `[start, start + region_size)`, and the SIMD verify never reads past
-`pattern_start + pattern.size()`. So the reads never fault in a release build.
-They only "fail" because ASan's shadow marks sub-ranges of that mapped, readable
-memory as off-limits to ordinary code. `seh_read_bytes` is the same: its
-`__try`-guarded copy reads a mapped data section that happens to contain an
-instrumented global's redzone.
+The scanner's reads stay strictly in bounds of the regions `VirtualQuery` reported as readable: the arithmetic in `find_pattern_raw` keeps every access inside `[start, start + region_size)`, and the SIMD verify never reads past `pattern_start + pattern.size()`. So the reads never fault in a release build. They only "fail" because ASan's shadow marks sub-ranges of that mapped, readable memory as off-limits to ordinary code. `seh_read_bytes` is the same: its `__try`-guarded copy reads a mapped data section that happens to contain an instrumented global's redzone.
 
-This is the well-known conflict between AddressSanitizer and code that
-intentionally reads memory it does not own (memory scanners, conservative garbage
-collectors, stack walkers). ASan cannot model a process reading its own shadow.
-It never arises in production: DetourModKit scans a separate target process that
-is not built with ASan.
+This is the well-known conflict between AddressSanitizer and code that intentionally reads memory it does not own (memory scanners, conservative garbage collectors, stack walkers). ASan cannot model a process reading its own shadow. It never arises in production: DetourModKit scans a separate target process that is not built with ASan.
 
 ## Two ASan mechanisms, two fixes
 
-A function that reads foreign memory trips ASan two different ways, and each needs
-its own treatment:
+A function that reads foreign memory trips ASan two different ways, and each needs its own treatment:
 
-1. **Compiler load instrumentation.** ASan rewrites the function's own loads to
-   check the shadow first. `__declspec(no_sanitize_address)` removes that
-   instrumentation. On MSVC the attribute is compile-time only and must sit on the
-   function's first declaration.
-2. **libc interceptors.** ASan hot-patches `memchr`, `memcpy`, `memmove`, etc. at
-   runtime, so a call to one checks its range against the shadow regardless of the
-   caller's attributes. `no_sanitize_address` does **not** disable this. The only
-   portable way to avoid it is to not call the intercepted function on foreign
-   memory.
+1. **Compiler load instrumentation.** ASan rewrites the function's own loads to check the shadow first. `__declspec(no_sanitize_address)` removes that instrumentation. On MSVC the attribute is compile-time only and must sit on the function's first declaration.
+2. **libc interceptors.** ASan hot-patches `memchr`, `memcpy`, `memmove`, etc. at runtime, so a call to one checks its range against the shadow regardless of the caller's attributes. `no_sanitize_address` does **not** disable this. The only portable way to avoid it is to not call the intercepted function on foreign memory.
 
 ## The fix
 
-Every change is guarded by `#if defined(__SANITIZE_ADDRESS__)`; release and
-non-ASan builds keep the original `memchr`/`memcpy` and emit identical code.
+Every change is guarded by `#if defined(__SANITIZE_ADDRESS__)`; release and non-ASan builds keep the original `memchr`/`memcpy` and emit identical code.
 
 `src/scanner.cpp`:
 
 - A translation-unit-local `DMK_NO_SANITIZE_ADDRESS` macro (empty off ASan).
-- `no_sanitize_address` on `find_pattern_raw`, `verify_pattern_avx2`, and the
-  `scan_for_byte` helper -- the functions whose instrumented SIMD/scalar loads
-  read the scanned region.
-- `scan_for_byte` replaces the inner-loop `memchr`. Under ASan it scans inline (no
-  interceptor); otherwise it forwards to `memchr`, so release keeps the optimized
-  path.
+- `no_sanitize_address` on `find_pattern_raw`, `verify_pattern_avx2`, and the `scan_for_byte` helper -- the functions whose instrumented SIMD/scalar loads read the scanned region.
+- `scan_for_byte` replaces the inner-loop `memchr`. Under ASan it scans inline (no interceptor); otherwise it forwards to `memchr`, so release keeps the optimized path.
 
 `src/memory.cpp`:
 
-- `seh_read_bytes` copies with the `__movsb` (`rep movsb`) intrinsic under ASan --
-  it emits the copy inline with no interceptable call -- and with `std::memcpy`
-  otherwise. No `no_sanitize_address` is applied here: the copy is the function's
-  only foreign read, and `__movsb` is neither instrumented nor intercepted, so the
-  attribute would suppress nothing and would be dead.
+- `seh_read_bytes` copies with the `__movsb` (`rep movsb`) intrinsic under ASan -- it emits the copy inline with no interceptable call -- and with `std::memcpy` otherwise. No `no_sanitize_address` is applied here: the copy is the function's only foreign read, and `__movsb` is neither instrumented nor intercepted, so the attribute would suppress nothing and would be dead.
 
-What this costs: ASan no longer validates the scanner's own reads of arbitrary
-process memory. That is unavoidable -- those reads are the false-positive source
--- and acceptable: the scanner's bounds logic is still exercised under ASan by the
-tests that scan small, heap-allocated (ASan-tracked) buffers, where a genuine
-over-read would still be caught, and by the full non-ASan suite.
+What this costs: ASan no longer validates the scanner's own reads of arbitrary process memory. That is unavoidable -- those reads are the false-positive source -- and acceptable: the scanner's bounds logic is still exercised under ASan by the tests that scan small, heap-allocated (ASan-tracked) buffers, where a genuine over-read would still be caught, and by the full non-ASan suite.
 
 ## Alternatives considered and rejected
 
-- **Skip the offending tests under ASan.** Removes coverage and is widely
-  considered an anti-pattern; the convention is to exclude the *function* that
-  legitimately bypasses ASan, not the test.
-- **`no_sanitize_address` alone.** Insufficient: it does not stop the
-  `memchr`/`memcpy` interceptors (see above).
-- **Sanitizer ignorelist / special-case-list file.** Unsupported by MSVC
-  AddressSanitizer.
-- **`__asan_unpoison_memory_region`.** Intended only for memory ASan owns;
-  unpoisoning another subsystem's redzones would corrupt ASan's bookkeeping and
-  mask real bugs.
-- **Disabling the intrinsic interceptors globally** (an `ASAN_OPTIONS` knob).
-  Weakens `memcpy`/`memchr` overflow detection across the entire suite.
+- **Skip the offending tests under ASan.** Removes coverage and is widely considered an anti-pattern; the convention is to exclude the *function* that legitimately bypasses ASan, not the test.
+- **`no_sanitize_address` alone.** Insufficient: it does not stop the `memchr`/`memcpy` interceptors (see above).
+- **Sanitizer ignorelist / special-case-list file.** Unsupported by MSVC AddressSanitizer.
+- **`__asan_unpoison_memory_region`.** Intended only for memory ASan owns; unpoisoning another subsystem's redzones would corrupt ASan's bookkeeping and mask real bugs.
+- **Disabling the intrinsic interceptors globally** (an `ASAN_OPTIONS` knob). Weakens `memcpy`/`memchr` overflow detection across the entire suite.
 
 ## Adding a new foreign-memory primitive
 
 If a new function deliberately reads memory the process does not own:
 
-1. Mark it `DMK_NO_SANITIZE_ADDRESS`, with the attribute on its first declaration
-   (on MSVC, the header prototype for an out-of-line function).
-2. Route any `memchr`/`memcpy`/`memmove`/`memset` it performs on that memory
-   around the interceptor under `#if defined(__SANITIZE_ADDRESS__)` -- an inline
-   loop, or `__movsb`/`__stosb` for bulk copies/fills.
+1. Mark it `DMK_NO_SANITIZE_ADDRESS`, with the attribute on its first declaration (on MSVC, the header prototype for an out-of-line function).
+2. Route any `memchr`/`memcpy`/`memmove`/`memset` it performs on that memory around the interceptor under `#if defined(__SANITIZE_ADDRESS__)` -- an inline loop, or `__movsb`/`__stosb` for bulk copies/fills.
 3. Keep the release path on the original libc call so shipped code is unchanged.
 
 ## References
 
-- [MSVC AddressSanitizer language, build, and debugging reference](https://learn.microsoft.com/en-us/cpp/sanitizers/asan-building?view=msvc-170)
-  -- the `__SANITIZE_ADDRESS__` macro, and that `__declspec(no_sanitize_address)`
-  "affects compiler behavior, not runtime behavior" (so it cannot disable the
-  runtime interceptors).
-- [MSVC AddressSanitizer known issues and limitations](https://learn.microsoft.com/en-us/cpp/sanitizers/asan-known-issues?view=msvc-170)
-  -- special-case-list (ignorelist) files are unsupported on MSVC.
-- [Clang AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
-  -- `__attribute__((no_sanitize("address")))`, and the stronger
-  `disable_sanitizer_instrumentation`, for excluding a function that legitimately
-  bypasses ASan.
-- [MaskRay -- All about sanitizer interceptors](https://maskray.me/blog/2023-01-08-all-about-sanitizer-interceptors)
-  -- on Windows, ASan installs its `memchr`/`memcpy`/... interceptors by
-  hot-patching the function entry at run time, which is why a compile-time
-  attribute on the caller cannot suppress them.
-- [google/sanitizers -- AddressSanitizerManualPoisoning](https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning)
-  -- `__asan_poison_memory_region` / `__asan_unpoison_memory_region` apply only to
-  memory ASan owns; they are not a tool for reads of foreign memory.
-- [`__movsb` intrinsic](https://learn.microsoft.com/en-us/cpp/intrinsics/movsb?view=msvc-170)
-  -- emits `rep movsb` inline with no interceptable call; declared in `<intrin.h>`.
+- [MSVC AddressSanitizer language, build, and debugging reference](https://learn.microsoft.com/en-us/cpp/sanitizers/asan-building?view=msvc-170) -- the `__SANITIZE_ADDRESS__` macro, and that `__declspec(no_sanitize_address)` "affects compiler behavior, not runtime behavior" (so it cannot disable the runtime interceptors).
+- [MSVC AddressSanitizer known issues and limitations](https://learn.microsoft.com/en-us/cpp/sanitizers/asan-known-issues?view=msvc-170) -- special-case-list (ignorelist) files are unsupported on MSVC.
+- [Clang AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) -- `__attribute__((no_sanitize("address")))`, and the stronger `disable_sanitizer_instrumentation`, for excluding a function that legitimately bypasses ASan.
+- [MaskRay -- All about sanitizer interceptors](https://maskray.me/blog/2023-01-08-all-about-sanitizer-interceptors) -- on Windows, ASan installs its `memchr`/`memcpy`/... interceptors by hot-patching the function entry at run time, which is why a compile-time attribute on the caller cannot suppress them.
+- [google/sanitizers -- AddressSanitizerManualPoisoning](https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning) -- `__asan_poison_memory_region` / `__asan_unpoison_memory_region` apply only to memory ASan owns; they are not a tool for reads of foreign memory.
+- [`__movsb` intrinsic](https://learn.microsoft.com/en-us/cpp/intrinsics/movsb?view=msvc-170) -- emits `rep movsb` inline with no interceptable call; declared in `<intrin.h>`.

--- a/docs/misc/hot-path-memory.md
+++ b/docs/misc/hot-path-memory.md
@@ -1,11 +1,6 @@
 # Reading Game Memory in Hot Paths
 
-This guide explains how to read and write game memory from code that runs at
-high frequency (per-frame render hooks, per-input-event detours, per-object
-apply loops) without paying the cost that the validation predicates carry. It is
-the reference for the `seh_*` and `read_ptr_*` primitives in
-[`memory.hpp`](../../include/DetourModKit/memory.hpp) and explains when to use
-each one.
+This guide explains how to read and write game memory from code that runs at high frequency (per-frame render hooks, per-input-event detours, per-object apply loops) without paying the cost that the validation predicates carry. It is the reference for the `seh_*` and `read_ptr_*` primitives in [`memory.hpp`](../../include/DetourModKit/memory.hpp) and explains when to use each one.
 
 ## The rule
 
@@ -13,38 +8,17 @@ each one.
 > dereference on a hot path. Read directly under a single SEH frame, optionally
 > pre-screened by a cheap arithmetic guard.
 
-`is_readable` / `is_writable` exist for one-shot setup validation and
-diagnostics. They are correct there and cheap when called a handful of times.
-They are the wrong tool for a path that runs hundreds or thousands of times per
-frame.
+`is_readable` / `is_writable` exist for one-shot setup validation and diagnostics. They are correct there and cheap when called a handful of times. They are the wrong tool for a path that runs hundreds or thousands of times per frame.
 
 ## Why the predicate is the wrong tool on a hot path
 
 `is_readable(addr, size)` does two things that do not belong in a tight loop:
 
-1. **It is not free, even on a cache hit.** A hit takes a per-shard reader lock
-   and a cache lookup. A miss issues a `VirtualQuery` syscall and rebuilds the
-   cache entry under an exclusive lock. When the addresses you check keep
-   changing (a new game object each iteration), almost every lookup misses, so
-   the cost is dominated by syscalls and lock traffic.
+1. **It is not free, even on a cache hit.** A hit takes a per-shard reader lock and a cache lookup. A miss issues a `VirtualQuery` syscall and rebuilds the cache entry under an exclusive lock. When the addresses you check keep changing (a new game object each iteration), almost every lookup misses, so the cost is dominated by syscalls and lock traffic.
 
-2. **It is a time-of-check to time-of-use illusion.** The page state it reports
-   can change between the check returning `true` and your dereference. A pointer
-   that passes the predicate can still fault, so you need a fault guard around
-   the read anyway. Once the read is inside a fault guard, the predicate adds no
-   safety, only cost.
+2. **It is a time-of-check to time-of-use illusion.** The page state it reports can change between the check returning `true` and your dereference. A pointer that passes the predicate can still fault, so you need a fault guard around the read anyway. Once the read is inside a fault guard, the predicate adds no safety, only cost.
 
-Concretely: a hook that resolves an object and reads eight dependent fields off
-it across a few distinct (cache-missing) objects can cost one to two orders of
-magnitude more per call when each read is gated than when the reads run directly
-under one fault guard. The multiplier is dominated by `VirtualQuery` latency on
-cache misses, the cache-miss rate, and shard-lock contention, so it varies by
-CPU, Windows build, and address-space size. At a few hundred such calls per
-frame that is the difference between imperceptible and a multi-millisecond frame
-spike. Build with `-DDMK_BUILD_BENCHMARKS=ON`, run the `DetourModKit_bench_memory`
-target (Phase 6 of `tests/bench_memory.cpp`), and read the
-`probe_gated_over_direct` value to measure it on your target. Recorded numbers
-and methodology are in [the memory benchmark notes](../analysis/memory_bench_v3.x/README.md).
+Concretely: a hook that resolves an object and reads eight dependent fields off it across a few distinct (cache-missing) objects can cost one to two orders of magnitude more per call when each read is gated than when the reads run directly under one fault guard. The multiplier is dominated by `VirtualQuery` latency on cache misses, the cache-miss rate, and shard-lock contention, so it varies by CPU, Windows build, and address-space size. At a few hundred such calls per frame that is the difference between imperceptible and a multi-millisecond frame spike. Build with `-DDMK_BUILD_BENCHMARKS=ON`, run the `DetourModKit_bench_memory` target (Phase 6 of `tests/bench_memory.cpp`), and read the `probe_gated_over_direct` value to measure it on your target. Recorded numbers and methodology are in [the memory benchmark notes](../analysis/memory_bench_v3.x/README.md).
 
 ## The pattern
 
@@ -88,9 +62,7 @@ bool probe_object(uintptr_t obj, ObjectFields &out) noexcept
 }
 ```
 
-For frame hooks, keep the hook body limited to cached state, branch-only guards,
-and one guarded read path. Resolve signatures, RTTI identities, and offsets
-outside the hook.
+For frame hooks, keep the hook body limited to cached state, branch-only guards, and one guarded read path. Resolve signatures, RTTI identities, and offsets outside the hook.
 
 ```cpp
 namespace Mem = DetourModKit::Memory;
@@ -117,12 +89,7 @@ void camera_update_hook(void *camera, float delta_time)
 }
 ```
 
-For a multi-level pointer chain, resolve the whole chain under one fault guard
-rather than calling `seh_read` once per link. The combined walk is one
-out-of-line call instead of N, keeps each link in a register instead of
-round-tripping it through `std::optional`, and validates its arguments once. (It
-does not save SEH-frame setup: on MSVC/x64 a `__try` success path is
-table-driven and free, so N of them cost nothing extra either.)
+For a multi-level pointer chain, resolve the whole chain under one fault guard rather than calling `seh_read` once per link. The combined walk is one out-of-line call instead of N, keeps each link in a register instead of round-tripping it through `std::optional`, and validates its arguments once. (It does not save SEH-frame setup: on MSVC/x64 a `__try` success path is table-driven and free, so N of them cost nothing extra either.)
 
 ```cpp
 // (*(*(base + 0x10) + 0x28)) + 0x8, read as a float, all under one guard.
@@ -149,12 +116,7 @@ if (value)
 
 ## Toolchain note
 
-The `seh_*` primitives use real `__try` / `__except` on MSVC, where the success
-path is table-driven and costs nothing extra. On MinGW (which has no SEH) they
-fall back to a `VirtualQuery`-guarded read, which is correct but pays a syscall;
-prefer `read_ptr_unchecked` on MinGW hot paths where you can guarantee
-structural validity. Shipping mod builds target MSVC, so the zero-cost path is
-the normal case.
+The `seh_*` primitives use real `__try` / `__except` on MSVC, where the success path is table-driven and costs nothing extra. On MinGW (which has no SEH) they fall back to a `VirtualQuery`-guarded read, which is correct but pays a syscall; prefer `read_ptr_unchecked` on MinGW hot paths where you can guarantee structural validity. Shipping mod builds target MSVC, so the zero-cost path is the normal case.
 
 ## Anti-patterns to remove
 

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -361,10 +361,7 @@ cmake --build build/mingw-release --parallel
 
 ## Installed Package Smoke Test
 
-`tests/package_smoke` is a minimal consumer project for validating installed
-release packages. It uses `find_package(DetourModKit REQUIRED)`, links
-`DetourModKit::DetourModKit`, and touches `HookManager` so the static
-dependency archives are required by the final link.
+`tests/package_smoke` is a minimal consumer project for validating installed release packages. It uses `find_package(DetourModKit REQUIRED)`, links `DetourModKit::DetourModKit`, and touches `HookManager` so the static dependency archives are required by the final link.
 
 ```bash
 cmake -S tests/package_smoke -B build/package-smoke-mingw -G Ninja \
@@ -375,8 +372,7 @@ cmake --build build/package-smoke-mingw --parallel
 ctest --test-dir build/package-smoke-mingw --output-on-failure
 ```
 
-The release workflow runs this smoke project for both MinGW and MSVC after
-installing the package and before uploading release artifacts.
+The release workflow runs this smoke project for both MinGW and MSVC after installing the package and before uploading release artifacts.
 
 ## Project Structure
 

--- a/docs/tests/test_compile.cpp
+++ b/docs/tests/test_compile.cpp
@@ -1,1 +1,4 @@
-int main() { return 0; }  
+int main()
+{
+    return 0;
+}

--- a/include/DetourModKit/anchors.hpp
+++ b/include/DetourModKit/anchors.hpp
@@ -49,13 +49,20 @@ namespace DetourModKit
          */
         enum class AnchorKind : std::uint8_t
         {
-            VtableIdentity, ///< Rtti::vtable_for_type -> a class vtable address by name.
-            RipGlobal,      ///< Scanner cascade -> an absolute address (Direct or RipRelative candidates).
-            CodeOperand,    ///< Scanner::read_code_constant -> an in-code immediate/displacement value.
-            StringXref,     ///< Scanner::find_string_xref -> the instruction (or function) referencing a string literal.
-            Manual,         ///< A pinned literal; surfaced as at-risk in a report.
-            CallArgHome,    ///< Reserved for a future prologue-dataflow backend; not yet resolvable.
-            Quorum          ///< Two independent sub-anchors that must resolve and agree before acceptance.
+            /// Rtti::vtable_for_type -> a class vtable address by name.
+            VtableIdentity,
+            /// Scanner cascade -> an absolute address (Direct or RipRelative candidates).
+            RipGlobal,
+            /// Scanner::read_code_constant -> an in-code immediate/displacement value.
+            CodeOperand,
+            /// Scanner::find_string_xref -> the instruction (or function) referencing a string literal.
+            StringXref,
+            /// A pinned literal; surfaced as at-risk in a report.
+            Manual,
+            /// Reserved for a future prologue-dataflow backend; not yet resolvable.
+            CallArgHome,
+            /// Two independent sub-anchors that must resolve and agree before acceptance.
+            Quorum
         };
 
         /**
@@ -64,8 +71,10 @@ namespace DetourModKit
          */
         enum class QuorumMatch : std::uint8_t
         {
-            ExactValue,     ///< Both sub-anchors must resolve to the identical value.
-            WithinTolerance ///< Resolved values may differ by at most @ref Anchor::quorum_tolerance.
+            /// Both sub-anchors must resolve to the identical value.
+            ExactValue,
+            /// Resolved values may differ by at most @ref Anchor::quorum_tolerance.
+            WithinTolerance
         };
 
         /**
@@ -74,10 +83,14 @@ namespace DetourModKit
          */
         enum class AnchorStatus : std::uint8_t
         {
-            Unresolved,  ///< Not yet attempted.
-            Resolved,    ///< Resolved; @ref ResolvedAnchor::value is valid.
-            Failed,      ///< The backend failed (fail closed: no value).
-            Unsupported  ///< The kind has no backend yet (CallArgHome).
+            /// Not yet attempted.
+            Unresolved,
+            /// Resolved; @ref ResolvedAnchor::value is valid.
+            Resolved,
+            /// The backend failed (fail closed: no value).
+            Failed,
+            /// The kind has no backend yet (CallArgHome).
+            Unsupported
         };
 
         /**
@@ -108,25 +121,36 @@ namespace DetourModKit
          */
         struct Anchor
         {
-            std::string_view label;                  ///< Human-readable id, echoed in the result.
-            AnchorKind kind = AnchorKind::Manual;    ///< Which backend resolves this anchor.
+            /// Human-readable id, echoed in the result.
+            std::string_view label;
+            /// Which backend resolves this anchor.
+            AnchorKind kind = AnchorKind::Manual;
 
-            std::string_view mangled;                ///< VtableIdentity: the class mangled name.
+            /// VtableIdentity: the class mangled name.
+            std::string_view mangled;
 
-            std::span<const Scanner::AddrCandidate> site; ///< RipGlobal / CodeOperand: the cascade.
-            Scanner::OperandKind operand_kind = Scanner::OperandKind::Immediate; ///< CodeOperand.
-            std::uint8_t operand_index = 0;          ///< CodeOperand: visible operand index.
-            std::uint8_t byte_width = 0;             ///< CodeOperand: 0 = decoded width.
+            /// RipGlobal / CodeOperand: the cascade.
+            std::span<const Scanner::AddrCandidate> site;
+            /// CodeOperand.
+            Scanner::OperandKind operand_kind = Scanner::OperandKind::Immediate;
+            /// CodeOperand: visible operand index.
+            std::uint8_t operand_index = 0;
+            /// CodeOperand: 0 = decoded width.
+            std::uint8_t byte_width = 0;
 
-            std::string_view xref_text;              ///< StringXref: the string literal content.
-            Scanner::StringEncoding xref_encoding =
-                Scanner::StringEncoding::Utf8;       ///< StringXref: how the string is stored.
-            Scanner::XrefReturn xref_return =
-                Scanner::XrefReturn::ReferencingInstruction; ///< StringXref: instruction vs function.
-            bool xref_require_terminator = true;     ///< StringXref: match a trailing NUL.
-            bool xref_broad_match = false;           ///< StringXref: keep lea/mov scan and add Zydis rarer shapes.
+            /// StringXref: the string literal content.
+            std::string_view xref_text;
+            /// StringXref: how the string is stored.
+            Scanner::StringEncoding xref_encoding = Scanner::StringEncoding::Utf8;
+            /// StringXref: instruction vs function.
+            Scanner::XrefReturn xref_return = Scanner::XrefReturn::ReferencingInstruction;
+            /// StringXref: match a trailing NUL.
+            bool xref_require_terminator = true;
+            /// StringXref: keep lea/mov scan and add Zydis rarer shapes.
+            bool xref_broad_match = false;
 
-            std::int64_t manual_value = 0;           ///< Manual: the pinned literal.
+            /// Manual: the pinned literal.
+            std::int64_t manual_value = 0;
 
             /**
              * @brief Optional fail-closed post-resolve check. nullptr (default)
@@ -145,10 +169,14 @@ namespace DetourModKit
             /// Opaque pointer passed verbatim to @ref validator; nullptr if unused.
             const void *validator_context = nullptr;
 
-            const Anchor *quorum_a = nullptr;        ///< Quorum: first independent sub-anchor (non-owning).
-            const Anchor *quorum_b = nullptr;        ///< Quorum: second independent sub-anchor (non-owning).
-            QuorumMatch quorum_match = QuorumMatch::ExactValue; ///< Quorum: how the two values must agree.
-            std::int64_t quorum_tolerance = 0;       ///< Quorum: max |first - second| when WithinTolerance.
+            /// Quorum: first independent sub-anchor (non-owning).
+            const Anchor *quorum_a = nullptr;
+            /// Quorum: second independent sub-anchor (non-owning).
+            const Anchor *quorum_b = nullptr;
+            /// Quorum: how the two values must agree.
+            QuorumMatch quorum_match = QuorumMatch::ExactValue;
+            /// Quorum: max |first - second| when WithinTolerance.
+            std::int64_t quorum_tolerance = 0;
         };
 
         /**

--- a/include/DetourModKit/async_logger.hpp
+++ b/include/DetourModKit/async_logger.hpp
@@ -87,7 +87,6 @@ namespace DetourModKit
             alignas(64) char data[POOL_SLOTS_PER_BLOCK * sizeof(PoolSlot)];
             Block *next{nullptr};
             PoolSlot *free_list{nullptr};
-            size_t slot_count{0};
             uint32_t constructed_mask{0};
 
             PoolSlot *get_slot(size_t index) noexcept
@@ -105,7 +104,6 @@ namespace DetourModKit
         void return_slot_locked(PoolSlot *slot, Block *block) noexcept;
 
         std::atomic<Block *> m_head{nullptr};
-        std::atomic<size_t> m_pool_size{0};
         std::atomic<size_t> m_heap_fallback_count{0};
         std::mutex m_pool_mutex;
     };
@@ -156,7 +154,8 @@ namespace DetourModKit
      */
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : 4324) // structure was padded due to alignment specifier
+// structure was padded due to alignment specifier
+#pragma warning(disable : 4324)
 #endif
 
     class DynamicMPMCQueue
@@ -216,7 +215,8 @@ namespace DetourModKit
             std::atomic<size_t> sequence;
             LogMessage data;
 
-            Slot() noexcept : sequence(0) {}
+            Slot() noexcept
+                : sequence(0) {}
 
             Slot(const Slot &) = delete;
             Slot &operator=(const Slot &) = delete;
@@ -224,8 +224,10 @@ namespace DetourModKit
             Slot &operator=(Slot &&) = delete;
         };
 
-        /// Validates capacity before member initialization to prevent
-        /// allocation of an invalid-sized buffer in the initializer list.
+        /**
+         * @brief Validates capacity before member initialization to prevent
+         *        allocation of an invalid-sized buffer in the initializer list.
+         */
         static size_t validated_capacity(size_t capacity);
 
         // Immutable after construction -- never resized.

--- a/include/DetourModKit/bootstrap.hpp
+++ b/include/DetourModKit/bootstrap.hpp
@@ -55,8 +55,9 @@ namespace DetourModKit
          *          shutdown event until on_dll_detach() is invoked.
          *
          *          init_fn is invoked on the worker thread (off the loader
-         *          lock). It should return true on success; a false return
-         *          is logged and the worker exits cleanly.
+         *          lock). It should return true on success; a false return is
+         *          logged and the worker then idles, blocking on the shutdown
+         *          event until on_dll_detach() signals it (it does not exit early).
          *
          *          shutdown_fn is invoked on the worker thread after the
          *          shutdown event is signaled, then DMK_Shutdown() is

--- a/include/DetourModKit/config.hpp
+++ b/include/DetourModKit/config.hpp
@@ -244,21 +244,18 @@ namespace DetourModKit
         {
             if constexpr (std::same_as<T, int>)
             {
-                register_int(section, ini_key, log_key_name,
-                             [&out](int v) { out.store(v, std::memory_order_relaxed); },
-                             default_value);
+                register_int(section, ini_key, log_key_name, [&out](int v)
+                             { out.store(v, std::memory_order_relaxed); }, default_value);
             }
             else if constexpr (std::same_as<T, bool>)
             {
-                register_bool(section, ini_key, log_key_name,
-                              [&out](bool v) { out.store(v, std::memory_order_relaxed); },
-                              default_value);
+                register_bool(section, ini_key, log_key_name, [&out](bool v)
+                              { out.store(v, std::memory_order_relaxed); }, default_value);
             }
             else
             {
-                register_float(section, ini_key, log_key_name,
-                               [&out](float v) { out.store(v, std::memory_order_relaxed); },
-                               default_value);
+                register_float(section, ini_key, log_key_name, [&out](float v)
+                               { out.store(v, std::memory_order_relaxed); }, default_value);
             }
         }
 
@@ -401,10 +398,14 @@ namespace DetourModKit
          */
         enum class AutoReloadStatus
         {
-            Started,         ///< Watcher is now running.
-            AlreadyRunning,  ///< Called twice; the existing watcher was kept.
-            NoPriorLoad,     ///< Config::load() was never called; no path to watch.
-            StartFailed      ///< Directory could not be opened or start handshake failed.
+            /// Watcher is now running.
+            Started,
+            /// Called twice; the existing watcher was kept.
+            AlreadyRunning,
+            /// Config::load() was never called; no path to watch.
+            NoPriorLoad,
+            /// Directory could not be opened or start handshake failed.
+            StartFailed
         };
 
         /**

--- a/include/DetourModKit/diagnostics.hpp
+++ b/include/DetourModKit/diagnostics.hpp
@@ -33,7 +33,8 @@ namespace DetourModKit
             MemoryCache,
             Worker,
             Bootstrap,
-            Count ///< Sentinel: the number of tracked subsystems. Not a subsystem.
+            /// Sentinel: the number of tracked subsystems. Not a subsystem.
+            Count
         };
 
         /**

--- a/include/DetourModKit/drift_manifest.hpp
+++ b/include/DetourModKit/drift_manifest.hpp
@@ -32,12 +32,18 @@ namespace DetourModKit
          */
         struct DriftRecord
         {
-            std::string name;                  ///< The landmark name (owned).
-            std::ptrdiff_t nominal_offset = 0; ///< Last-known offset recorded at write time.
-            std::ptrdiff_t healed_offset = 0;  ///< Resolved offset (meaningful only when @ref ok).
-            std::ptrdiff_t delta = 0;          ///< healed_offset - nominal_offset (meaningful only when @ref ok).
-            bool ok = false;                   ///< Whether the landmark healed.
-            HealError error{};                 ///< Failure reason (meaningful only when @ref ok is false).
+            /// The landmark name (owned).
+            std::string name;
+            /// Last-known offset recorded at write time.
+            std::ptrdiff_t nominal_offset = 0;
+            /// Resolved offset (meaningful only when @ref ok).
+            std::ptrdiff_t healed_offset = 0;
+            /// healed_offset - nominal_offset (meaningful only when @ref ok).
+            std::ptrdiff_t delta = 0;
+            /// Whether the landmark healed.
+            bool ok = false;
+            /// Failure reason (meaningful only when @ref ok is false).
+            HealError error{};
         };
 
         /**
@@ -46,8 +52,10 @@ namespace DetourModKit
          */
         enum class ManifestError : std::uint8_t
         {
-            MissingHeader, ///< The first non-blank line was not the manifest header.
-            MalformedLine  ///< A record line had the wrong field count or an unparseable field.
+            /// The first non-blank line was not the manifest header.
+            MissingHeader,
+            /// A record line had the wrong field count or an unparseable field.
+            MalformedLine
         };
 
         /**

--- a/include/DetourModKit/event_dispatcher.hpp
+++ b/include/DetourModKit/event_dispatcher.hpp
@@ -272,13 +272,14 @@ namespace DetourModKit
                 // that has already been installed in the snapshot.
                 this->m_handler_count.store(next->size(), std::memory_order_release);
                 this->m_handlers.store(std::shared_ptr<const HandlerList>(std::move(next)),
-                                      std::memory_order_release);
+                                       std::memory_order_release);
             }
 
             std::weak_ptr<void> weak = this->m_alive;
             return Subscription(
                 std::move(weak),
-                [this, id]() noexcept -> bool { return this->unsubscribe(id); });
+                [this, id]() noexcept -> bool
+                { return this->unsubscribe(id); });
         }
 
         /**
@@ -431,7 +432,8 @@ namespace DetourModKit
             std::scoped_lock lock{this->m_writer_mutex};
             auto current = this->m_handlers.load(std::memory_order_acquire);
             auto it = std::find_if(current->begin(), current->end(),
-                                   [id](const Entry &entry) { return entry.id == id; });
+                                   [id](const Entry &entry)
+                                   { return entry.id == id; });
             if (it == current->end())
             {
                 // Not found; treat as successful (idempotent unsubscribe).
@@ -465,7 +467,7 @@ namespace DetourModKit
             // stale snapshot containing the removed handler is still safe
             // because the handler callable is retained by the old snapshot.
             this->m_handlers.store(std::shared_ptr<const HandlerList>(std::move(next)),
-                                  std::memory_order_release);
+                                   std::memory_order_release);
             this->m_handler_count.store(current->size() - 1, std::memory_order_release);
             return true;
         }
@@ -488,7 +490,8 @@ namespace DetourModKit
         struct EmitGuard
         {
             int &depth;
-            explicit EmitGuard(int &depth_ref) noexcept : depth(depth_ref) { ++depth; }
+            explicit EmitGuard(int &depth_ref) noexcept
+                : depth(depth_ref) { ++depth; }
             ~EmitGuard() noexcept { --depth; }
             EmitGuard(const EmitGuard &) = delete;
             EmitGuard &operator=(const EmitGuard &) = delete;
@@ -503,8 +506,9 @@ namespace DetourModKit
         std::atomic<size_t> m_handler_count{0};
         std::atomic<uint64_t> m_next_id{1};
         std::mutex m_writer_mutex; // serializes writers only
-        std::shared_ptr<void> m_alive; // Prevents Subscription::reset() from calling
-                                      // unsubscribe() after dispatcher destruction.
+        // Prevents Subscription::reset() from calling unsubscribe() after
+        // dispatcher destruction.
+        std::shared_ptr<void> m_alive;
     };
 
 } // namespace DetourModKit

--- a/include/DetourModKit/hook_manager.hpp
+++ b/include/DetourModKit/hook_manager.hpp
@@ -706,8 +706,8 @@ namespace DetourModKit
          */
         template <typename F>
             requires std::invocable<F, safetyhook::VmHook &> &&
-                     (!std::is_void_v<std::invoke_result_t<F, safetyhook::VmHook &>>) &&
-                     (!std::is_reference_v<std::invoke_result_t<F, safetyhook::VmHook &>>)
+                         (!std::is_void_v<std::invoke_result_t<F, safetyhook::VmHook &>>) &&
+                         (!std::is_reference_v<std::invoke_result_t<F, safetyhook::VmHook &>>)
         [[nodiscard]] auto with_vmt_method(std::string_view vmt_name, size_t method_index, F &&fn)
             -> std::optional<std::invoke_result_t<F, safetyhook::VmHook &>>
         {
@@ -900,8 +900,8 @@ namespace DetourModKit
          */
         template <typename F>
             requires std::invocable<F, InlineHook &> &&
-                     (!std::is_void_v<std::invoke_result_t<F, InlineHook &>>) &&
-                     (!std::is_reference_v<std::invoke_result_t<F, InlineHook &>>)
+                         (!std::is_void_v<std::invoke_result_t<F, InlineHook &>>) &&
+                         (!std::is_reference_v<std::invoke_result_t<F, InlineHook &>>)
         [[nodiscard]] auto with_inline_hook(std::string_view hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
@@ -965,8 +965,8 @@ namespace DetourModKit
          */
         template <typename F>
             requires std::invocable<F, InlineHook &> &&
-                     (!std::is_void_v<std::invoke_result_t<F, InlineHook &>>) &&
-                     (!std::is_reference_v<std::invoke_result_t<F, InlineHook &>>)
+                         (!std::is_void_v<std::invoke_result_t<F, InlineHook &>>) &&
+                         (!std::is_reference_v<std::invoke_result_t<F, InlineHook &>>)
         [[nodiscard]] auto try_with_inline_hook(std::string_view hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, InlineHook &>>
         {
@@ -1004,8 +1004,8 @@ namespace DetourModKit
          */
         template <typename F>
             requires std::invocable<F, MidHook &> &&
-                     (!std::is_void_v<std::invoke_result_t<F, MidHook &>>) &&
-                     (!std::is_reference_v<std::invoke_result_t<F, MidHook &>>)
+                         (!std::is_void_v<std::invoke_result_t<F, MidHook &>>) &&
+                         (!std::is_reference_v<std::invoke_result_t<F, MidHook &>>)
         [[nodiscard]] auto with_mid_hook(std::string_view hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
@@ -1069,8 +1069,8 @@ namespace DetourModKit
          */
         template <typename F>
             requires std::invocable<F, MidHook &> &&
-                     (!std::is_void_v<std::invoke_result_t<F, MidHook &>>) &&
-                     (!std::is_reference_v<std::invoke_result_t<F, MidHook &>>)
+                         (!std::is_void_v<std::invoke_result_t<F, MidHook &>>) &&
+                         (!std::is_reference_v<std::invoke_result_t<F, MidHook &>>)
         [[nodiscard]] auto try_with_mid_hook(std::string_view hook_id, F &&fn)
             -> std::optional<std::invoke_result_t<F, MidHook &>>
         {
@@ -1125,7 +1125,8 @@ namespace DetourModKit
         struct ReentrancyGuard
         {
             int &counter;
-            explicit ReentrancyGuard(int &cnt) noexcept : counter(cnt) { ++counter; }
+            explicit ReentrancyGuard(int &cnt) noexcept
+                : counter(cnt) { ++counter; }
             ~ReentrancyGuard() noexcept { --counter; }
             ReentrancyGuard(const ReentrancyGuard &) = delete;
             ReentrancyGuard &operator=(const ReentrancyGuard &) = delete;

--- a/include/DetourModKit/input.hpp
+++ b/include/DetourModKit/input.hpp
@@ -384,9 +384,12 @@ namespace DetourModKit
         // Interception gates, recomputed alongside the modifier caches. Each
         // decides whether an active-input hook is installed lazily by the poll
         // loop, so a mod that never opts in pays no interception cost.
-        std::atomic<bool> m_has_wheel_bindings{false};          // any MouseWheel trigger -> WndProc hook
-        std::atomic<bool> m_has_consume_gamepad_bindings{false}; // any consume gamepad binding -> XInput hook
-        std::atomic<bool> m_has_wheel_consume_bindings{false};   // any consume wheel binding -> swallow wheel messages
+        // any MouseWheel trigger -> WndProc hook
+        std::atomic<bool> m_has_wheel_bindings{false};
+        // any consume gamepad binding -> XInput hook
+        std::atomic<bool> m_has_consume_gamepad_bindings{false};
+        // any consume wheel binding -> swallow wheel messages
+        std::atomic<bool> m_has_wheel_consume_bindings{false};
     };
 
     /**

--- a/include/DetourModKit/input_codes.hpp
+++ b/include/DetourModKit/input_codes.hpp
@@ -86,28 +86,40 @@ namespace DetourModKit
      * @param vk The VK code (e.g., 0x41 for 'A').
      * @return InputCode Tagged as Keyboard.
      */
-    constexpr InputCode keyboard_key(int vk) noexcept { return {InputSource::Keyboard, vk}; }
+    constexpr InputCode keyboard_key(int vk) noexcept
+    {
+        return {InputSource::Keyboard, vk};
+    }
 
     /**
      * @brief Creates a mouse InputCode from a Windows Virtual Key code.
      * @param vk The VK code (e.g., 0x01 for VK_LBUTTON).
      * @return InputCode Tagged as Mouse.
      */
-    constexpr InputCode mouse_button(int vk) noexcept { return {InputSource::Mouse, vk}; }
+    constexpr InputCode mouse_button(int vk) noexcept
+    {
+        return {InputSource::Mouse, vk};
+    }
 
     /**
      * @brief Creates a gamepad InputCode from an XInput button code.
      * @param code The XInput button mask or synthetic trigger code (see GamepadCode).
      * @return InputCode Tagged as Gamepad.
      */
-    constexpr InputCode gamepad_button(int code) noexcept { return {InputSource::Gamepad, code}; }
+    constexpr InputCode gamepad_button(int code) noexcept
+    {
+        return {InputSource::Gamepad, code};
+    }
 
     /**
      * @brief Creates a mouse-wheel InputCode from a wheel direction code.
      * @param code The wheel direction identifier (see WheelCode).
      * @return InputCode Tagged as MouseWheel.
      */
-    constexpr InputCode mouse_wheel(int code) noexcept { return {InputSource::MouseWheel, code}; }
+    constexpr InputCode mouse_wheel(int code) noexcept
+    {
+        return {InputSource::MouseWheel, code};
+    }
 
     /**
      * @namespace GamepadCode
@@ -138,8 +150,10 @@ namespace DetourModKit
         inline constexpr int LeftTrigger = 0x10000;
         inline constexpr int RightTrigger = 0x10001;
 
-        /// Synthetic codes for thumbstick axes treated as digital inputs.
-        /// Each direction fires when the axis exceeds the stick deadzone threshold.
+        /**
+         * @brief Synthetic codes for thumbstick axes treated as digital inputs.
+         * @details Each direction fires when the axis exceeds the stick deadzone threshold.
+         */
         inline constexpr int LeftStickUp = 0x10002;
         inline constexpr int LeftStickDown = 0x10003;
         inline constexpr int LeftStickLeft = 0x10004;
@@ -152,8 +166,10 @@ namespace DetourModKit
         /// Default analog trigger threshold (0-255 range, values above are "pressed").
         inline constexpr int TriggerThreshold = 30;
 
-        /// Default thumbstick deadzone threshold (0-32767 range).
-        /// Matches XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE (7849).
+        /**
+         * @brief Default thumbstick deadzone threshold (0-32767 range).
+         * @details Matches XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE (7849).
+         */
         inline constexpr int StickThreshold = 7849;
     } // namespace GamepadCode
 

--- a/include/DetourModKit/logger.hpp
+++ b/include/DetourModKit/logger.hpp
@@ -189,9 +189,11 @@ namespace DetourModKit
             }
         }
 
-        /// @name Convenience log methods
-        /// Shorthand for `log(LogLevel::X, fmt, args...)`. See log() for parameter docs.
-        /// @{
+        /**
+         * @name Convenience log methods
+         * @brief Shorthand for `log(LogLevel::X, fmt, args...)`. See log() for parameter docs.
+         * @{
+         */
         template <typename... Args>
         void trace(std::format_string<Args...> fmt, Args &&...args)
         {
@@ -221,7 +223,7 @@ namespace DetourModKit
         {
             log(LogLevel::Error, fmt, std::forward<Args>(args)...);
         }
-        /// @}
+        /** @} */
 
         /**
          * @brief Converts a log level string to the LogLevel enum.

--- a/include/DetourModKit/memory.hpp
+++ b/include/DetourModKit/memory.hpp
@@ -79,8 +79,8 @@ namespace DetourModKit
          * @note Starts a background cleanup thread that runs periodically.
          */
         [[nodiscard]] bool init_cache(size_t cache_size = DEFAULT_CACHE_SIZE,
-                        unsigned int expiry_ms = DEFAULT_CACHE_EXPIRY_MS,
-                        size_t shard_count = DEFAULT_CACHE_SHARD_COUNT);
+                                      unsigned int expiry_ms = DEFAULT_CACHE_EXPIRY_MS,
+                                      size_t shard_count = DEFAULT_CACHE_SHARD_COUNT);
 
         /**
          * @brief Clears all entries from the memory region cache.
@@ -306,8 +306,10 @@ namespace DetourModKit
          */
         struct ModuleRange
         {
-            uintptr_t base = 0; ///< Mapped base address (equal to the HMODULE value).
-            uintptr_t end = 0;  ///< Exclusive upper bound (base + SizeOfImage from the PE OptionalHeader).
+            /// Mapped base address (equal to the HMODULE value).
+            uintptr_t base = 0;
+            /// Exclusive upper bound (base + SizeOfImage from the PE OptionalHeader).
+            uintptr_t end = 0;
 
             /// True iff this range is populated (base != 0 && end > base).
             [[nodiscard]] constexpr bool valid() const noexcept { return base != 0 && end > base; }

--- a/include/DetourModKit/profiler.hpp
+++ b/include/DetourModKit/profiler.hpp
@@ -54,15 +54,21 @@
 // array-reference binding accepts any array, including function-local
 // `char buf[N]`. Callers remain responsible for static-storage lifetime.
 // Prefer string literals or namespace-scope `static constexpr char` arrays.
-#define DMK_PROFILE_SCOPE(name) \
-    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_, __LINE__) { name }
+#define DMK_PROFILE_SCOPE(name)                                             \
+    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_, __LINE__) \
+    {                                                                       \
+        name                                                                \
+    }
 
 // Scoped timing using the enclosing function name. `__func__` is a static-
 // storage array per [dcl.fct.def.general]/8, so it binds to the array-
 // reference constructor and the stored pointer remains valid for the
 // lifetime of the process.
-#define DMK_PROFILE_FUNCTION() \
-    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_func_, __LINE__) { __func__ }
+#define DMK_PROFILE_FUNCTION()                                                   \
+    ::DetourModKit::ScopedProfile DMK_CONCAT(dmk_scoped_profile_func_, __LINE__) \
+    {                                                                            \
+        __func__                                                                 \
+    }
 
 #else
 
@@ -82,7 +88,8 @@ namespace DetourModKit
      */
     struct ProfileSample
     {
-        std::atomic<uint32_t> sequence{0}; ///< Odd = write in progress, even = committed.
+        /// Odd = write in progress, even = committed.
+        std::atomic<uint32_t> sequence{0};
         /**
          * @brief Non-owning pointer to the sample name.
          * @note Caller must ensure the pointed-to string outlives the
@@ -92,9 +99,12 @@ namespace DetourModKit
          *       it does NOT verify static-storage.
          */
         const char *name{nullptr};
-        int64_t start_ticks{0};  ///< QPC tick count at scope entry.
-        uint32_t duration_us{0}; ///< Duration in microseconds (max ~71 minutes).
-        uint32_t thread_id{0};   ///< Win32 thread ID of the recording thread.
+        /// QPC tick count at scope entry.
+        int64_t start_ticks{0};
+        /// Duration in microseconds (max ~71 minutes).
+        uint32_t duration_us{0};
+        /// Win32 thread ID of the recording thread.
+        uint32_t thread_id{0};
 
         ProfileSample() noexcept = default;
         ProfileSample(const ProfileSample &) = delete;

--- a/include/DetourModKit/rtti_dissect.hpp
+++ b/include/DetourModKit/rtti_dissect.hpp
@@ -42,12 +42,16 @@ namespace DetourModKit
      */
     namespace Rtti
     {
-        /// Hard cap on a self-heal search radius (bytes per side). Bounds the
-        /// worst-case probe count so an accidental SIZE_MAX window cannot hang.
+        /**
+         * @brief Hard cap on a self-heal search radius (bytes per side). Bounds the
+         *        worst-case probe count so an accidental SIZE_MAX window cannot hang.
+         */
         inline constexpr std::size_t MAX_HEAL_WINDOW = 4096;
 
-        /// Hard cap on the number of landmarks in one @ref solve_fingerprint
-        /// template.
+        /**
+         * @brief Hard cap on the number of landmarks in one @ref solve_fingerprint
+         *        template.
+         */
         inline constexpr std::size_t MAX_FINGERPRINT_LANDMARKS = 32;
 
         /**
@@ -64,17 +68,28 @@ namespace DetourModKit
          */
         struct PointeeType
         {
-            std::uintptr_t vtable = 0;        ///< Resolved vtable pointer.
-            std::uintptr_t col_addr = 0;      ///< COL the vtable points back to.
-            std::uintptr_t td_addr = 0;       ///< TypeDescriptor base.
-            std::uintptr_t name_addr = 0;     ///< Mangled-name buffer (td_addr + 0x10).
-            std::uintptr_t object_base = 0;   ///< Start of the resolved (sub)object.
-            std::uintptr_t complete_obj = 0;  ///< object_base - col_offset (underflow-clamped).
-            std::uintptr_t pointer_value = 0; ///< Raw qword read at the probed slot.
-            std::uint32_t col_offset = 0;     ///< COL.offset (+0x04): this vtable's offset in the complete object.
-            bool was_pointer = false;         ///< true when the slot held a pointer-to-object (deref'd once).
-            std::uint16_t name_len = 0;       ///< Length of the mangled name in @ref name_buf.
-            char name_buf[Rtti::MAX_TYPE_NAME_LEN + 1] = {}; ///< NUL-terminated mangled name.
+            /// Resolved vtable pointer.
+            std::uintptr_t vtable = 0;
+            /// COL the vtable points back to.
+            std::uintptr_t col_addr = 0;
+            /// TypeDescriptor base.
+            std::uintptr_t td_addr = 0;
+            /// Mangled-name buffer (td_addr + 0x10).
+            std::uintptr_t name_addr = 0;
+            /// Start of the resolved (sub)object.
+            std::uintptr_t object_base = 0;
+            /// object_base - col_offset (underflow-clamped).
+            std::uintptr_t complete_obj = 0;
+            /// Raw qword read at the probed slot.
+            std::uintptr_t pointer_value = 0;
+            /// COL.offset (+0x04): this vtable's offset in the complete object.
+            std::uint32_t col_offset = 0;
+            /// true when the slot held a pointer-to-object (deref'd once).
+            bool was_pointer = false;
+            /// Length of the mangled name in @ref name_buf.
+            std::uint16_t name_len = 0;
+            /// NUL-terminated mangled name.
+            char name_buf[Rtti::MAX_TYPE_NAME_LEN + 1] = {};
 
             /// Non-owning view of the mangled name held in @ref name_buf.
             [[nodiscard]] std::string_view name() const noexcept
@@ -116,9 +131,12 @@ namespace DetourModKit
          */
         struct LabeledSlot
         {
-            std::uintptr_t slot_addr = 0; ///< Address of the resolved slot.
-            std::size_t slot_index = 0;   ///< Zero-based index of the slot in the swept block.
-            PointeeType type;             ///< Reverse-identified type (carries its own name buffer).
+            /// Address of the resolved slot.
+            std::uintptr_t slot_addr = 0;
+            /// Zero-based index of the slot in the swept block.
+            std::size_t slot_index = 0;
+            /// Reverse-identified type (carries its own name buffer).
+            PointeeType type;
         };
 
         /**
@@ -170,9 +188,12 @@ namespace DetourModKit
          */
         enum class Indirection : std::uint8_t
         {
-            PointerToObject, ///< Match only slots that held a pointer-to-object.
-            ObjectBase,      ///< Match only slots that were a direct object base.
-            Any              ///< Match either shape (use when capture and heal may straddle a DLL boundary).
+            /// Match only slots that held a pointer-to-object.
+            PointerToObject,
+            /// Match only slots that were a direct object base.
+            ObjectBase,
+            /// Match either shape (use when capture and heal may straddle a DLL boundary).
+            Any
         };
 
         /**
@@ -181,9 +202,12 @@ namespace DetourModKit
          */
         enum class HealError : std::uint8_t
         {
-            BadDescriptor, ///< The landmark/fingerprint is malformed; no memory was touched.
-            NoMatch,       ///< No slot in the window resolved to the expected type.
-            Ambiguous      ///< Equidistant slots both match (heal) or tied-score deltas (fingerprint).
+            /// The landmark/fingerprint is malformed; no memory was touched.
+            BadDescriptor,
+            /// No slot in the window resolved to the expected type.
+            NoMatch,
+            /// Equidistant slots both match (heal) or tied-score deltas (fingerprint).
+            Ambiguous
         };
 
         /**
@@ -207,13 +231,20 @@ namespace DetourModKit
          */
         struct Landmark
         {
-            std::uintptr_t base = 0;           ///< Resolved struct base. Filled at call time; never persisted.
-            std::ptrdiff_t nominal_offset = 0; ///< Last known field offset within @ref base.
-            std::size_t window = 0x40;         ///< Search radius per side in bytes (capped at MAX_HEAL_WINDOW).
-            std::string_view expected_mangled; ///< MSVC mangled name to match. Aliases caller storage.
-            Indirection indirection = Indirection::PointerToObject; ///< Required slot shape.
-            std::size_t stride = sizeof(std::uintptr_t);            ///< Probe step (and candidate alignment). Zero -> 8.
-            bool required = true; ///< Consulted only by @ref solve_fingerprint; a required landmark must match.
+            /// Resolved struct base. Filled at call time; never persisted.
+            std::uintptr_t base = 0;
+            /// Last known field offset within @ref base.
+            std::ptrdiff_t nominal_offset = 0;
+            /// Search radius per side in bytes (capped at MAX_HEAL_WINDOW).
+            std::size_t window = 0x40;
+            /// MSVC mangled name to match. Aliases caller storage.
+            std::string_view expected_mangled;
+            /// Required slot shape.
+            Indirection indirection = Indirection::PointerToObject;
+            /// Probe step (and candidate alignment). Zero -> 8.
+            std::size_t stride = sizeof(std::uintptr_t);
+            /// Consulted only by @ref solve_fingerprint; a required landmark must match.
+            bool required = true;
         };
 
         /**
@@ -222,11 +253,16 @@ namespace DetourModKit
          */
         struct HealHit
         {
-            std::ptrdiff_t healed_offset = 0; ///< slot_addr - base: the field offset to use (== nominal_offset on no drift).
-            std::uintptr_t slot_addr = 0;     ///< Address of the matching slot.
-            std::uintptr_t object_addr = 0;   ///< Resolved object base behind the slot.
-            std::uintptr_t vtable = 0;        ///< Resolved vtable of the matched object.
-            bool was_pointer = false;         ///< Shape of the matched slot.
+            /// slot_addr - base: the field offset to use (== nominal_offset on no drift).
+            std::ptrdiff_t healed_offset = 0;
+            /// Address of the matching slot.
+            std::uintptr_t slot_addr = 0;
+            /// Resolved object base behind the slot.
+            std::uintptr_t object_addr = 0;
+            /// Resolved vtable of the matched object.
+            std::uintptr_t vtable = 0;
+            /// Shape of the matched slot.
+            bool was_pointer = false;
         };
 
         /**
@@ -280,9 +316,12 @@ namespace DetourModKit
          */
         struct FingerprintHit
         {
-            std::ptrdiff_t delta = 0;       ///< The single uniform byte shift applied to every landmark offset.
-            std::size_t matched = 0;        ///< Required landmarks satisfied at @ref delta (equals the required count).
-            std::size_t optional_matched = 0; ///< Optional landmarks also satisfied at @ref delta.
+            /// The single uniform byte shift applied to every landmark offset.
+            std::ptrdiff_t delta = 0;
+            /// Required landmarks satisfied at @ref delta (equals the required count).
+            std::size_t matched = 0;
+            /// Optional landmarks also satisfied at @ref delta.
+            std::size_t optional_matched = 0;
         };
 
         /**
@@ -332,12 +371,18 @@ namespace DetourModKit
          */
         struct DriftEntry
         {
-            std::string_view name;             ///< Aliases the landmark's @c expected_mangled.
-            std::ptrdiff_t nominal_offset = 0; ///< The landmark's last-known offset.
-            std::ptrdiff_t healed_offset = 0;  ///< The resolved offset (valid only when @ref ok).
-            std::ptrdiff_t delta = 0;          ///< healed_offset - nominal_offset (valid only when @ref ok).
-            bool ok = false;                   ///< Whether the landmark healed.
-            HealError error{};                 ///< Failure reason; meaningful only when @ref ok is false.
+            /// Aliases the landmark's @c expected_mangled.
+            std::string_view name;
+            /// The landmark's last-known offset.
+            std::ptrdiff_t nominal_offset = 0;
+            /// The resolved offset (valid only when @ref ok).
+            std::ptrdiff_t healed_offset = 0;
+            /// healed_offset - nominal_offset (valid only when @ref ok).
+            std::ptrdiff_t delta = 0;
+            /// Whether the landmark healed.
+            bool ok = false;
+            /// Failure reason; meaningful only when @ref ok is false.
+            HealError error{};
         };
 
         /**

--- a/include/DetourModKit/scanner.hpp
+++ b/include/DetourModKit/scanner.hpp
@@ -355,8 +355,10 @@ namespace DetourModKit
          */
         enum class ScannerKind : std::uint8_t
         {
-            Executable, ///< scan_executable_regions: committed execute-readable pages.
-            Readable    ///< scan_readable_regions: all committed readable pages (superset).
+            /// scan_executable_regions: committed execute-readable pages.
+            Executable,
+            /// scan_readable_regions: all committed readable pages (superset).
+            Readable
         };
 
         /**
@@ -365,8 +367,10 @@ namespace DetourModKit
          */
         enum class ResolveMode : std::uint8_t
         {
-            Direct,     ///< Returned address = match + disp_offset.
-            RipRelative ///< Read int32 displacement at (match + disp_offset), compute match + instr_end_offset + disp.
+            /// Returned address = match + disp_offset.
+            Direct,
+            /// Read int32 displacement at (match + disp_offset), compute match + instr_end_offset + disp.
+            RipRelative
         };
 
         /**
@@ -664,8 +668,10 @@ namespace DetourModKit
          */
         enum class OperandKind : std::uint8_t
         {
-            Immediate,         ///< An immediate operand (e.g. the imm of `add reg, imm`).
-            MemoryDisplacement ///< A memory operand's displacement (e.g. the disp of `[reg + disp]`).
+            /// An immediate operand (e.g. the imm of `add reg, imm`).
+            Immediate,
+            /// A memory operand's displacement (e.g. the disp of `[reg + disp]`).
+            MemoryDisplacement
         };
 
         /**
@@ -728,8 +734,10 @@ namespace DetourModKit
          */
         enum class StringEncoding : std::uint8_t
         {
-            Utf8,   ///< One byte per character (char / std::string literals).
-            Utf16le ///< Two bytes per character, little-endian (wchar_t / L"" on Windows).
+            /// One byte per character (char / std::string literals).
+            Utf8,
+            /// Two bytes per character, little-endian (wchar_t / L"" on Windows).
+            Utf16le
         };
 
         /**
@@ -738,8 +746,10 @@ namespace DetourModKit
          */
         enum class XrefReturn : std::uint8_t
         {
-            ReferencingInstruction, ///< Exact address of the instruction that loads the string.
-            EnclosingFunction       ///< Best-effort prologue back-scan from the instruction (heuristic).
+            /// Exact address of the instruction that loads the string.
+            ReferencingInstruction,
+            /// Best-effort prologue back-scan from the instruction (heuristic).
+            EnclosingFunction
         };
 
         /**
@@ -748,13 +758,20 @@ namespace DetourModKit
          */
         enum class StringXrefError : std::uint8_t
         {
-            EmptyQuery,         ///< The query text was empty.
-            InvalidRange,       ///< @p range was not a valid mapped image.
-            StringNotFound,     ///< The string bytes were not found in any readable page of the image.
-            StringAmbiguous,    ///< The string occurs more than once (linker-pooled or repeated).
-            NoReference,        ///< No recognized RIP-relative reference in the image resolves to the string.
-            AmbiguousReference, ///< More than one instruction references the string.
-            FunctionNotFound    ///< EnclosingFunction mode: no prologue within the back-scan window.
+            /// The query text was empty.
+            EmptyQuery,
+            /// @p range was not a valid mapped image.
+            InvalidRange,
+            /// The string bytes were not found in any readable page of the image.
+            StringNotFound,
+            /// The string occurs more than once (linker-pooled or repeated).
+            StringAmbiguous,
+            /// No recognized RIP-relative reference in the image resolves to the string.
+            NoReference,
+            /// More than one instruction references the string.
+            AmbiguousReference,
+            /// EnclosingFunction mode: no prologue within the back-scan window.
+            FunctionNotFound
         };
 
         /**
@@ -798,8 +815,10 @@ namespace DetourModKit
          */
         struct StringRefQuery
         {
-            std::string_view text;                          ///< Literal content (no quotes).
-            StringEncoding encoding = StringEncoding::Utf8; ///< How it is stored in the image.
+            /// Literal content (no quotes).
+            std::string_view text;
+            /// How it is stored in the image.
+            StringEncoding encoding = StringEncoding::Utf8;
             /**
              * @brief Match a trailing NUL so a prefix of a longer literal is not
              *        matched (e.g. "Player" inside "PlayerController").
@@ -905,9 +924,12 @@ namespace DetourModKit
          */
         enum class SimdLevel
         {
-            Scalar, ///< No SIMD (byte-by-byte verification)
-            Sse2,   ///< SSE2 (16 bytes per iteration)
-            Avx2    ///< AVX2 (32 bytes per iteration, with SSE2 + scalar tail)
+            /// No SIMD (byte-by-byte verification)
+            Scalar,
+            /// SSE2 (16 bytes per iteration)
+            Sse2,
+            /// AVX2 (32 bytes per iteration, with SSE2 + scalar tail)
+            Avx2
         };
 
         /**

--- a/scripts/check_comment_style.py
+++ b/scripts/check_comment_style.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Advisory lint for DetourModKit's comment-marker conventions.
+
+The rules it guards are defined in AGENTS.md, "Comment conventions". Across the
+repo's own tracked C++ sources (submodules under external/ are excluded because
+git ls-files lists only this repo's files) it flags:
+
+  - a trailing ``///<`` member doc (documentation belongs on the line above the
+    member, as ``///`` or a ``/** */`` block);
+  - a multi-line ``///`` doc (two or more consecutive ``///`` lines -- that is a
+    multi-line documentation comment and belongs in a ``/** */`` block);
+  - a structural/block Doxygen tag on a ``///`` line (``@brief``, ``@param``,
+    ``@return``, ``@note``, ``@name`` and the like -- the moment one is needed,
+    switch to ``/** */``). Inline link markup (``@ref``, ``@c``, ``@p``, ``@a``)
+    is allowed on a ``///`` line and is not flagged.
+
+Exit status is 1 with the offenders printed when any rule is violated, else 0.
+"""
+import re
+import subprocess
+import sys
+
+# Structural/block tags that imply a /** */ block; inline link tags are omitted.
+BLOCK_TAG = re.compile(
+    r"^\s*///.*@(brief|param|tparam|return|retval|note|warning|details|throws|pre|post|name|\{|\})"
+)
+# A /// documentation line, excluding the trailing-doc ///< form.
+DOC_LINE = re.compile(r"^\s*///([^<]|$)")
+
+
+def main() -> int:
+    files = subprocess.check_output(["git", "ls-files", "*.cpp", "*.hpp"], text=True).split()
+    problems = []
+    for path in files:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            lines = handle.read().split("\n")
+        prev_is_doc = False
+        for number, line in enumerate(lines, 1):
+            if "///<" in line:
+                problems.append(f"{path}:{number}: trailing ///< (move the doc above the member)")
+            if BLOCK_TAG.match(line):
+                problems.append(f"{path}:{number}: block Doxygen tag on a /// line (use /** */)")
+            is_doc = bool(DOC_LINE.match(line))
+            if is_doc and prev_is_doc:
+                problems.append(f"{path}:{number}: multi-line /// doc (use /** */)")
+            prev_is_doc = is_doc
+
+    if problems:
+        print('Comment-style violations (see AGENTS.md, "Comment conventions"):')
+        print("\n".join(problems))
+        return 1
+    print("Comment style OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/async_logger.cpp
+++ b/src/async_logger.cpp
@@ -71,7 +71,6 @@ namespace DetourModKit
 
         new_block->next = existing;
         new_block->free_list = nullptr;
-        new_block->slot_count = POOL_SLOTS_PER_BLOCK;
 
         PoolSlot *slots = reinterpret_cast<PoolSlot *>(new_block->data);
         static_assert(POOL_SLOTS_PER_BLOCK <= 32, "constructed_mask is uint32_t; increase its width if POOL_SLOTS_PER_BLOCK > 32");
@@ -86,7 +85,6 @@ namespace DetourModKit
         new_block->free_list = &slots[0];
 
         m_head.store(new_block, std::memory_order_release);
-        m_pool_size.fetch_add(1, std::memory_order_relaxed);
     }
 
     StringPool &StringPool::instance() noexcept
@@ -114,7 +112,6 @@ namespace DetourModKit
             {
                 PoolSlot *slot = b->free_list;
                 b->free_list = slot->next_free;
-                --b->slot_count;
                 return slot;
             }
         }
@@ -197,7 +194,6 @@ namespace DetourModKit
     {
         slot->next_free = block->free_list;
         block->free_list = slot;
-        ++block->slot_count;
     }
 
     LogMessage::LogMessage(LogLevel lvl, std::string_view msg)
@@ -342,7 +338,7 @@ namespace DetourModKit
             if (diff == 0)
             {
                 if (m_enqueue_pos.compare_exchange_weak(pos, pos + 1,
-                                                       std::memory_order_relaxed))
+                                                        std::memory_order_relaxed))
                 {
                     slot.data = std::move(item);
                     slot.sequence.store(pos + 1, std::memory_order_release);
@@ -373,7 +369,7 @@ namespace DetourModKit
             if (diff == 0)
             {
                 if (m_dequeue_pos.compare_exchange_weak(pos, pos + 1,
-                                                       std::memory_order_relaxed))
+                                                        std::memory_order_relaxed))
                 {
                     item = std::move(slot.data);
                     slot.sequence.store(pos + m_capacity, std::memory_order_release);
@@ -477,10 +473,10 @@ namespace DetourModKit
                                     now.time_since_epoch()) %
                                 1000;
                 *m_file_stream << "[" << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S")
-                              << "." << std::setfill('0') << std::setw(3) << ms.count()
-                              << std::setfill(' ') << "] "
-                              << "[" << std::setw(7) << std::left << log_level_to_string(level) << "] :: "
-                              << message << '\n';
+                               << "." << std::setfill('0') << std::setw(3) << ms.count()
+                               << std::setfill(' ') << "] "
+                               << "[" << std::setw(7) << std::left << log_level_to_string(level) << "] :: "
+                               << message << '\n';
                 m_file_stream->flush();
             }
             return true;
@@ -511,7 +507,7 @@ namespace DetourModKit
         std::unique_lock<std::mutex> lock(m_flush_mutex);
 
         const bool flushed = m_flush_cv.wait_for(lock, timeout, [this]() noexcept
-                                                { return m_pending_messages.load(std::memory_order_acquire) == 0; });
+                                                 { return m_pending_messages.load(std::memory_order_acquire) == 0; });
 
         return flushed;
     }
@@ -525,7 +521,7 @@ namespace DetourModKit
     {
         bool expected = false;
         if (!m_shutdown_requested.compare_exchange_strong(expected, true,
-                                                         std::memory_order_acq_rel))
+                                                          std::memory_order_acq_rel))
         {
             return;
         }
@@ -627,7 +623,7 @@ namespace DetourModKit
 
                 std::unique_lock<std::mutex> lock(m_flush_mutex);
                 m_flush_cv.wait_for(lock, m_config.flush_interval, [this]()
-                                   { return !m_queue.empty() || !m_running.load(std::memory_order_acquire); });
+                                    { return !m_queue.empty() || !m_running.load(std::memory_order_acquire); });
             }
         }
 
@@ -690,10 +686,10 @@ namespace DetourModKit
                             1000;
 
             *m_file_stream << "[" << std::put_time(&cached_tm, "%Y-%m-%d %H:%M:%S")
-                          << "." << std::setfill('0') << std::setw(3) << ms.count()
-                          << std::setfill(' ') << "] "
-                          << "[" << std::setw(7) << std::left << log_level_to_string(msg.level) << "] :: "
-                          << msg.message() << '\n';
+                           << "." << std::setfill('0') << std::setw(3) << ms.count()
+                           << std::setfill(' ') << "] "
+                           << "[" << std::setw(7) << std::left << log_level_to_string(msg.level) << "] :: "
+                           << msg.message() << '\n';
         }
 
         m_file_stream->flush();
@@ -786,10 +782,10 @@ namespace DetourModKit
                                 message.timestamp.time_since_epoch()) %
                             1000;
             *m_file_stream << "[" << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S")
-                          << "." << std::setfill('0') << std::setw(3) << ms.count()
-                          << std::setfill(' ') << "] "
-                          << "[" << std::setw(7) << std::left << log_level_to_string(message.level) << "] :: "
-                          << message.message() << '\n';
+                           << "." << std::setfill('0') << std::setw(3) << ms.count()
+                           << std::setfill(' ') << "] "
+                           << "[" << std::setw(7) << std::left << log_level_to_string(message.level) << "] :: "
+                           << message.message() << '\n';
             m_file_stream->flush();
 
             if (m_file_stream->fail())

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -583,10 +583,14 @@ namespace
      */
     struct IniLoadOutcome
     {
-        bool read_succeeded{false};   ///< Bytes successfully read from disk
-        bool parse_succeeded{false};  ///< CSimpleIniA::LoadData returned SI_OK
-        SI_Error parse_rc{SI_OK};     ///< Raw SimpleIni return code (when read_succeeded)
-        std::optional<std::uint64_t> hash; ///< FNV-1a hash of the read bytes
+        /// Bytes successfully read from disk
+        bool read_succeeded{false};
+        /// CSimpleIniA::LoadData returned SI_OK
+        bool parse_succeeded{false};
+        /// Raw SimpleIni return code (when read_succeeded)
+        SI_Error parse_rc{SI_OK};
+        /// FNV-1a hash of the read bytes
+        std::optional<std::uint64_t> hash;
     };
 
     /**
@@ -765,11 +769,9 @@ namespace
                 {
                     std::unique_lock<std::mutex> lock(m_mutex);
                     m_cv.wait(lock, [&]()
-                              {
-                                  return st.stop_requested() ||
-                                         m_shutdown.load(std::memory_order_acquire) ||
-                                         m_reload_requested.load(std::memory_order_acquire);
-                              });
+                              { return st.stop_requested() ||
+                                       m_shutdown.load(std::memory_order_acquire) ||
+                                       m_reload_requested.load(std::memory_order_acquire); });
                 }
 
                 if (st.stop_requested() ||
@@ -816,8 +818,10 @@ namespace
         return s_servicer;
     }
 
-    /// Replaces an existing item with the same section+key, or appends if none found.
-    /// Caller must hold get_config_mutex().
+    /**
+     * @brief Replaces an existing item with the same section+key, or appends if none found.
+     * @note Caller must hold get_config_mutex().
+     */
     void replace_or_append(std::unique_ptr<ConfigItemBase> item)
     {
         auto &items = get_registered_config_items();
@@ -842,7 +846,8 @@ namespace
         if (module_dir.empty() || module_dir == L".")
         {
             logger.warning("Config: Could not reliably determine module directory or it's current working directory. Using relative path for INI: {}", ini_filename);
-            return std::filesystem::path(ini_filename); // Fallback to relative path
+            // Fallback to relative path
+            return std::filesystem::path(ini_filename);
         }
 
         try
@@ -955,12 +960,8 @@ void DetourModKit::Config::register_string(std::string_view section, std::string
 void DetourModKit::Config::register_log_level(std::string_view section, std::string_view ini_key,
                                               std::string_view default_value)
 {
-    register_string(section, ini_key, "Log level",
-                    [](const std::string &value)
-                    {
-                        Logger::get_instance().set_log_level(Logger::string_to_log_level(value));
-                    },
-                    std::string(default_value));
+    register_string(section, ini_key, "Log level", [](const std::string &value)
+                    { Logger::get_instance().set_log_level(Logger::string_to_log_level(value)); }, std::string(default_value));
 }
 
 void DetourModKit::Config::register_key_combo(std::string_view section, std::string_view ini_key,
@@ -1028,12 +1029,8 @@ void DetourModKit::Config::register_consume_flag(
     // and re-runs on every load()/reload(), stays valid. set_consume is a no-op
     // for an unknown name, so registering this before the binding exists is safe.
     std::string binding_name_str(input_binding_name);
-    register_bool(section, ini_key, log_key_name,
-                  [binding_name_str](bool consume)
-                  {
-                      InputManager::get_instance().set_consume(binding_name_str, consume);
-                  },
-                  default_value);
+    register_bool(section, ini_key, log_key_name, [binding_name_str](bool consume)
+                  { InputManager::get_instance().set_consume(binding_name_str, consume); }, default_value);
 }
 
 void DetourModKit::Config::load(std::string_view ini_filename)
@@ -1045,7 +1042,8 @@ void DetourModKit::Config::load(std::string_view ini_filename)
 
         Logger &logger = Logger::get_instance();
         std::filesystem::path ini_path = get_ini_file_path(std::string(ini_filename), logger);
-        std::string ini_path_str = ini_path.string(); // convert to narrow string for logger formatting
+        // convert to narrow string for logger formatting
+        std::string ini_path_str = ini_path.string();
         CSimpleIniA ini;
         ini.SetUnicode(false);  // Assume ASCII/MBCS INI
         ini.SetMultiKey(false); // Disallow duplicate keys in a section

--- a/src/config_watcher.cpp
+++ b/src/config_watcher.cpp
@@ -97,7 +97,8 @@ namespace DetourModKit
             HANDLE h{INVALID_HANDLE_VALUE};
 
             OwnedHandle() = default;
-            explicit OwnedHandle(HANDLE raw) noexcept : h(raw) {}
+            explicit OwnedHandle(HANDLE raw) noexcept
+                : h(raw) {}
 
             OwnedHandle(const OwnedHandle &) = delete;
             OwnedHandle &operator=(const OwnedHandle &) = delete;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -203,11 +203,14 @@ namespace DetourModKit
             return false;
         }
 
-        /// Reports whether any consume binding carries a suppressible gamepad button
-        /// (gates the XInput hook). Only digital buttons gate it: the detour masks
-        /// XINPUT_GAMEPAD.wButtons, so analog triggers and stick directions (the
-        /// synthetic codes >= GamepadCode::LeftTrigger) can never be cleared and must
-        /// not install a hook that would mask nothing.
+        /**
+         * @brief Reports whether any consume binding carries a suppressible gamepad button
+         *        (gates the XInput hook).
+         * @details Only digital buttons gate it: the detour masks XINPUT_GAMEPAD.wButtons,
+         *          so analog triggers and stick directions (the synthetic codes >=
+         *          GamepadCode::LeftTrigger) can never be cleared and must not install a
+         *          hook that would mask nothing.
+         */
         bool scan_for_consume_gamepad_bindings(const std::vector<InputBinding> &bindings) noexcept
         {
             for (const auto &binding : bindings)
@@ -248,20 +251,22 @@ namespace DetourModKit
             return false;
         }
 
-        /// Builds the detour-evaluable consume rule list from the current bindings.
-        /// A rule is emitted for every consume binding whose masked triggers include
-        /// a digital gamepad button, but only when every known modifier (across all
-        /// bindings) is itself a digital gamepad button. The XInput detour sees only
-        /// XINPUT_GAMEPAD.wButtons, so it cannot observe a keyboard/mouse modifier or
-        /// an analog trigger/stick used as a modifier; if any such modifier exists,
-        /// the poll loop's strict-match decision is not reproducible in the detour,
-        /// so the whole list is dropped and the reactive (poll-published) mask alone
-        /// covers the held-modifier case. For an eligible binding the rule carries:
-        ///   modifier_mask  -- all of the chord's modifier bits,
-        ///   trigger_mask   -- the chord's digital gamepad trigger bits to clear,
-        ///   forbidden_mask -- every other known modifier bit, so holding a modifier
-        ///                     that belongs to a different chord rejects this one,
-        ///                     exactly as the poll loop's strict-match check does.
+        /**
+         * @brief Builds the detour-evaluable consume rule list from the current bindings.
+         * @details A rule is emitted for every consume binding whose masked triggers include
+         *          a digital gamepad button, but only when every known modifier (across all
+         *          bindings) is itself a digital gamepad button. The XInput detour sees only
+         *          XINPUT_GAMEPAD.wButtons, so it cannot observe a keyboard/mouse modifier or
+         *          an analog trigger/stick used as a modifier; if any such modifier exists,
+         *          the poll loop's strict-match decision is not reproducible in the detour,
+         *          so the whole list is dropped and the reactive (poll-published) mask alone
+         *          covers the held-modifier case. For an eligible binding the rule carries:
+         *            modifier_mask  -- all of the chord's modifier bits,
+         *            trigger_mask   -- the chord's digital gamepad trigger bits to clear,
+         *            forbidden_mask -- every other known modifier bit, so holding a modifier
+         *                              that belongs to a different chord rejects this one,
+         *                              exactly as the poll loop's strict-match check does.
+         */
         std::vector<detail::GamepadConsumeRule>
         build_gamepad_consume_rules(const std::vector<InputBinding> &bindings,
                                     const std::vector<InputCode> &known_modifiers) noexcept
@@ -370,9 +375,9 @@ namespace DetourModKit
         m_has_gamepad_bindings.store(scan_for_gamepad_bindings(m_bindings), std::memory_order_relaxed);
         m_has_wheel_bindings.store(scan_for_wheel_bindings(m_bindings), std::memory_order_relaxed);
         m_has_consume_gamepad_bindings.store(scan_for_consume_gamepad_bindings(m_bindings),
-                                            std::memory_order_relaxed);
+                                             std::memory_order_relaxed);
         m_has_wheel_consume_bindings.store(scan_for_wheel_consume_bindings(m_bindings),
-                                          std::memory_order_relaxed);
+                                           std::memory_order_relaxed);
 
         // Publish the detour-side consume rule list. The XInput detour evaluates
         // these against the exact snapshot the game reads, closing the leading-edge
@@ -401,7 +406,7 @@ namespace DetourModKit
         try
         {
             m_poll_thread = std::jthread([this](std::stop_token token)
-                                        { poll_loop(std::move(token)); });
+                                         { poll_loop(std::move(token)); });
         }
         catch (...)
         {
@@ -820,7 +825,7 @@ namespace DetourModKit
 
             std::unique_lock lock(m_cv_mutex);
             m_cv.wait_for(lock, stop_token, m_poll_interval, [&stop_token]()
-                         { return stop_token.stop_requested(); });
+                          { return stop_token.stop_requested(); });
         }
     }
 
@@ -1395,8 +1400,8 @@ namespace DetourModKit
         }
 
         m_poller = std::make_shared<InputPoller>(std::move(m_pending_bindings), poll_interval,
-                                                m_require_focus, m_gamepad_index, m_trigger_threshold,
-                                                m_stick_threshold);
+                                                 m_require_focus, m_gamepad_index, m_trigger_threshold,
+                                                 m_stick_threshold);
         m_pending_bindings.clear();
         m_poller->start();
         m_active_poller.store(m_poller, std::memory_order_release);
@@ -1539,7 +1544,8 @@ namespace DetourModKit
             {
                 auto new_end = std::remove_if(
                     m_pending_bindings.begin(), m_pending_bindings.end(),
-                    [name](const InputBinding &b) { return b.name == name; });
+                    [name](const InputBinding &b)
+                    { return b.name == name; });
                 removed_pending = static_cast<size_t>(
                     std::distance(new_end, m_pending_bindings.end()));
                 m_pending_bindings.erase(new_end, m_pending_bindings.end());

--- a/src/input_intercept.cpp
+++ b/src/input_intercept.cpp
@@ -31,12 +31,14 @@ namespace DetourModKit::detail
         /// Undocumented ordinal that exports XInputGetStateEx (reports the Guide button).
         constexpr WORD s_xinput_get_state_ex_ordinal = 100;
 
-        /// How long a published suppression mask stays valid without a refresh.
-        /// Set above the maximum allowed poll interval (MAX_POLL_INTERVAL) so a
-        /// healthy poll thread at any configured rate keeps the mask continuously
-        /// alive, while still bounding a stalled poll thread so it cannot latch the
-        /// game's input off indefinitely. Twice the largest poll interval leaves
-        /// headroom for a slow cycle's own body to run before the deadline lapses.
+        /**
+         * @brief How long a published suppression mask stays valid without a refresh.
+         * @details Set above the maximum allowed poll interval (MAX_POLL_INTERVAL) so a
+         *          healthy poll thread at any configured rate keeps the mask continuously
+         *          alive, while still bounding a stalled poll thread so it cannot latch the
+         *          game's input off indefinitely. Twice the largest poll interval leaves
+         *          headroom for a slow cycle's own body to run before the deadline lapses.
+         */
         constexpr uint64_t s_suppress_ttl_ms = 2000;
 
         // --- XInput interception state ---
@@ -74,9 +76,12 @@ namespace DetourModKit::detail
         // mirroring how the reactive mask is cleared and how s_wheel_consume is gated.
         std::atomic<bool> s_rule_suppress_enabled{false};
 
-        /// Packs a rule into one word: modifier (bits 0-15), forbidden (16-31),
-        /// trigger (32-47). Three 16-bit masks fit a uint64 with room to spare, so a
-        /// rule is published and read as a single atomic store/load.
+        /**
+         * @brief Packs a rule into one word: modifier (bits 0-15), forbidden (16-31),
+         *        trigger (32-47).
+         * @details Three 16-bit masks fit a uint64 with room to spare, so a rule is
+         *          published and read as a single atomic store/load.
+         */
         constexpr uint64_t pack_consume_rule(const GamepadConsumeRule &rule) noexcept
         {
             return static_cast<uint64_t>(rule.modifier_mask) |
@@ -202,11 +207,13 @@ namespace DetourModKit::detail
                 const int delta = GET_WHEEL_DELTA_WPARAM(wparam);
                 if (delta > 0)
                 {
-                    s_wheel_count[0].fetch_add(1, std::memory_order_relaxed); // Up
+                    // Up
+                    s_wheel_count[0].fetch_add(1, std::memory_order_relaxed);
                 }
                 else if (delta < 0)
                 {
-                    s_wheel_count[1].fetch_add(1, std::memory_order_relaxed); // Down
+                    // Down
+                    s_wheel_count[1].fetch_add(1, std::memory_order_relaxed);
                 }
                 if (s_wheel_consume.load(std::memory_order_relaxed))
                 {
@@ -221,11 +228,13 @@ namespace DetourModKit::detail
                 const int delta = GET_WHEEL_DELTA_WPARAM(wparam);
                 if (delta > 0)
                 {
-                    s_wheel_count[3].fetch_add(1, std::memory_order_relaxed); // Right
+                    // Right
+                    s_wheel_count[3].fetch_add(1, std::memory_order_relaxed);
                 }
                 else if (delta < 0)
                 {
-                    s_wheel_count[2].fetch_add(1, std::memory_order_relaxed); // Left
+                    // Left
+                    s_wheel_count[2].fetch_add(1, std::memory_order_relaxed);
                 }
                 if (s_wheel_consume.load(std::memory_order_relaxed))
                 {

--- a/src/input_intercept.hpp
+++ b/src/input_intercept.hpp
@@ -57,8 +57,10 @@ namespace DetourModKit::detail
      */
     struct WheelPulseState
     {
-        std::array<int, 4> pending{};  ///< Unconsumed notches per direction.
-        std::array<bool, 4> pulsing{}; ///< Whether the previous cycle emitted a pulse.
+        /// Unconsumed notches per direction.
+        std::array<int, 4> pending{};
+        /// Whether the previous cycle emitted a pulse.
+        std::array<bool, 4> pulsing{};
     };
 
     /**
@@ -75,8 +77,10 @@ namespace DetourModKit::detail
      */
     struct GamepadSuppressState
     {
-        uint16_t armed{0};                      ///< Currently suppressed XInput button bits.
-        std::array<uint64_t, 16> deadline_ms{}; ///< Per-bit release deadline; a held bit uses the sentinel.
+        /// Currently suppressed XInput button bits.
+        uint16_t armed{0};
+        /// Per-bit release deadline; a held bit uses the sentinel.
+        std::array<uint64_t, 16> deadline_ms{};
     };
 
     /**
@@ -117,9 +121,12 @@ namespace DetourModKit::detail
      */
     struct GamepadConsumeRule
     {
-        uint16_t modifier_mask{0};  ///< Digital button bits that must all be held.
-        uint16_t forbidden_mask{0}; ///< Known-modifier bits outside this chord; any held rejects it (strict match).
-        uint16_t trigger_mask{0};   ///< Digital button bits to clear when the chord matches.
+        /// Digital button bits that must all be held.
+        uint16_t modifier_mask{0};
+        /// Known-modifier bits outside this chord; any held rejects it (strict match).
+        uint16_t forbidden_mask{0};
+        /// Digital button bits to clear when the chord matches.
+        uint16_t trigger_mask{0};
     };
 
     /**

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -104,8 +104,8 @@ namespace DetourModKit
         if (m_log_file_stream_ptr->is_open() && m_log_file_stream_ptr->good())
         {
             *m_log_file_stream_ptr << "[" << get_timestamp() << "] "
-                                  << "[" << std::setw(7) << std::left << "INFO" << "] :: "
-                                  << "Logger reconfiguring. New file: " << file_name << '\n';
+                                   << "[" << std::setw(7) << std::left << "INFO" << "] :: "
+                                   << "Logger reconfiguring. New file: " << file_name << '\n';
             m_log_file_stream_ptr->flush();
             m_log_file_stream_ptr->close();
         }
@@ -127,8 +127,8 @@ namespace DetourModKit
         else
         {
             *m_log_file_stream_ptr << "[" << get_timestamp() << "] "
-                                  << "[" << std::setw(7) << std::left << "INFO" << "] :: "
-                                  << "Logger reconfigured. Now logging to: " << file_name << '\n';
+                                   << "[" << std::setw(7) << std::left << "INFO" << "] :: "
+                                   << "Logger reconfigured. Now logging to: " << file_name << '\n';
         }
     }
 
@@ -156,8 +156,8 @@ namespace DetourModKit
         else
         {
             *m_log_file_stream_ptr << "[" << get_timestamp() << "] ["
-                                  << std::setw(7) << std::left << "INFO"
-                                  << "] :: Logger initialized. Logging to: " << m_log_file_name << '\n';
+                                   << std::setw(7) << std::left << "INFO"
+                                   << "] :: Logger initialized. Logging to: " << m_log_file_name << '\n';
         }
     }
 
@@ -165,7 +165,7 @@ namespace DetourModKit
     {
         bool expected = false;
         if (!m_shutdown_called.compare_exchange_strong(expected, true,
-                                                      std::memory_order_acq_rel))
+                                                       std::memory_order_acq_rel))
         {
             return;
         }
@@ -176,7 +176,7 @@ namespace DetourModKit
     {
         bool expected = false;
         if (!m_shutdown_called.compare_exchange_strong(expected, true,
-                                                      std::memory_order_acq_rel))
+                                                       std::memory_order_acq_rel))
         {
             return;
         }
@@ -288,8 +288,8 @@ namespace DetourModKit
             if (m_log_file_stream_ptr->is_open() && m_log_file_stream_ptr->good())
             {
                 *m_log_file_stream_ptr << "[" << get_timestamp() << "] "
-                                      << "[" << std::setw(7) << std::left << level_str << "] :: "
-                                      << message << '\n';
+                                       << "[" << std::setw(7) << std::left << level_str << "] :: "
+                                       << message << '\n';
 
                 // Flush on warnings/errors to ensure critical messages survive crashes
                 if (level >= LogLevel::Warning)
@@ -314,13 +314,9 @@ namespace DetourModKit
             const auto in_time_t = std::chrono::system_clock::to_time_t(now);
             std::tm timeinfo_struct = {};
 
-#if defined(_MSC_VER)
-            if (localtime_s(&timeinfo_struct, &in_time_t) != 0)
-            {
-                throw std::runtime_error("localtime_s failed to convert time.");
-            }
-#elif defined(__MINGW32__) || defined(__MINGW64__)
-            // MinGW: localtime_s has reversed parameter order (ISO C11 Annex K)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
+            // MinGW's localtime_s takes the same (struct tm *, const time_t *) argument
+            // order as MSVC, not the ISO C11 Annex K order, so the call is identical.
             if (localtime_s(&timeinfo_struct, &in_time_t) != 0)
             {
                 throw std::runtime_error("localtime_s failed to convert time.");

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -123,12 +123,14 @@ namespace
         // Monotonic counter guarantees insertion-order uniqueness for correct eviction
         std::map<uint64_t, uintptr_t> lru_index;
         // Sorted by base address for O(log n) containment lookup
-        std::vector<std::pair<uintptr_t, uintptr_t>> sorted_ranges; // {base, base+size}
+        // {base, base+size}
+        std::vector<std::pair<uintptr_t, uintptr_t>> sorted_ranges;
         uint64_t entry_counter{0};
         size_t capacity;
         size_t max_capacity;
 
-        CacheShard() : capacity(0), max_capacity(0)
+        CacheShard()
+            : capacity(0), max_capacity(0)
         {
             entries.reserve(64);
             sorted_ranges.reserve(64);
@@ -156,7 +158,7 @@ namespace
     {
         return (static_cast<size_t>((address * 0x9E3779B97F4A7C15ULL) >> 48)) % shard_count;
     }
-}
+} // namespace
 
 // Internal static variables and helper functions for memory cache.
 // Anonymous namespace ensures internal linkage, preventing ODR violations
@@ -227,7 +229,8 @@ namespace
 
     // On-demand cleanup fallback timer (used when background thread is disabled)
     std::atomic<uint64_t> s_lastCleanupTimeNs{0};
-    constexpr uint64_t CLEANUP_INTERVAL_NS = 1'000'000'000ULL; // 1 second in nanoseconds
+    // 1 second in nanoseconds
+    constexpr uint64_t CLEANUP_INTERVAL_NS = 1'000'000'000ULL;
 
     // Always-available cache statistics
     struct CacheStats
@@ -299,7 +302,7 @@ namespace
     {
         auto range = std::make_pair(base_addr, base_addr + region_size);
         auto pos = std::lower_bound(shard.sorted_ranges.begin(),
-                                     shard.sorted_ranges.end(), range);
+                                    shard.sorted_ranges.end(), range);
         shard.sorted_ranges.insert(pos, range);
     }
 
@@ -310,8 +313,8 @@ namespace
     void remove_sorted_range(CacheShard &shard, uintptr_t base_addr) noexcept
     {
         auto it = std::lower_bound(shard.sorted_ranges.begin(),
-                                    shard.sorted_ranges.end(),
-                                    std::make_pair(base_addr, uintptr_t{0}));
+                                   shard.sorted_ranges.end(),
+                                   std::make_pair(base_addr, uintptr_t{0}));
         if (it != shard.sorted_ranges.end() && it->first == base_addr)
             shard.sorted_ranges.erase(it);
     }
@@ -351,8 +354,8 @@ namespace
         // Finds the last range starting at or before the queried address,
         // then verifies containment and entry validity.
         auto range_it = std::upper_bound(shard.sorted_ranges.begin(),
-                                          shard.sorted_ranges.end(),
-                                          std::make_pair(address, UINTPTR_MAX));
+                                         shard.sorted_ranges.end(),
+                                         std::make_pair(address, UINTPTR_MAX));
         if (range_it != shard.sorted_ranges.begin())
         {
             --range_it;
@@ -608,7 +611,8 @@ namespace
             if (!s_cleanupThreadRunning.load(std::memory_order_acquire))
                 break;
 
-            cleanup_expired_entries(true); // force=true to hold state mutex during vector iteration
+            // force=true to hold state mutex during vector iteration
+            cleanup_expired_entries(true);
             s_cleanupRequested.store(false, std::memory_order_relaxed);
         }
     }
@@ -719,7 +723,8 @@ namespace
             shard_count = 1;
 
         const size_t entries_per_shard = (cache_size + shard_count - 1) / shard_count;
-        const size_t hard_max_per_shard = entries_per_shard * 2; // Hard upper bound: 2x capacity
+        // Hard upper bound: 2x capacity
+        const size_t hard_max_per_shard = entries_per_shard * 2;
 
         try
         {
@@ -840,7 +845,7 @@ namespace
         }
     }
 
-} // anonymous namespace (cache internals)
+} // namespace
 
 bool DetourModKit::Memory::init_cache(size_t cache_size, unsigned int expiry_ms, size_t shard_count)
 {
@@ -1388,7 +1393,8 @@ uintptr_t DetourModKit::Memory::read_ptr_unsafe(uintptr_t base, ptrdiff_t offset
                 {
                     const uint64_t now_ns = current_time_ns();
                     const uint64_t expiry_ns = static_cast<uint64_t>(
-                        s_configuredExpiryMs.load(std::memory_order_acquire)) * 1'000'000ULL;
+                                                   s_configuredExpiryMs.load(std::memory_order_acquire)) *
+                                               1'000'000ULL;
                     CachedMemoryRegionInfo *cached = find_in_shard(
                         s_cacheShards[shard_idx],
                         src, sizeof(uintptr_t), now_ns, expiry_ns);
@@ -1429,7 +1435,7 @@ uintptr_t DetourModKit::Memory::read_ptr_unsafe(uintptr_t base, ptrdiff_t offset
 namespace
 {
     inline constexpr uintptr_t SEH_READ_MIN_VALID_ADDR = 0x10000;
-} // anonymous namespace (seh_read internals)
+} // namespace
 
 bool DetourModKit::Memory::seh_read_bytes(uintptr_t addr, void *out, size_t bytes) noexcept
 {
@@ -1558,7 +1564,7 @@ namespace
         return true;
 #endif
     }
-} // anonymous namespace (pointer-chain internals)
+} // namespace
 
 std::optional<uintptr_t> DetourModKit::Memory::seh_resolve_chain(
     uintptr_t base, std::span<const ptrdiff_t> offsets) noexcept
@@ -1682,7 +1688,7 @@ namespace
         static ModuleRangeCache cache;
         return cache;
     }
-} // anonymous namespace (module-range internals)
+} // namespace
 
 std::optional<DetourModKit::Memory::ModuleRange>
 DetourModKit::Memory::module_range_for(const void *address) noexcept
@@ -1728,7 +1734,8 @@ DetourModKit::Memory::ModuleRange DetourModKit::Memory::own_module_range() noexc
     // guarded by the C++23 thread-safe-initialization rules. Taking the
     // address of own_module_range itself anchors the lookup in whichever
     // DLL/EXE statically linked this translation unit.
-    static const ModuleRange cached = [] {
+    static const ModuleRange cached = []
+    {
         HMODULE mod = nullptr;
         if (!GetModuleHandleExW(
                 GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
@@ -1746,7 +1753,8 @@ DetourModKit::Memory::ModuleRange DetourModKit::Memory::own_module_range() noexc
 
 DetourModKit::Memory::ModuleRange DetourModKit::Memory::host_module_range() noexcept
 {
-    static const ModuleRange cached = [] {
+    static const ModuleRange cached = []
+    {
         HMODULE mod = GetModuleHandleW(nullptr);
         if (!mod)
             return ModuleRange{};

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -40,7 +40,7 @@ namespace DetourModKit::detail
             return true;
 
         // Confirm the critical section lives in committed, readable memory before
-        // dereferencing OwningThread. A wrong kLoaderLockOffset (foreign or future
+        // dereferencing OwningThread. A wrong LOADER_LOCK_OFFSET (foreign or future
         // PEB layout) would otherwise read a bogus pointer and fault the host.
         constexpr DWORD READABLE_PROTECT =
             PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -98,8 +98,9 @@ namespace DetourModKit
         const int64_t delta_ticks = end_ticks - start_ticks;
 
         // Convert ticks to microseconds: (delta * 1'000'000) / frequency.
-        // Use 64-bit intermediate to avoid overflow for deltas up to ~9200 seconds
-        // at a 10 MHz QPC frequency (common on modern hardware).
+        // The 64-bit intermediate (delta * 1'000'000) cannot overflow for any realistic
+        // delta: at a 10 MHz QPC frequency it would take a delta over ~922,000 seconds.
+        // duration_us is additionally clamped to UINT32_MAX microseconds (~71 minutes).
         const auto duration_us = static_cast<uint32_t>(
             std::min<int64_t>((delta_ticks * 1'000'000) / m_qpc_frequency,
                               static_cast<int64_t>(UINT32_MAX)));

--- a/src/rtti.cpp
+++ b/src/rtti.cpp
@@ -335,13 +335,11 @@ namespace DetourModKit
                 mod.base + static_cast<std::uintptr_t>(static_cast<std::uint32_t>(dos->e_lfanew));
             // The NT headers must lie inside the image; a wild e_lfanew is the
             // signature of a forged or truncated header.
-            if (!Memory::contains(mod, nt_addr)
-                || !Memory::contains(mod, nt_addr + sizeof(IMAGE_NT_HEADERS64)))
+            if (!Memory::contains(mod, nt_addr) || !Memory::contains(mod, nt_addr + sizeof(IMAGE_NT_HEADERS64)))
                 return 0;
 
             const auto nt = Memory::seh_read<IMAGE_NT_HEADERS64>(nt_addr);
-            if (!nt || nt->Signature != IMAGE_NT_SIGNATURE
-                || nt->OptionalHeader.Magic != IMAGE_NT_OPTIONAL_HDR64_MAGIC)
+            if (!nt || nt->Signature != IMAGE_NT_SIGNATURE || nt->OptionalHeader.Magic != IMAGE_NT_OPTIONAL_HDR64_MAGIC)
                 return 0;
 
             // The Windows loader caps a PE at 96 sections; a larger count is
@@ -355,8 +353,7 @@ namespace DetourModKit
             // sizeof(IMAGE_NT_HEADERS64) instead would misplace the table whenever
             // the optional-header size differs from the compile-time struct size.
             const std::uintptr_t sec_table =
-                nt_addr + offsetof(IMAGE_NT_HEADERS64, OptionalHeader)
-                + nt->FileHeader.SizeOfOptionalHeader;
+                nt_addr + offsetof(IMAGE_NT_HEADERS64, OptionalHeader) + nt->FileHeader.SizeOfOptionalHeader;
 
             std::size_t count = 0;
             for (std::uint32_t i = 0; i < num_sections && count < cap; ++i)
@@ -439,7 +436,8 @@ namespace DetourModKit
                     continue;
                 }
 
-                std::uintptr_t buf[512]; // a 4 KiB page holds at most 512 qwords
+                // a 4 KiB page holds at most 512 qwords
+                std::uintptr_t buf[512];
                 const std::size_t want = (qwords < 512) ? qwords : 512;
                 if (Memory::seh_read_bytes(addr, buf, want * sizeof(std::uintptr_t)))
                 {

--- a/src/rtti_internal.hpp
+++ b/src/rtti_internal.hpp
@@ -74,10 +74,14 @@ namespace DetourModKit
              */
             struct ColSite
             {
-                std::uintptr_t col_addr = 0;   ///< Address of the COL the vtable points back to.
-                std::uintptr_t td_addr = 0;    ///< TypeDescriptor base (image base + COL.pTypeDescriptor RVA).
-                std::uintptr_t name_addr = 0;  ///< Mangled-name buffer (td_addr + TD_NAME_OFFSET).
-                std::uint32_t col_offset = 0;  ///< COL.offset (+0x04): this vtable's offset in the complete object.
+                /// Address of the COL the vtable points back to.
+                std::uintptr_t col_addr = 0;
+                /// TypeDescriptor base (image base + COL.pTypeDescriptor RVA).
+                std::uintptr_t td_addr = 0;
+                /// Mangled-name buffer (td_addr + TD_NAME_OFFSET).
+                std::uintptr_t name_addr = 0;
+                /// COL.offset (+0x04): this vtable's offset in the complete object.
+                std::uint32_t col_offset = 0;
             };
 
             /**

--- a/src/scanner_cascade.cpp
+++ b/src/scanner_cascade.cpp
@@ -609,4 +609,3 @@ DetourModKit::Scanner::resolve_cascade_in_host_module_with_prologue_fallback(
     }
     return resolve_cascade_in_module_with_prologue_fallback(candidates, label, range);
 }
-

--- a/src/scanner_internal.hpp
+++ b/src/scanner_internal.hpp
@@ -67,8 +67,10 @@ namespace DetourModKit
              */
             struct ExecutableWindow
             {
-                std::uintptr_t base = 0; ///< Absolute address of the first readable byte.
-                std::size_t span = 0;    ///< Window length in bytes.
+                /// Absolute address of the first readable byte.
+                std::uintptr_t base = 0;
+                /// Window length in bytes.
+                std::size_t span = 0;
             };
 
             /**

--- a/src/string_xref.cpp
+++ b/src/string_xref.cpp
@@ -95,7 +95,8 @@ namespace DetourModKit
                 emit(static_cast<std::uint8_t>(ch));
                 if (wide)
                 {
-                    emit(0x00); // High byte of a Latin-1 code unit in UTF-16LE.
+                    // High byte of a Latin-1 code unit in UTF-16LE.
+                    emit(0x00);
                 }
             }
             if (query.require_terminator)
@@ -135,7 +136,8 @@ namespace DetourModKit
         {
             found_count = 0;
             std::uintptr_t first_site = 0;
-            constexpr std::size_t instr_len = 7; // REX.W + opcode + ModRM + disp32.
+            // REX.W + opcode + ModRM + disp32.
+            constexpr std::size_t instr_len = 7;
 
             for (const auto &window : Scanner::detail::collect_executable_windows(range))
             {
@@ -171,7 +173,8 @@ namespace DetourModKit
                     }
                     else
                     {
-                        return 0; // Ambiguous; caller maps found_count >= 2 to AmbiguousReference.
+                        // Ambiguous; caller maps found_count >= 2 to AmbiguousReference.
+                        return 0;
                     }
                 }
             }
@@ -227,7 +230,8 @@ namespace DetourModKit
                     if (!ZYAN_SUCCESS(ZydisDecoderDecodeFull(&decoder, bytes + offset,
                                                              window.span - offset, &insn, operands)))
                     {
-                        ++offset; // Byte-restart recovery: realign past data / jump tables.
+                        // Byte-restart recovery: realign past data / jump tables.
+                        ++offset;
                         continue;
                     }
 
@@ -264,7 +268,8 @@ namespace DetourModKit
                         }
                         else
                         {
-                            return 0; // Ambiguous; caller maps found_count >= 2 to AmbiguousReference.
+                            // Ambiguous; caller maps found_count >= 2 to AmbiguousReference.
+                            return 0;
                         }
                     }
 

--- a/src/win_file_stream.cpp
+++ b/src/win_file_stream.cpp
@@ -52,7 +52,8 @@ namespace DetourModKit
         if (mode & std::ios_base::app)
         {
             if (SetFilePointer(static_cast<HANDLE>(m_handle), 0, nullptr, FILE_END) ==
-                INVALID_SET_FILE_POINTER && GetLastError() != NO_ERROR)
+                    INVALID_SET_FILE_POINTER &&
+                GetLastError() != NO_ERROR)
             {
                 CloseHandle(static_cast<HANDLE>(m_handle));
                 m_handle = INVALID_HANDLE_VALUE;

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -63,7 +63,7 @@ namespace DetourModKit
     {
         bool expected = false;
         if (!m_joined.compare_exchange_strong(expected, true,
-                                             std::memory_order_acq_rel))
+                                              std::memory_order_acq_rel))
         {
             return;
         }

--- a/tests/bench_event_dispatcher.cpp
+++ b/tests/bench_event_dispatcher.cpp
@@ -101,7 +101,8 @@ namespace
 
         const BenchEvent evt{42};
         const auto total_start = Clock::now();
-        const double med = median_ns_per_op(iterations, samples, [&]() {
+        const double med = median_ns_per_op(iterations, samples, [&]()
+                                            {
             if (use_safe)
             {
                 dispatcher.emit_safe(evt);
@@ -109,8 +110,7 @@ namespace
             else
             {
                 dispatcher.emit(evt);
-            }
-        });
+            } });
         const auto total_end = Clock::now();
 
         const auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -130,10 +130,11 @@ namespace
         DetourModKit::EventDispatcher<BenchEvent> dispatcher;
 
         const auto total_start = Clock::now();
-        const double med = median_ns_per_op(iterations, samples, [&]() {
-            auto sub = dispatcher.subscribe(&noop_handler);
-            // sub destroyed here: triggers unsubscribe
-        });
+        const double med = median_ns_per_op(iterations, samples, [&]()
+                                            {
+                                                auto sub = dispatcher.subscribe(&noop_handler);
+                                                // sub destroyed here: triggers unsubscribe
+                                            });
         const auto total_end = Clock::now();
 
         const auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -166,7 +167,8 @@ namespace
 
         for (std::size_t t = 0; t < thread_count; ++t)
         {
-            workers.emplace_back([&dispatcher, &go, &evt, per_thread_iters]() {
+            workers.emplace_back([&dispatcher, &go, &evt, per_thread_iters]()
+                                 {
                 while (!go.load(std::memory_order_acquire))
                 {
                     std::this_thread::yield();
@@ -174,8 +176,7 @@ namespace
                 for (std::size_t i = 0; i < per_thread_iters; ++i)
                 {
                     dispatcher.emit(evt);
-                }
-            });
+                } });
         }
 
         const auto start = Clock::now();
@@ -207,17 +208,16 @@ namespace
 
         // Inside the handler, subscribe() will be rejected by the
         // reentrancy guard. The cost measured here is the rejection path.
-        auto sub = dispatcher.subscribe([&dispatcher](const BenchEvent &) {
+        auto sub = dispatcher.subscribe([&dispatcher](const BenchEvent &)
+                                        {
             auto inner = dispatcher.subscribe(&noop_handler);
-            (void)inner;
-        });
+            (void)inner; });
 
         const BenchEvent evt{0};
 
         const auto total_start = Clock::now();
-        const double med = median_ns_per_op(iterations, samples, [&]() {
-            dispatcher.emit(evt);
-        });
+        const double med = median_ns_per_op(iterations, samples, [&]()
+                                            { dispatcher.emit(evt); });
         const auto total_end = Clock::now();
 
         const auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/tests/bench_memory.cpp
+++ b/tests/bench_memory.cpp
@@ -163,7 +163,8 @@ namespace
         const std::size_t n = lat.size();
         if (n == 0)
             return {0, 0, 0};
-        auto pct = [&](double p) {
+        auto pct = [&](double p)
+        {
             const std::size_t idx = std::min(n - 1, static_cast<std::size_t>(p * static_cast<double>(n)));
             return lat[idx];
         };
@@ -204,7 +205,8 @@ namespace
 
         for (unsigned t = 0; t < threads; ++t)
         {
-            workers.emplace_back([&, t]() {
+            workers.emplace_back([&, t]()
+                                 {
                 auto &lat = per_thread[t];
                 lat.reserve(ops_per_thread);
                 // Each thread starts at a different offset so they collide on
@@ -225,8 +227,7 @@ namespace
                     sink(r ? 1u : 0u);
                     lat.push_back(static_cast<double>(
                         std::chrono::duration_cast<std::chrono::nanoseconds>(e - s).count()));
-                }
-            });
+                } });
         }
 
         go.store(true, std::memory_order_release);
@@ -343,18 +344,16 @@ int main()
     // --- Phase 1: cache OFF -> validators take the direct-VirtualQuery branch.
     Mem::shutdown_cache(); // ensure uninitialized
     std::printf("[1] Validation MISS / uncached (cache off -> VirtualQuery branch)\n");
-    const double ns_qry = median_ns_per_call(kIters, kSamples, [&]() {
+    const double ns_qry = median_ns_per_call(kIters, kSamples, [&]()
+                                             {
         MEMORY_BASIC_INFORMATION mbi;
-        sink(VirtualQuery(page, &mbi, sizeof(mbi)));
-    });
+        sink(VirtualQuery(page, &mbi, sizeof(mbi))); });
     report("raw VirtualQuery", ns_qry);
-    const double ns_isr_miss = median_ns_per_call(kIters, kSamples, [&]() {
-        sink(Mem::is_readable(page, 8) ? 1u : 0u);
-    });
+    const double ns_isr_miss = median_ns_per_call(kIters, kSamples, [&]()
+                                                  { sink(Mem::is_readable(page, 8) ? 1u : 0u); });
     report("is_readable MISS", ns_isr_miss);
-    const double ns_isw_miss = median_ns_per_call(kIters, kSamples, [&]() {
-        sink(Mem::is_writable(page, 8) ? 1u : 0u);
-    });
+    const double ns_isw_miss = median_ns_per_call(kIters, kSamples, [&]()
+                                                  { sink(Mem::is_writable(page, 8) ? 1u : 0u); });
     report("is_writable MISS", ns_isw_miss);
 
     // --- Phase 2: cache ON, warm -> validators hit the fresh entry.
@@ -366,37 +365,31 @@ int main()
     sink(Mem::is_readable(page, 8) ? 1u : 0u); // warm the entry
     sink(Mem::is_writable(page, 8) ? 1u : 0u);
     std::printf("\n[2] Validation WARM HIT (cache on, entry fresh within TTL)\n");
-    const double ns_isr_hit = median_ns_per_call(kIters, kSamples, [&]() {
-        sink(Mem::is_readable(page, 8) ? 1u : 0u);
-    });
+    const double ns_isr_hit = median_ns_per_call(kIters, kSamples, [&]()
+                                                 { sink(Mem::is_readable(page, 8) ? 1u : 0u); });
     report("is_readable HIT", ns_isr_hit);
-    const double ns_isw_hit = median_ns_per_call(kIters, kSamples, [&]() {
-        sink(Mem::is_writable(page, 8) ? 1u : 0u);
-    });
+    const double ns_isw_hit = median_ns_per_call(kIters, kSamples, [&]()
+                                                 { sink(Mem::is_writable(page, 8) ? 1u : 0u); });
     report("is_writable HIT", ns_isw_hit);
 
     // --- Phase 3: direct access primitives (no cache dependence).
     std::printf("\n[3] Direct access primitives\n");
-    const double ns_dread = median_ns_per_call(kIters, kSamples, [&]() {
-        sink(*reinterpret_cast<volatile std::uint64_t *>(page));
-    });
+    const double ns_dread = median_ns_per_call(kIters, kSamples, [&]()
+                                               { sink(*reinterpret_cast<volatile std::uint64_t *>(page)); });
     report("direct volatile load", ns_dread);
-    const double ns_unchecked = median_ns_per_call(kIters, kSamples, [&]() {
-        sink(Mem::read_ptr_unchecked(addr, 0));
-    });
+    const double ns_unchecked = median_ns_per_call(kIters, kSamples, [&]()
+                                                   { sink(Mem::read_ptr_unchecked(addr, 0)); });
     report("read_ptr_unchecked", ns_unchecked);
-    const double ns_sehread = median_ns_per_call(kIters, kSamples, [&]() {
+    const double ns_sehread = median_ns_per_call(kIters, kSamples, [&]()
+                                                 {
         auto v = Mem::seh_read<std::uint64_t>(addr);
-        sink(v ? *v : 0u);
-    });
+        sink(v ? *v : 0u); });
     report("seh_read<u64>", ns_sehread);
-    const double ns_dstore = median_ns_per_call(kIters, kSamples, [&]() {
-        *reinterpret_cast<volatile std::uint64_t *>(page) = g_sink.load(std::memory_order_relaxed);
-    });
+    const double ns_dstore = median_ns_per_call(kIters, kSamples, [&]()
+                                                { *reinterpret_cast<volatile std::uint64_t *>(page) = g_sink.load(std::memory_order_relaxed); });
     report("direct volatile store", ns_dstore);
-    const double ns_wbytes = median_ns_per_call(kWriteIters, kSamples, [&]() {
-        (void)Mem::write_bytes(reinterpret_cast<std::byte *>(page), src, 8);
-    });
+    const double ns_wbytes = median_ns_per_call(kWriteIters, kSamples, [&]()
+                                                { (void)Mem::write_bytes(reinterpret_cast<std::byte *>(page), src, 8); });
     report("write_bytes(8)", ns_wbytes);
 
     std::printf("\n  cache stats: %s\n", Mem::get_cache_stats().c_str());
@@ -412,10 +405,10 @@ int main()
             grow_vad(target - grown);
             grown = target;
         }
-        const double ns = median_ns_per_call(kIters, kSamples, [&]() {
+        const double ns = median_ns_per_call(kIters, kSamples, [&]()
+                                             {
             MEMORY_BASIC_INFORMATION mbi;
-            sink(VirtualQuery(page, &mbi, sizeof(mbi)));
-        });
+            sink(VirtualQuery(page, &mbi, sizeof(mbi))); });
         std::printf("  +%6zu reserved regions   %10.2f ns/call\n", grown, ns);
     }
 
@@ -493,7 +486,8 @@ int main()
     const std::span<const std::ptrdiff_t> chain_span{chain_offsets};
 
     std::printf("\n[8] Pointer chain (%zu links, warm cache)\n", CHAIN_CELLS);
-    const double ns_gated_walk = median_ns_per_call(kIters, kSamples, [&]() {
+    const double ns_gated_walk = median_ns_per_call(kIters, kSamples, [&]()
+                                                    {
         std::uintptr_t cur = chain_base;
         bool ok = true;
         for (std::size_t i = 0; i + 1 < CHAIN_CELLS; ++i)
@@ -508,18 +502,17 @@ int main()
         std::uint64_t v = 0;
         if (ok && Mem::is_readable(reinterpret_cast<void *>(cur), sizeof(std::uint64_t)))
             v = *reinterpret_cast<volatile std::uint64_t *>(cur);
-        sink(v);
-    });
+        sink(v); });
     report("gated link walk", ns_gated_walk);
-    const double ns_resolve_chain = median_ns_per_call(kIters, kSamples, [&]() {
+    const double ns_resolve_chain = median_ns_per_call(kIters, kSamples, [&]()
+                                                       {
         const auto a = Mem::seh_resolve_chain(chain_base, chain_span);
-        sink(a ? *a : 0u);
-    });
+        sink(a ? *a : 0u); });
     report("seh_resolve_chain", ns_resolve_chain);
-    const double ns_read_chain = median_ns_per_call(kIters, kSamples, [&]() {
+    const double ns_read_chain = median_ns_per_call(kIters, kSamples, [&]()
+                                                    {
         const auto v = Mem::seh_read_chain<std::uint64_t>(chain_base, chain_span);
-        sink(v ? *v : 0u);
-    });
+        sink(v ? *v : 0u); });
     report("seh_read_chain<u64>", ns_read_chain);
     std::printf("  gated/seh_read_chain ratio: %.1fx\n",
                 ns_read_chain > 0 ? ns_gated_walk / ns_read_chain : 0.0);

--- a/tests/bench_scanner.cpp
+++ b/tests/bench_scanner.cpp
@@ -221,19 +221,19 @@ namespace
         g_sink.fetch_add(reinterpret_cast<std::uintptr_t>(warm_smart),
                          std::memory_order_relaxed);
 
-        const double us_smart = median_us_per_iter(iterations, samples, [&]() {
+        const double us_smart = median_us_per_iter(iterations, samples, [&]()
+                                                   {
             const auto *m =
                 DetourModKit::Scanner::find_pattern(buffer.data(), buffer.size(), smart);
             g_sink.fetch_add(reinterpret_cast<std::uintptr_t>(m),
-                             std::memory_order_relaxed);
-        });
+                             std::memory_order_relaxed); });
 
-        const double us_naive = median_us_per_iter(iterations, samples, [&]() {
+        const double us_naive = median_us_per_iter(iterations, samples, [&]()
+                                                   {
             const auto *m =
                 DetourModKit::Scanner::find_pattern(buffer.data(), buffer.size(), naive);
             g_sink.fetch_add(reinterpret_cast<std::uintptr_t>(m),
-                             std::memory_order_relaxed);
-        });
+                             std::memory_order_relaxed); });
 
         const double speedup = us_naive / us_smart;
         const double smart_throughput = 1.0e6 / us_smart;

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -1679,4 +1679,3 @@ TEST(LogMessageMoveTest, MovedFromMessageReturnsEmpty)
 
     EXPECT_TRUE(src.message().empty());
 }
-

--- a/tests/test_bootstrap.cpp
+++ b/tests/test_bootstrap.cpp
@@ -486,10 +486,11 @@ TEST(BootstrapOnLogicDllUnload, IsIdempotent)
 
     void *trampoline = nullptr;
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "logic_unload_idem",
-        reinterpret_cast<uintptr_t>(&logic_unload_target_add),
-        reinterpret_cast<void *>(&logic_unload_detour_add),
-        &trampoline).has_value());
+                                               "logic_unload_idem",
+                                               reinterpret_cast<uintptr_t>(&logic_unload_target_add),
+                                               reinterpret_cast<void *>(&logic_unload_detour_add),
+                                               &trampoline)
+                    .has_value());
     InputManager::get_instance().register_press(
         "logic_unload_idem_bind", {keyboard_key(0x42)}, []() {});
 
@@ -510,17 +511,19 @@ TEST(BootstrapOnLogicDllUnloadAll, RemovesAllHooksAndBindings)
 
     void *trampoline_add = nullptr;
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "logic_unload_all_add",
-        reinterpret_cast<uintptr_t>(&logic_unload_target_add),
-        reinterpret_cast<void *>(&logic_unload_detour_add),
-        &trampoline_add).has_value());
+                                               "logic_unload_all_add",
+                                               reinterpret_cast<uintptr_t>(&logic_unload_target_add),
+                                               reinterpret_cast<void *>(&logic_unload_detour_add),
+                                               &trampoline_add)
+                    .has_value());
 
     void *trampoline_sub = nullptr;
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "logic_unload_all_sub",
-        reinterpret_cast<uintptr_t>(&logic_unload_target_sub),
-        reinterpret_cast<void *>(&logic_unload_detour_sub),
-        &trampoline_sub).has_value());
+                                               "logic_unload_all_sub",
+                                               reinterpret_cast<uintptr_t>(&logic_unload_target_sub),
+                                               reinterpret_cast<void *>(&logic_unload_detour_sub),
+                                               &trampoline_sub)
+                    .has_value());
 
     InputManager::get_instance().register_press(
         "logic_unload_all_bind_a", {keyboard_key(0x43)}, []() {});
@@ -548,10 +551,11 @@ TEST(BootstrapOnLogicDllUnloadAll, IsIdempotent)
 
     void *trampoline = nullptr;
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "logic_unload_all_idem",
-        reinterpret_cast<uintptr_t>(&logic_unload_target_add),
-        reinterpret_cast<void *>(&logic_unload_detour_add),
-        &trampoline).has_value());
+                                               "logic_unload_all_idem",
+                                               reinterpret_cast<uintptr_t>(&logic_unload_target_add),
+                                               reinterpret_cast<void *>(&logic_unload_detour_add),
+                                               &trampoline)
+                    .has_value());
     InputManager::get_instance().register_press(
         "logic_unload_all_idem_bind", {keyboard_key(0x45)}, []() {});
 
@@ -582,16 +586,18 @@ TEST(BootstrapOnLogicDllUnloadAll, CoexistsWithNamedOverload)
 
     void *trampoline_named = nullptr;
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "logic_unload_mixed_named",
-        reinterpret_cast<uintptr_t>(&logic_unload_target_add),
-        reinterpret_cast<void *>(&logic_unload_detour_add),
-        &trampoline_named).has_value());
+                                               "logic_unload_mixed_named",
+                                               reinterpret_cast<uintptr_t>(&logic_unload_target_add),
+                                               reinterpret_cast<void *>(&logic_unload_detour_add),
+                                               &trampoline_named)
+                    .has_value());
     void *trampoline_residual = nullptr;
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "logic_unload_mixed_residual",
-        reinterpret_cast<uintptr_t>(&logic_unload_target_sub),
-        reinterpret_cast<void *>(&logic_unload_detour_sub),
-        &trampoline_residual).has_value());
+                                               "logic_unload_mixed_residual",
+                                               reinterpret_cast<uintptr_t>(&logic_unload_target_sub),
+                                               reinterpret_cast<void *>(&logic_unload_detour_sub),
+                                               &trampoline_residual)
+                    .has_value());
 
     InputManager::get_instance().register_press(
         "logic_unload_mixed_named_bind", {keyboard_key(0x46)}, []() {});
@@ -713,8 +719,14 @@ namespace
         ~LoadedFixtureModule() { unload(); }
     };
 
-    int __cdecl fixture_detour_compute_damage(int, int) { return 0xC0DE; }
-    int __cdecl fixture_detour_compute_armor(int, int) { return 0xCAFE; }
+    int __cdecl fixture_detour_compute_damage(int, int)
+    {
+        return 0xC0DE;
+    }
+    int __cdecl fixture_detour_compute_armor(int, int)
+    {
+        return 0xCAFE;
+    }
 } // namespace
 
 // Drives the Bootstrap helpers through a real LoadLibrary / FreeLibrary cycle
@@ -732,15 +744,17 @@ TEST(BootstrapOnLogicDllUnload, FixtureDllRoundTrip)
     void *tramp_damage = nullptr;
     void *tramp_armor = nullptr;
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "fixture_dll_damage",
-        reinterpret_cast<uintptr_t>(mod.compute_damage),
-        reinterpret_cast<void *>(&fixture_detour_compute_damage),
-        &tramp_damage).has_value());
+                                               "fixture_dll_damage",
+                                               reinterpret_cast<uintptr_t>(mod.compute_damage),
+                                               reinterpret_cast<void *>(&fixture_detour_compute_damage),
+                                               &tramp_damage)
+                    .has_value());
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "fixture_dll_armor",
-        reinterpret_cast<uintptr_t>(mod.compute_armor),
-        reinterpret_cast<void *>(&fixture_detour_compute_armor),
-        &tramp_armor).has_value());
+                                               "fixture_dll_armor",
+                                               reinterpret_cast<uintptr_t>(mod.compute_armor),
+                                               reinterpret_cast<void *>(&fixture_detour_compute_armor),
+                                               &tramp_armor)
+                    .has_value());
 
     InputManager::get_instance().register_press(
         "fixture_dll_bind_a", {keyboard_key(0x4A)}, []() {});
@@ -800,15 +814,17 @@ TEST(BootstrapOnLogicDllUnloadAll, FixtureDllRoundTrip)
     void *tramp_damage = nullptr;
     void *tramp_armor = nullptr;
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "fixture_all_damage",
-        reinterpret_cast<uintptr_t>(mod.compute_damage),
-        reinterpret_cast<void *>(&fixture_detour_compute_damage),
-        &tramp_damage).has_value());
+                                               "fixture_all_damage",
+                                               reinterpret_cast<uintptr_t>(mod.compute_damage),
+                                               reinterpret_cast<void *>(&fixture_detour_compute_damage),
+                                               &tramp_damage)
+                    .has_value());
     ASSERT_TRUE(HookManager::get_instance().create_inline_hook(
-        "fixture_all_armor",
-        reinterpret_cast<uintptr_t>(mod.compute_armor),
-        reinterpret_cast<void *>(&fixture_detour_compute_armor),
-        &tramp_armor).has_value());
+                                               "fixture_all_armor",
+                                               reinterpret_cast<uintptr_t>(mod.compute_armor),
+                                               reinterpret_cast<void *>(&fixture_detour_compute_armor),
+                                               &tramp_armor)
+                    .has_value());
     InputManager::get_instance().register_press(
         "fixture_all_bind", {keyboard_key(0x4C)}, []() {});
 
@@ -832,11 +848,12 @@ TEST(BootstrapOnLogicDllUnloadAll, FixtureDllRoundTrip)
     HookConfig strict;
     strict.fail_if_already_hooked = true;
     EXPECT_TRUE(HookManager::get_instance().create_inline_hook(
-        "fixture_all_damage_reloaded",
-        reinterpret_cast<uintptr_t>(mod.compute_damage),
-        reinterpret_cast<void *>(&fixture_detour_compute_damage),
-        &tramp_reload,
-        strict).has_value());
+                                               "fixture_all_damage_reloaded",
+                                               reinterpret_cast<uintptr_t>(mod.compute_damage),
+                                               reinterpret_cast<void *>(&fixture_detour_compute_damage),
+                                               &tramp_reload,
+                                               strict)
+                    .has_value());
 
     HookManager::get_instance().remove_all_hooks();
 }

--- a/tests/test_code_constant.cpp
+++ b/tests/test_code_constant.cpp
@@ -163,7 +163,7 @@ TEST(CodeConstantTest, ReportsCurrentValueNotStaleNominal)
     cc.site = cands;
     cc.kind = Scanner::OperandKind::Immediate;
     cc.operand_index = 1;
-    cc.nominal = 0xE0;     // a stale last-known value
+    cc.nominal = 0xE0; // a stale last-known value
     cc.has_nominal = true;
 
     // The drift case: nominal differs from the live value; the live value wins.

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -14,9 +14,9 @@
 #include "DetourModKit/input.hpp"
 
 using namespace DetourModKit;
+using DetourModKit::gamepad_button;
 using DetourModKit::keyboard_key;
 using DetourModKit::mouse_button;
-using DetourModKit::gamepad_button;
 
 class ConfigTest : public ::testing::Test
 {
@@ -248,10 +248,8 @@ TEST_F(ConfigTest, KeyCombo_CommentOnlyLineYieldsEmpty)
     ini_file.close();
 
     Config::KeyComboList test_value;
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys",
-                               [&test_value](const Config::KeyComboList &c)
-                               { test_value = c; },
-                               "");
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
+                               { test_value = c; }, "");
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
     EXPECT_TRUE(test_value.empty());
 }
@@ -264,10 +262,8 @@ TEST_F(ConfigTest, KeyCombo_EmptyCommaSeparatorsAreSkipped)
     ini_file.close();
 
     Config::KeyComboList test_value;
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys",
-                               [&test_value](const Config::KeyComboList &c)
-                               { test_value = c; },
-                               "");
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
+                               { test_value = c; }, "");
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
     ASSERT_EQ(test_value.size(), 2u);
     EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x72));
@@ -282,10 +278,8 @@ TEST_F(ConfigTest, KeyCombo_HexWithOnlyPrefixIsSkipped)
     ini_file.close();
 
     Config::KeyComboList test_value;
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys",
-                               [&test_value](const Config::KeyComboList &c)
-                               { test_value = c; },
-                               "");
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
+                               { test_value = c; }, "");
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
     ASSERT_EQ(test_value.size(), 1u);
     EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x72));
@@ -300,10 +294,8 @@ TEST_F(ConfigTest, KeyCombo_HexValueAboveIntMaxIsSkipped)
     ini_file.close();
 
     Config::KeyComboList test_value;
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys",
-                               [&test_value](const Config::KeyComboList &c)
-                               { test_value = c; },
-                               "");
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
+                               { test_value = c; }, "");
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
     ASSERT_EQ(test_value.size(), 1u);
     EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x10));
@@ -317,10 +309,8 @@ TEST_F(ConfigTest, KeyCombo_DoublePlusSkipsEmptySegment)
     ini_file.close();
 
     Config::KeyComboList test_value;
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys",
-                               [&test_value](const Config::KeyComboList &c)
-                               { test_value = c; },
-                               "");
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
+                               { test_value = c; }, "");
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
     ASSERT_EQ(test_value.size(), 1u);
     ASSERT_EQ(test_value[0].modifiers.size(), 1u);
@@ -339,10 +329,8 @@ TEST_F(ConfigTest, KeyCombo_TrailingPlusParsedAsTrigger)
     ini_file.close();
 
     Config::KeyComboList test_value;
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys",
-                               [&test_value](const Config::KeyComboList &c)
-                               { test_value = c; },
-                               "");
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
+                               { test_value = c; }, "");
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
     ASSERT_EQ(test_value.size(), 1u);
     EXPECT_EQ(test_value[0].keys[0], keyboard_key(0x11));
@@ -357,10 +345,8 @@ TEST_F(ConfigTest, KeyCombo_OnlyPlusSignsYieldsEmpty)
     ini_file.close();
 
     Config::KeyComboList test_value;
-    Config::register_key_combo("TestSection", "TestKeys", "test_keys",
-                               [&test_value](const Config::KeyComboList &c)
-                               { test_value = c; },
-                               "F3");
+    Config::register_key_combo("TestSection", "TestKeys", "test_keys", [&test_value](const Config::KeyComboList &c)
+                               { test_value = c; }, "F3");
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
     EXPECT_TRUE(test_value.empty());
 }
@@ -369,10 +355,8 @@ TEST_F(ConfigTest, KeyCombo_DefaultParsesMultipleCombos)
 {
     Config::KeyComboList captured;
 
-    Config::register_key_combo("Hotkeys", "Toggle", "toggle",
-                               [&captured](const Config::KeyComboList &c)
-                               { captured = c; },
-                               "Ctrl+F3,Gamepad_LT+Gamepad_A");
+    Config::register_key_combo("Hotkeys", "Toggle", "toggle", [&captured](const Config::KeyComboList &c)
+                               { captured = c; }, "Ctrl+F3,Gamepad_LT+Gamepad_A");
     EXPECT_NO_THROW(Config::load(test_ini_file_.string()));
 
     ASSERT_EQ(captured.size(), 2u);
@@ -869,7 +853,6 @@ TEST_F(ConfigTest, RegisterString_DefaultValueNotMovedFrom)
     EXPECT_EQ(val, "my_default");
 }
 
-
 TEST_F(ConfigTest, RegisterKeyCombo_SingleKey)
 {
     Config::KeyComboList combo;
@@ -1363,14 +1346,11 @@ TEST_F(ConfigTest, AccumulativeSetterMustBeIdempotent)
 
     std::vector<std::string> items;
 
-    Config::register_string("TestSection", "Items", "items",
-                            [&items](const std::string &v)
+    Config::register_string("TestSection", "Items", "items", [&items](const std::string &v)
                             {
                                 // Idempotent pattern: clear before applying
                                 items.clear();
-                                items.push_back(v);
-                            },
-                            "default_item");
+                                items.push_back(v); }, "default_item");
 
     // After registration: ["default_item"]
     ASSERT_EQ(items.size(), 1u);
@@ -1521,18 +1501,12 @@ TEST_F(ConfigTest, Reload_PreservesRegistrations)
     std::vector<bool> bool_invocations;
     std::vector<std::string> string_invocations;
 
-    Config::register_int("S", "Count", "count",
-                         [&](int v)
-                         { int_invocations.push_back(v); },
-                         0);
-    Config::register_bool("S", "Enabled", "enabled",
-                          [&](bool v)
-                          { bool_invocations.push_back(v); },
-                          false);
-    Config::register_string("S", "Label", "label",
-                            [&](const std::string &v)
-                            { string_invocations.push_back(v); },
-                            std::string("default"));
+    Config::register_int("S", "Count", "count", [&](int v)
+                         { int_invocations.push_back(v); }, 0);
+    Config::register_bool("S", "Enabled", "enabled", [&](bool v)
+                          { bool_invocations.push_back(v); }, false);
+    Config::register_string("S", "Label", "label", [&](const std::string &v)
+                            { string_invocations.push_back(v); }, std::string("default"));
 
     {
         std::ofstream f(test_ini_file_);
@@ -1573,28 +1547,21 @@ TEST_F(ConfigTest, Reload_SetterThrows_RemainingSettersStillRun)
     std::atomic<int> third_value{0};
     std::atomic<int> throw_count{0};
 
-    Config::register_int("S", "First", "first",
-                         [&first_value](int v)
-                         { first_value.store(v, std::memory_order_release); },
-                         0);
+    Config::register_int("S", "First", "first", [&first_value](int v)
+                         { first_value.store(v, std::memory_order_release); }, 0);
     // Setter fires once at register, once at load, once at reload; start
     // throwing only on the third invocation so the failure lands on the
     // reload path.
-    Config::register_int("S", "Middle", "middle",
-                         [&throw_count](int /*v*/)
+    Config::register_int("S", "Middle", "middle", [&throw_count](int /*v*/)
                          {
                              const int calls =
                                  throw_count.fetch_add(1, std::memory_order_relaxed) + 1;
                              if (calls >= 3)
                              {
                                  throw std::runtime_error("middle setter deliberately throws");
-                             }
-                         },
-                         0);
-    Config::register_int("S", "Third", "third",
-                         [&third_value](int v)
-                         { third_value.store(v, std::memory_order_release); },
-                         0);
+                             } }, 0);
+    Config::register_int("S", "Third", "third", [&third_value](int v)
+                         { third_value.store(v, std::memory_order_release); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -1621,10 +1588,8 @@ TEST_F(ConfigTest, Reload_AfterClear_ReturnsFalse_BecausePathCleared)
     // clear_registered_items() also clears the remembered INI path, so
     // reload() takes the no-last-loaded-path branch (not a no-items one).
     int value = 0;
-    Config::register_int("S", "K", "k",
-                         [&value](int v)
-                         { value = v; },
-                         1);
+    Config::register_int("S", "K", "k", [&value](int v)
+                         { value = v; }, 1);
 
     {
         std::ofstream f(test_ini_file_);
@@ -1642,10 +1607,8 @@ TEST_F(ConfigTest, ReloadHotkey_RegistersBinding)
     InputManager::get_instance().shutdown();
 
     int value = 0;
-    Config::register_int("S", "K", "k",
-                         [&value](int v)
-                         { value = v; },
-                         1);
+    Config::register_int("S", "K", "k", [&value](int v)
+                         { value = v; }, 1);
 
     {
         std::ofstream f(test_ini_file_);
@@ -1692,10 +1655,8 @@ TEST_F(ConfigTest, ReloadHotkey_ActuallyFiresOnPress)
     InputManager::get_instance().shutdown();
 
     int value = 0;
-    Config::register_int("S", "K", "k",
-                         [&value](int v)
-                         { value = v; },
-                         1);
+    Config::register_int("S", "K", "k", [&value](int v)
+                         { value = v; }, 1);
 
     {
         std::ofstream f(test_ini_file_);
@@ -1738,10 +1699,8 @@ TEST_F(ConfigTest, DisableAutoReload_FromReloadCallback_DoesNotDeadlock)
     Config::disable_auto_reload();
 
     std::atomic<int> current_value{0};
-    Config::register_int("S", "K", "k",
-                         [&](int v)
-                         { current_value.store(v, std::memory_order_release); },
-                         0);
+    Config::register_int("S", "K", "k", [&](int v)
+                         { current_value.store(v, std::memory_order_release); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -1791,13 +1750,10 @@ TEST_F(ConfigTest, AutoReload_EndToEnd)
     std::atomic<int> current_value{0};
     std::atomic<int> setter_invocations{0};
 
-    Config::register_int("S", "K", "k",
-                         [&](int v)
+    Config::register_int("S", "K", "k", [&](int v)
                          {
                              current_value.store(v, std::memory_order_release);
-                             setter_invocations.fetch_add(1, std::memory_order_relaxed);
-                         },
-                         0);
+                             setter_invocations.fetch_add(1, std::memory_order_relaxed); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -1869,10 +1825,8 @@ TEST_F(ConfigTest, AutoReload_Enable_ReportsAlreadyRunning)
     Config::disable_auto_reload();
 
     int value = 0;
-    Config::register_int("S", "K", "k",
-                         [&value](int v)
-                         { value = v; },
-                         0);
+    Config::register_int("S", "K", "k", [&value](int v)
+                         { value = v; }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -1905,10 +1859,8 @@ TEST_F(ConfigTest, AutoReload_Enable_ReportsStartFailed)
     }
 
     int value = 0;
-    Config::register_int("S", "K", "k",
-                         [&value](int v)
-                         { value = v; },
-                         0);
+    Config::register_int("S", "K", "k", [&value](int v)
+                         { value = v; }, 0);
     ASSERT_NO_THROW(Config::load(ini_path.string()));
 
     // Destroy the parent directory so CreateFileW fails inside start().
@@ -1938,10 +1890,8 @@ TEST_F(ConfigTest, AutoReload_Enable_AfterStartFailed_RecoversOnRetry)
     }
 
     int value = 0;
-    Config::register_int("S", "K", "k",
-                         [&value](int v)
-                         { value = v; },
-                         0);
+    Config::register_int("S", "K", "k", [&value](int v)
+                         { value = v; }, 0);
     ASSERT_NO_THROW(Config::load(ini_path.string()));
 
     // Remove the watched directory to drive start() into StartFailed.
@@ -1972,10 +1922,8 @@ TEST_F(ConfigTest, AutoReload_Enable_AfterStartFailed_RecoversOnRetry)
 TEST_F(ConfigTest, Reload_ContentUnchanged_SkipsSetters)
 {
     std::atomic<int> setter_hits{0};
-    Config::register_int("S", "K", "k",
-                         [&](int /*v*/)
-                         { setter_hits.fetch_add(1, std::memory_order_relaxed); },
-                         0);
+    Config::register_int("S", "K", "k", [&](int /*v*/)
+                         { setter_hits.fetch_add(1, std::memory_order_relaxed); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -1994,10 +1942,8 @@ TEST_F(ConfigTest, Reload_ContentUnchanged_SkipsSetters)
 TEST_F(ConfigTest, Reload_ContentChanged_RunsSetters)
 {
     std::atomic<int> setter_hits{0};
-    Config::register_int("S", "K", "k",
-                         [&](int /*v*/)
-                         { setter_hits.fetch_add(1, std::memory_order_relaxed); },
-                         0);
+    Config::register_int("S", "K", "k", [&](int /*v*/)
+                         { setter_hits.fetch_add(1, std::memory_order_relaxed); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -2024,10 +1970,8 @@ TEST_F(ConfigTest, Reload_FileUnreadable_FallsBackToReload)
     // existing contract when SimpleIni itself fails to open the file)
     // and does not crash.
     std::atomic<int> setter_hits{0};
-    Config::register_int("S", "K", "k",
-                         [&](int /*v*/)
-                         { setter_hits.fetch_add(1, std::memory_order_relaxed); },
-                         0);
+    Config::register_int("S", "K", "k", [&](int /*v*/)
+                         { setter_hits.fetch_add(1, std::memory_order_relaxed); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -2055,15 +1999,12 @@ TEST_F(ConfigTest, Servicer_RapidPresses_CoalesceToAtMostOneReloadPerBurst)
     // most once; subsequent unchanged-bytes calls short-circuit on the
     // content hash.
     std::atomic<int> setter_hits{0};
-    Config::register_int("S", "K", "k",
-                         [&](int /*v*/)
+    Config::register_int("S", "K", "k", [&](int /*v*/)
                          {
                              // Sleep so overlapping reload() calls from
                              // multiple threads actually race.
                              std::this_thread::sleep_for(std::chrono::milliseconds{10});
-                             setter_hits.fetch_add(1, std::memory_order_relaxed);
-                         },
-                         0);
+                             setter_hits.fetch_add(1, std::memory_order_relaxed); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -2079,7 +2020,8 @@ TEST_F(ConfigTest, Servicer_RapidPresses_CoalesceToAtMostOneReloadPerBurst)
     threads.reserve(kThreads);
     for (int i = 0; i < kThreads; ++i)
     {
-        threads.emplace_back([] { (void)Config::reload(); });
+        threads.emplace_back([]
+                             { (void)Config::reload(); });
     }
     for (auto &t : threads)
     {
@@ -2091,7 +2033,8 @@ TEST_F(ConfigTest, Servicer_RapidPresses_CoalesceToAtMostOneReloadPerBurst)
     const int delta = setter_hits.load(std::memory_order_relaxed) - baseline;
     EXPECT_LE(delta, 1)
         << "Content-hash skip must collapse concurrent unchanged-bytes reloads "
-           "to at most one setter pass (observed delta=" << delta << ").";
+           "to at most one setter pass (observed delta="
+        << delta << ").";
 }
 
 TEST_F(ConfigTest, Reload_WatcherPath_HashSkip_EmitsOnReloadFalse)
@@ -2101,10 +2044,8 @@ TEST_F(ConfigTest, Reload_WatcherPath_HashSkip_EmitsOnReloadFalse)
     Config::disable_auto_reload();
 
     std::atomic<int> current_value{0};
-    Config::register_int("S", "K", "k",
-                         [&](int v)
-                         { current_value.store(v, std::memory_order_release); },
-                         0);
+    Config::register_int("S", "K", "k", [&](int v)
+                         { current_value.store(v, std::memory_order_release); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -2182,13 +2123,13 @@ TEST_F(ConfigTest, Reload_EmptyFile_DoesNotCrash)
     // SimpleIni treats a zero-byte buffer as SI_OK with no sections; a
     // subsequent reload() against the same empty bytes must hash-skip.
     std::atomic<int> setter_hits{0};
-    Config::register_int("S", "K", "k",
-                         [&](int /*v*/)
-                         { setter_hits.fetch_add(1, std::memory_order_relaxed); },
-                         7);
+    Config::register_int("S", "K", "k", [&](int /*v*/)
+                         { setter_hits.fetch_add(1, std::memory_order_relaxed); }, 7);
 
     // Create an empty file.
-    { std::ofstream f(test_ini_file_, std::ios::binary); }
+    {
+        std::ofstream f(test_ini_file_, std::ios::binary);
+    }
     ASSERT_TRUE(std::filesystem::exists(test_ini_file_));
     ASSERT_EQ(std::filesystem::file_size(test_ini_file_), 0u);
 
@@ -2212,10 +2153,8 @@ TEST_F(ConfigTest, Reload_HashResetOnLoadFailure)
     // A load() against a missing file must clear the cached content
     // hash so a later successful load() cannot spuriously hash-skip.
     std::atomic<int> setter_hits{0};
-    Config::register_int("S", "K", "k",
-                         [&](int /*v*/)
-                         { setter_hits.fetch_add(1, std::memory_order_relaxed); },
-                         0);
+    Config::register_int("S", "K", "k", [&](int /*v*/)
+                         { setter_hits.fetch_add(1, std::memory_order_relaxed); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -2249,10 +2188,8 @@ TEST_F(ConfigTest, Reload_HashResetOnReadFailure)
     // reload() read failure. A stale hash would let a subsequent
     // identical-bytes reload hash-skip and leave state at defaults.
     std::atomic<int> setter_hits{0};
-    Config::register_int("S", "K", "k",
-                         [&](int /*v*/)
-                         { setter_hits.fetch_add(1, std::memory_order_relaxed); },
-                         0);
+    Config::register_int("S", "K", "k", [&](int /*v*/)
+                         { setter_hits.fetch_add(1, std::memory_order_relaxed); }, 0);
 
     {
         std::ofstream f(test_ini_file_);
@@ -2288,7 +2225,8 @@ TEST_F(ConfigTest, RegisterPressCombo_EmptyDefaultRegistersName)
     auto guard = Config::register_press_combo(
         "Input", "EmptyDefaultKey", "binding with empty default",
         "empty-default-binding",
-        [&]() { press_count.fetch_add(1, std::memory_order_relaxed); },
+        [&]()
+        { press_count.fetch_add(1, std::memory_order_relaxed); },
         "");
 
     EXPECT_EQ(InputManager::get_instance().binding_count(), static_cast<size_t>(1))

--- a/tests/test_event_dispatcher.cpp
+++ b/tests/test_event_dispatcher.cpp
@@ -52,9 +52,8 @@ TEST(EventDispatcherTest, EmitCallsHandler)
     EventDispatcher<SimpleEvent> dispatcher;
     int received = 0;
 
-    auto sub = dispatcher.subscribe([&received](const SimpleEvent &e) {
-        received = e.value;
-    });
+    auto sub = dispatcher.subscribe([&received](const SimpleEvent &e)
+                                    { received = e.value; });
 
     dispatcher.emit(SimpleEvent{99});
     EXPECT_EQ(received, 99);
@@ -65,9 +64,12 @@ TEST(EventDispatcherTest, EmitCallsMultipleHandlers)
     EventDispatcher<SimpleEvent> dispatcher;
     int count = 0;
 
-    auto sub1 = dispatcher.subscribe([&count](const SimpleEvent &) { ++count; });
-    auto sub2 = dispatcher.subscribe([&count](const SimpleEvent &) { ++count; });
-    auto sub3 = dispatcher.subscribe([&count](const SimpleEvent &) { ++count; });
+    auto sub1 = dispatcher.subscribe([&count](const SimpleEvent &)
+                                     { ++count; });
+    auto sub2 = dispatcher.subscribe([&count](const SimpleEvent &)
+                                     { ++count; });
+    auto sub3 = dispatcher.subscribe([&count](const SimpleEvent &)
+                                     { ++count; });
 
     dispatcher.emit(SimpleEvent{1});
     EXPECT_EQ(count, 3);
@@ -78,9 +80,8 @@ TEST(EventDispatcherTest, EmitPassesEventByConstRef)
     EventDispatcher<StringEvent> dispatcher;
     std::string captured;
 
-    auto sub = dispatcher.subscribe([&captured](const StringEvent &e) {
-        captured = e.message;
-    });
+    auto sub = dispatcher.subscribe([&captured](const StringEvent &e)
+                                    { captured = e.message; });
 
     dispatcher.emit(StringEvent{"hello world"});
     EXPECT_EQ(captured, "hello world");
@@ -94,7 +95,8 @@ TEST(EventDispatcherTest, SubscriptionUnsubscribesOnDestruction)
     int count = 0;
 
     {
-        auto sub = dispatcher.subscribe([&count](const SimpleEvent &) { ++count; });
+        auto sub = dispatcher.subscribe([&count](const SimpleEvent &)
+                                        { ++count; });
         dispatcher.emit(SimpleEvent{1});
         EXPECT_EQ(count, 1);
         EXPECT_EQ(dispatcher.subscriber_count(), 1u);
@@ -111,7 +113,8 @@ TEST(EventDispatcherTest, SubscriptionReset_Unsubscribes)
     EventDispatcher<SimpleEvent> dispatcher;
     int count = 0;
 
-    auto sub = dispatcher.subscribe([&count](const SimpleEvent &) { ++count; });
+    auto sub = dispatcher.subscribe([&count](const SimpleEvent &)
+                                    { ++count; });
     dispatcher.emit(SimpleEvent{1});
     EXPECT_EQ(count, 1);
 
@@ -136,7 +139,8 @@ TEST(EventDispatcherTest, SubscriptionMoveConstructor)
     EventDispatcher<SimpleEvent> dispatcher;
     int count = 0;
 
-    auto sub1 = dispatcher.subscribe([&count](const SimpleEvent &) { ++count; });
+    auto sub1 = dispatcher.subscribe([&count](const SimpleEvent &)
+                                     { ++count; });
     auto sub2 = std::move(sub1);
 
     EXPECT_FALSE(sub1.active()); // NOLINT: testing moved-from state
@@ -153,8 +157,10 @@ TEST(EventDispatcherTest, SubscriptionMoveAssignment)
     int count_a = 0;
     int count_b = 0;
 
-    auto sub_a = dispatcher.subscribe([&count_a](const SimpleEvent &) { ++count_a; });
-    auto sub_b = dispatcher.subscribe([&count_b](const SimpleEvent &) { ++count_b; });
+    auto sub_a = dispatcher.subscribe([&count_a](const SimpleEvent &)
+                                      { ++count_a; });
+    auto sub_b = dispatcher.subscribe([&count_b](const SimpleEvent &)
+                                      { ++count_b; });
     EXPECT_EQ(dispatcher.subscriber_count(), 2u);
 
     // Move-assign sub_b over sub_a. sub_a's old handler is unsubscribed.
@@ -181,8 +187,10 @@ TEST(EventDispatcherTest, UnsubscribeOne_LeavesOthers)
     int count_a = 0;
     int count_b = 0;
 
-    auto sub_a = dispatcher.subscribe([&count_a](const SimpleEvent &) { ++count_a; });
-    auto sub_b = dispatcher.subscribe([&count_b](const SimpleEvent &) { ++count_b; });
+    auto sub_a = dispatcher.subscribe([&count_a](const SimpleEvent &)
+                                      { ++count_a; });
+    auto sub_b = dispatcher.subscribe([&count_b](const SimpleEvent &)
+                                      { ++count_b; });
 
     sub_a.reset();
 
@@ -198,8 +206,10 @@ TEST(EventDispatcherTest, Clear_RemovesAllSubscribers)
     EventDispatcher<SimpleEvent> dispatcher;
     int count = 0;
 
-    auto sub1 = dispatcher.subscribe([&count](const SimpleEvent &) { ++count; });
-    auto sub2 = dispatcher.subscribe([&count](const SimpleEvent &) { ++count; });
+    auto sub1 = dispatcher.subscribe([&count](const SimpleEvent &)
+                                     { ++count; });
+    auto sub2 = dispatcher.subscribe([&count](const SimpleEvent &)
+                                     { ++count; });
 
     dispatcher.clear();
     EXPECT_EQ(dispatcher.subscriber_count(), 0u);
@@ -215,10 +225,10 @@ TEST(EventDispatcherTest, EmitSafe_CatchesHandlerExceptions)
     EventDispatcher<SimpleEvent> dispatcher;
     int count = 0;
 
-    auto sub1 = dispatcher.subscribe([](const SimpleEvent &) {
-        throw std::runtime_error("handler error");
-    });
-    auto sub2 = dispatcher.subscribe([&count](const SimpleEvent &) { ++count; });
+    auto sub1 = dispatcher.subscribe([](const SimpleEvent &)
+                                     { throw std::runtime_error("handler error"); });
+    auto sub2 = dispatcher.subscribe([&count](const SimpleEvent &)
+                                     { ++count; });
 
     // emit_safe should not propagate exceptions; sub2 should still run
     dispatcher.emit_safe(SimpleEvent{1});
@@ -250,8 +260,10 @@ TEST(EventDispatcherTest, IndependentDispatchers_DoNotInterfere)
     int int_count = 0;
     int str_count = 0;
 
-    auto sub1 = int_dispatcher.subscribe([&int_count](const SimpleEvent &) { ++int_count; });
-    auto sub2 = str_dispatcher.subscribe([&str_count](const StringEvent &) { ++str_count; });
+    auto sub1 = int_dispatcher.subscribe([&int_count](const SimpleEvent &)
+                                         { ++int_count; });
+    auto sub2 = str_dispatcher.subscribe([&str_count](const StringEvent &)
+                                         { ++str_count; });
 
     int_dispatcher.emit(SimpleEvent{1});
     EXPECT_EQ(int_count, 1);
@@ -269,9 +281,8 @@ TEST(EventDispatcherTest, ConcurrentEmit_NoDataRace)
     EventDispatcher<SimpleEvent> dispatcher;
     std::atomic<int> total{0};
 
-    auto sub = dispatcher.subscribe([&total](const SimpleEvent &e) {
-        total.fetch_add(e.value, std::memory_order_relaxed);
-    });
+    auto sub = dispatcher.subscribe([&total](const SimpleEvent &e)
+                                    { total.fetch_add(e.value, std::memory_order_relaxed); });
 
     constexpr int threads = 8;
     constexpr int emits_per_thread = 1000;
@@ -280,12 +291,12 @@ TEST(EventDispatcherTest, ConcurrentEmit_NoDataRace)
 
     for (int t = 0; t < threads; ++t)
     {
-        workers.emplace_back([&dispatcher]() {
+        workers.emplace_back([&dispatcher]()
+                             {
             for (int i = 0; i < emits_per_thread; ++i)
             {
                 dispatcher.emit(SimpleEvent{1});
-            }
-        });
+            } });
     }
 
     for (auto &w : workers)
@@ -306,13 +317,13 @@ TEST(EventDispatcherTest, ConcurrentEmitAndSubscribe_NoDataRace)
     std::vector<std::thread> emitters;
     for (int t = 0; t < 4; ++t)
     {
-        emitters.emplace_back([&dispatcher, &stop, &emit_count]() {
+        emitters.emplace_back([&dispatcher, &stop, &emit_count]()
+                              {
             while (!stop.load(std::memory_order_relaxed))
             {
                 dispatcher.emit_safe(SimpleEvent{1});
                 emit_count.fetch_add(1, std::memory_order_relaxed);
-            }
-        });
+            } });
     }
 
     // Subscribe/unsubscribe churn on main thread while emitters run
@@ -346,13 +357,13 @@ TEST(EventDispatcherTest, SubscribeInsideHandler_IsRejected)
     Subscription inner_sub;
     bool handler_ran = false;
 
-    auto sub = dispatcher.subscribe([&](const SimpleEvent &) {
+    auto sub = dispatcher.subscribe([&](const SimpleEvent &)
+                                    {
         // Attempting to subscribe from within a handler must be rejected
         // to prevent deadlock (exclusive lock inside shared lock).
         inner_sub = dispatcher.subscribe([&](const SimpleEvent &) {
             handler_ran = true;
-        });
-    });
+        }); });
 
     dispatcher.emit(SimpleEvent{1});
 
@@ -371,12 +382,12 @@ TEST(EventDispatcherTest, UnsubscribeInsideHandler_IsRejected)
     int call_count = 0;
 
     Subscription held_sub;
-    held_sub = dispatcher.subscribe([&](const SimpleEvent &) {
+    held_sub = dispatcher.subscribe([&](const SimpleEvent &)
+                                    {
         ++call_count;
         // Attempting to unsubscribe from within a handler is silently
         // skipped to prevent deadlock.
-        held_sub.reset();
-    });
+        held_sub.reset(); });
 
     dispatcher.emit(SimpleEvent{1});
     EXPECT_EQ(call_count, 1);
@@ -394,9 +405,8 @@ TEST(EventDispatcherTest, EmitSafe_ReentrancyGuardAlsoApplies)
     EventDispatcher<SimpleEvent> dispatcher;
     Subscription inner_sub;
 
-    auto sub = dispatcher.subscribe([&](const SimpleEvent &) {
-        inner_sub = dispatcher.subscribe([](const SimpleEvent &) {});
-    });
+    auto sub = dispatcher.subscribe([&](const SimpleEvent &)
+                                    { inner_sub = dispatcher.subscribe([](const SimpleEvent &) {}); });
 
     dispatcher.emit_safe(SimpleEvent{1});
     EXPECT_FALSE(inner_sub.active());
@@ -410,9 +420,12 @@ TEST(EventDispatcherTest, UnsubscribeMiddle_PreservesOrder)
     EventDispatcher<SimpleEvent> dispatcher;
     std::vector<int> order;
 
-    auto sub_a = dispatcher.subscribe([&order](const SimpleEvent &) { order.push_back(1); });
-    auto sub_b = dispatcher.subscribe([&order](const SimpleEvent &) { order.push_back(2); });
-    auto sub_c = dispatcher.subscribe([&order](const SimpleEvent &) { order.push_back(3); });
+    auto sub_a = dispatcher.subscribe([&order](const SimpleEvent &)
+                                      { order.push_back(1); });
+    auto sub_b = dispatcher.subscribe([&order](const SimpleEvent &)
+                                      { order.push_back(2); });
+    auto sub_c = dispatcher.subscribe([&order](const SimpleEvent &)
+                                      { order.push_back(3); });
 
     // Remove the middle subscriber
     sub_b.reset();
@@ -435,7 +448,8 @@ TEST(EventDispatcherTest, SubscriptionsInVector_CleanupOnClear)
 
     for (int i = 0; i < 10; ++i)
     {
-        subs.push_back(dispatcher.subscribe([&count](const SimpleEvent &) { ++count; }));
+        subs.push_back(dispatcher.subscribe([&count](const SimpleEvent &)
+                                            { ++count; }));
     }
     EXPECT_EQ(dispatcher.subscriber_count(), 10u);
 
@@ -450,9 +464,8 @@ TEST(EventDispatcherTest, Emit_PropagatesHandlerException)
 {
     EventDispatcher<SimpleEvent> dispatcher;
 
-    auto sub = dispatcher.subscribe([](const SimpleEvent &) {
-        throw std::runtime_error("handler error");
-    });
+    auto sub = dispatcher.subscribe([](const SimpleEvent &)
+                                    { throw std::runtime_error("handler error"); });
 
     EXPECT_THROW(dispatcher.emit(SimpleEvent{1}), std::runtime_error);
 }
@@ -462,18 +475,14 @@ TEST(EventDispatcherTest, EmitSafe_AllHandlersRunDespiteMultipleExceptions)
     EventDispatcher<SimpleEvent> dispatcher;
     int success_count = 0;
 
-    auto sub1 = dispatcher.subscribe([](const SimpleEvent &) {
-        throw std::runtime_error("error 1");
-    });
-    auto sub2 = dispatcher.subscribe([&success_count](const SimpleEvent &) {
-        ++success_count;
-    });
-    auto sub3 = dispatcher.subscribe([](const SimpleEvent &) {
-        throw std::logic_error("error 2");
-    });
-    auto sub4 = dispatcher.subscribe([&success_count](const SimpleEvent &) {
-        ++success_count;
-    });
+    auto sub1 = dispatcher.subscribe([](const SimpleEvent &)
+                                     { throw std::runtime_error("error 1"); });
+    auto sub2 = dispatcher.subscribe([&success_count](const SimpleEvent &)
+                                     { ++success_count; });
+    auto sub3 = dispatcher.subscribe([](const SimpleEvent &)
+                                     { throw std::logic_error("error 2"); });
+    auto sub4 = dispatcher.subscribe([&success_count](const SimpleEvent &)
+                                     { ++success_count; });
 
     // emit_safe must not propagate; all non-throwing handlers must execute
     dispatcher.emit_safe(SimpleEvent{1});
@@ -489,11 +498,11 @@ TEST(EventDispatcherTest, UnsubscribeInsideHandler_SucceedsOnDestruction)
 
     {
         Subscription held_sub;
-        held_sub = dispatcher.subscribe([&](const SimpleEvent &) {
+        held_sub = dispatcher.subscribe([&](const SimpleEvent &)
+                                        {
             ++call_count;
             // Deferred: reset() inside handler is silently skipped
-            held_sub.reset();
-        });
+            held_sub.reset(); });
 
         dispatcher.emit(SimpleEvent{1});
         EXPECT_EQ(call_count, 1);
@@ -550,7 +559,8 @@ TEST(EventDispatcherTest, SnapshotStability_DuringEmit)
 
     // Pre-subscribed handler signals when the emit has begun, then blocks
     // until the main thread allows it to continue.
-    auto old_sub = dispatcher.subscribe([&](const SimpleEvent &) {
+    auto old_sub = dispatcher.subscribe([&](const SimpleEvent &)
+                                        {
         {
             std::lock_guard lk{gate_mtx};
             started = true;
@@ -559,24 +569,22 @@ TEST(EventDispatcherTest, SnapshotStability_DuringEmit)
 
         std::unique_lock lk{gate_mtx};
         handler_may_finish.wait(lk, [&] { return may_finish; });
-        old_calls.fetch_add(1, std::memory_order_relaxed);
-    });
+        old_calls.fetch_add(1, std::memory_order_relaxed); });
 
     // Launch an emitter thread; it will block inside the pre-subscribed
     // handler holding a shared_ptr snapshot of the current handler list.
-    std::thread emitter([&] {
-        dispatcher.emit(SimpleEvent{0});
-    });
+    std::thread emitter([&]
+                        { dispatcher.emit(SimpleEvent{0}); });
 
     {
         std::unique_lock lk{gate_mtx};
-        handler_started.wait(lk, [&] { return started; });
+        handler_started.wait(lk, [&]
+                             { return started; });
     }
 
     // Subscribe a new handler while the emit is still in flight.
-    auto new_sub = dispatcher.subscribe([&](const SimpleEvent &) {
-        new_calls.fetch_add(1, std::memory_order_relaxed);
-    });
+    auto new_sub = dispatcher.subscribe([&](const SimpleEvent &)
+                                        { new_calls.fetch_add(1, std::memory_order_relaxed); });
 
     // The freshly-subscribed handler must not be visible to the in-flight
     // emit, which captured its snapshot before new_sub was published.
@@ -627,4 +635,3 @@ TEST(EventDispatcherTest, SnapshotReclamation_NoLeak)
         << "Dispatcher should hold exactly one reference to its snapshot "
            "after all subscriptions are released";
 }
-

--- a/tests/test_hook_manager.cpp
+++ b/tests/test_hook_manager.cpp
@@ -2199,7 +2199,7 @@ TEST_F(HookManagerTest, VmtHook_ConcurrentCreateAndShutdown)
     for (int i = 0; i < kThreads; ++i)
     {
         threads.emplace_back([&, i]
-        {
+                             {
             start_latch.arrive_and_wait();
             auto result = hook_manager_->create_vmt_hook(
                 std::format("ConcVmt{}", i), targets[i].get());
@@ -2212,8 +2212,7 @@ TEST_F(HookManagerTest, VmtHook_ConcurrentCreateAndShutdown)
                 rejected_count.fetch_add(1, std::memory_order_relaxed);
                 std::lock_guard<std::mutex> lock(errors_mutex);
                 errors.push_back(result.error());
-            }
-        });
+            } });
     }
 
     start_latch.arrive_and_wait();
@@ -2526,7 +2525,8 @@ TEST_F(HookManagerTest, LateShutdown_DrainsReadersBeforeClearingMaps)
     std::atomic<bool> reader_may_return{false};
     std::atomic<bool> reader_observed_valid{false};
 
-    std::thread reader([&]() {
+    std::thread reader([&]()
+                       {
         bool invoked = hm.with_inline_hook("late-shutdown-hook", [&](InlineHook &hook) {
             reader_started.store(true, std::memory_order_release);
             // Hold the shared_lock while the main thread races shutdown().
@@ -2540,8 +2540,7 @@ TEST_F(HookManagerTest, LateShutdown_DrainsReadersBeforeClearingMaps)
             reader_observed_valid.store(!hook.get_name().empty(),
                                         std::memory_order_release);
         });
-        EXPECT_TRUE(invoked);
-    });
+        EXPECT_TRUE(invoked); });
 
     while (!reader_started.load(std::memory_order_acquire))
     {
@@ -2553,7 +2552,8 @@ TEST_F(HookManagerTest, LateShutdown_DrainsReadersBeforeClearingMaps)
     // destructor-equivalent ordering.
     std::atomic<bool> killer_started{false};
     std::atomic<bool> shutdown_returned{false};
-    std::thread killer([&]() {
+    std::thread killer([&]()
+                       {
         // Publish entry into hm.shutdown() before the call so the main
         // thread can wait on this flag instead of an unconditional sleep.
         // Without this, shutdown_returned == false could mean "blocked on
@@ -2561,8 +2561,7 @@ TEST_F(HookManagerTest, LateShutdown_DrainsReadersBeforeClearingMaps)
         // letting a premature-return regression slip through.
         killer_started.store(true, std::memory_order_release);
         hm.shutdown();
-        shutdown_returned.store(true, std::memory_order_release);
-    });
+        shutdown_returned.store(true, std::memory_order_release); });
 
     // Wait until the killer has actually entered hm.shutdown() before we
     // assert it is blocked. After that, a short sleep lets the
@@ -2774,4 +2773,3 @@ TEST_F(HookManagerTest, TryInstallMidAob_LogsOnceOnPatternFailure)
     EXPECT_FALSE(name.has_value());
     EXPECT_EQ(logfile.count_error_lines(), static_cast<size_t>(1));
 }
-

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -12,8 +12,8 @@
 #include "input_intercept.hpp"
 
 using namespace DetourModKit;
-using DetourModKit::keyboard_key;
 using DetourModKit::gamepad_button;
+using DetourModKit::keyboard_key;
 
 // --- InputSource string conversion ---
 
@@ -1311,7 +1311,7 @@ TEST_F(InputManagerTest, RegisterGamepadWithModifier)
     InputManager &mgr = InputManager::get_instance();
 
     mgr.register_press("lb_a", {gamepad_button(GamepadCode::A)},
-                        {gamepad_button(GamepadCode::LeftBumper)}, []() {});
+                       {gamepad_button(GamepadCode::LeftBumper)}, []() {});
 
     EXPECT_EQ(mgr.binding_count(), 1u);
 }
@@ -1348,7 +1348,7 @@ TEST_F(InputManagerTest, MixedKeyboardAndGamepadBindings)
 
     mgr.register_press("kb_toggle", {keyboard_key(0x72)}, {keyboard_key(0x11)}, []() {});
     mgr.register_press("gp_toggle", {gamepad_button(GamepadCode::A)},
-                        {gamepad_button(GamepadCode::LeftBumper)}, []() {});
+                       {gamepad_button(GamepadCode::LeftBumper)}, []() {});
     mgr.register_hold("mouse_hold", {mouse_button(0x05)}, [](bool) {});
 
     EXPECT_EQ(mgr.binding_count(), 3u);
@@ -1687,7 +1687,7 @@ TEST_F(InputManagerTest, ThumbstickAndButtonMixed)
     mgr.register_press("gp_a", {gamepad_button(GamepadCode::A)}, []() {});
     mgr.register_hold("ls_up", {gamepad_button(GamepadCode::LeftStickUp)}, [](bool) {});
     mgr.register_press("rs_right", {gamepad_button(GamepadCode::RightStickRight)},
-                        {gamepad_button(GamepadCode::LeftBumper)}, []() {});
+                       {gamepad_button(GamepadCode::LeftBumper)}, []() {});
 
     EXPECT_EQ(mgr.binding_count(), 3u);
 

--- a/tests/test_input_intercept.cpp
+++ b/tests/test_input_intercept.cpp
@@ -29,9 +29,9 @@ using DetourModKit::detail::take_wheel_counts;
 using DetourModKit::detail::uninstall;
 using DetourModKit::detail::WheelPulseState;
 using DetourModKit::detail::wndproc_installed;
-using DetourModKit::detail::XInputGetStateFn;
 using DetourModKit::detail::xinput_installed;
 using DetourModKit::detail::xinput_trampoline;
+using DetourModKit::detail::XInputGetStateFn;
 
 namespace
 {
@@ -450,7 +450,8 @@ namespace
 
     void ensure_test_window_class_registered() noexcept
     {
-        static const bool registered = [] {
+        static const bool registered = []
+        {
             WNDCLASSEXW wc{};
             wc.cbSize = sizeof(wc);
             wc.lpfnWndProc = DefWindowProcW;
@@ -757,7 +758,8 @@ TEST(InterceptDisarmTest, PollerDisarmsWheelConsumeAfterClearBindings)
     InputPoller poller(std::move(bindings), std::chrono::milliseconds(2), false);
     poller.start();
 
-    const auto cleanup = [&]() noexcept {
+    const auto cleanup = [&]() noexcept
+    {
         poller.shutdown(); // routes through detail::uninstall()
         uninstall();
         if (IsWindow(hwnd))
@@ -770,7 +772,8 @@ TEST(InterceptDisarmTest, PollerDisarmsWheelConsumeAfterClearBindings)
     // The poll thread lazily subclasses the game window; wait until it lands on OUR
     // window (procedure changes away from the recording predecessor).
     const bool hooked_ours = wait_until(
-        [&] {
+        [&]
+        {
             return wndproc_installed() &&
                    GetWindowLongPtrW(hwnd, GWLP_WNDPROC) != predecessor;
         },
@@ -784,7 +787,8 @@ TEST(InterceptDisarmTest, PollerDisarmsWheelConsumeAfterClearBindings)
     // Wait until the swallow flag engages: an owned wheel message stops reaching the
     // game's predecessor procedure.
     const bool consume_engaged = wait_until(
-        [&] {
+        [&]
+        {
             const int before = g_forwarded_wheel_msgs.load(std::memory_order_relaxed);
             SendMessageW(hwnd, WM_MOUSEWHEEL, wheel_wparam(1), 0);
             return g_forwarded_wheel_msgs.load(std::memory_order_relaxed) == before;
@@ -799,7 +803,8 @@ TEST(InterceptDisarmTest, PollerDisarmsWheelConsumeAfterClearBindings)
 
     // Wait until the swallow flag disarms: the message is forwarded again.
     const bool consume_disarmed = wait_until(
-        [&] {
+        [&]
+        {
             const int before = g_forwarded_wheel_msgs.load(std::memory_order_relaxed);
             SendMessageW(hwnd, WM_MOUSEWHEEL, wheel_wparam(1), 0);
             return g_forwarded_wheel_msgs.load(std::memory_order_relaxed) == before + 1;

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -1534,7 +1534,7 @@ namespace
                ("test_logger_overload_" + std::to_string(GetCurrentProcessId()) + "_" +
                 std::to_string(counter.fetch_add(1)) + ".log");
     }
-}
+} // namespace
 
 TEST(LoggerConfigureOverload, TwoArgConfigureUsesDefaultTimestamp)
 {
@@ -1545,4 +1545,3 @@ TEST(LoggerConfigureOverload, TwoArgConfigureUsesDefaultTimestamp)
     EXPECT_TRUE(std::filesystem::exists(path));
     std::filesystem::remove(path);
 }
-

--- a/tests/test_memory_chain.cpp
+++ b/tests/test_memory_chain.cpp
@@ -47,7 +47,7 @@ TEST(MemorySehResolveChain, TwoLevelResolvesFinalAddress)
 {
     uint64_t target = 0x1122334455667788ull;
     uintptr_t mid = reinterpret_cast<uintptr_t>(&target); // holds &target
-    uintptr_t root = reinterpret_cast<uintptr_t>(&mid);    // holds &mid
+    uintptr_t root = reinterpret_cast<uintptr_t>(&mid);   // holds &mid
 
     // deref(&root) -> &mid, deref(&mid) -> &target; final offset 0 not dereferenced.
     const auto addr = Memory::seh_resolve_chain(reinterpret_cast<uintptr_t>(&root), {0, 0, 0});
@@ -181,7 +181,8 @@ TEST(MemorySehReadChain, ReadsNonDefaultConstructibleType)
         uint32_t a;
         uint32_t b;
         NoDefault() = delete;
-        constexpr NoDefault(uint32_t x, uint32_t y) noexcept : a(x), b(y) {}
+        constexpr NoDefault(uint32_t x, uint32_t y) noexcept
+            : a(x), b(y) {}
     };
     static_assert(std::is_trivially_copyable_v<NoDefault>);
     static_assert(!std::is_default_constructible_v<NoDefault>);

--- a/tests/test_profiler.cpp
+++ b/tests/test_profiler.cpp
@@ -270,15 +270,15 @@ TEST_F(ProfilerRecordTest, ConcurrentRecord_NoDataRace)
 
     for (int t = 0; t < threads; ++t)
     {
-        workers.emplace_back([&profiler]() {
+        workers.emplace_back([&profiler]()
+                             {
             LARGE_INTEGER tick;
             for (int i = 0; i < samples_per_thread; ++i)
             {
                 QueryPerformanceCounter(&tick);
                 profiler.record("concurrent", tick.QuadPart,
                                 tick.QuadPart + 100, GetCurrentThreadId());
-            }
-        });
+            } });
     }
 
     for (auto &w : workers)
@@ -301,12 +301,12 @@ TEST_F(ProfilerRecordTest, ConcurrentScopedProfile_NoDataRace)
 
     for (int t = 0; t < threads; ++t)
     {
-        workers.emplace_back([]() {
+        workers.emplace_back([]()
+                             {
             for (int i = 0; i < scopes_per_thread; ++i)
             {
                 ScopedProfile sp("concurrent_scope");
-            }
-        });
+            } });
     }
 
     for (auto &w : workers)
@@ -330,15 +330,15 @@ TEST_F(ProfilerRecordTest, ConcurrentRecordAndExport_NoTornReads)
     std::vector<std::thread> writers;
     for (int t = 0; t < 4; ++t)
     {
-        writers.emplace_back([&profiler, &stop]() {
+        writers.emplace_back([&profiler, &stop]()
+                             {
             LARGE_INTEGER tick;
             while (!stop.load(std::memory_order_relaxed))
             {
                 QueryPerformanceCounter(&tick);
                 profiler.record("concurrent_export", tick.QuadPart,
                                 tick.QuadPart + 100, GetCurrentThreadId());
-            }
-        });
+            } });
     }
 
     // Reader thread: export while writers are active. Loop until the window
@@ -347,7 +347,8 @@ TEST_F(ProfilerRecordTest, ConcurrentRecordAndExport_NoTornReads)
     // export can outlast the 50 ms window; keying the exit on a completed export
     // (not on wall-clock alone) keeps export_count deterministic instead of
     // letting it flake at 0.
-    std::thread reader([&profiler, &stop, &export_count]() {
+    std::thread reader([&profiler, &stop, &export_count]()
+                       {
         while (!stop.load(std::memory_order_relaxed) ||
                export_count.load(std::memory_order_relaxed) == 0)
         {
@@ -360,8 +361,7 @@ TEST_F(ProfilerRecordTest, ConcurrentRecordAndExport_NoTornReads)
                 EXPECT_EQ(json.back(), ']');
             }
             export_count.fetch_add(1, std::memory_order_relaxed);
-        }
-    });
+        } });
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     stop.store(true, std::memory_order_relaxed);
@@ -487,7 +487,9 @@ TEST_F(ProfilerRecordTest, ExportChromeJson_EscapesBackspaceFormFeedAndRawContro
     // Name with backspace, form-feed, and a raw control byte (SOH = 0x01).
     // String concatenation separates \x01 from the trailing 'd' to prevent
     // the compiler from parsing "\x01d" as a single hex escape (0x1D).
-    const char name[] = "a\bb\fc" "\x01" "d";
+    const char name[] = "a\bb\fc"
+                        "\x01"
+                        "d";
     profiler.record(name, tick.QuadPart, tick.QuadPart + 100, 1);
 
     const std::string json = profiler.export_chrome_json();
@@ -549,18 +551,19 @@ TEST_F(ProfilerRecordTest, ConcurrentRecord_WrapsBuffer_ExporterRemainsWellForme
     writers.reserve(8);
     for (int t = 0; t < 8; ++t)
     {
-        writers.emplace_back([&profiler, &stop]() {
+        writers.emplace_back([&profiler, &stop]()
+                             {
             LARGE_INTEGER tick;
             while (!stop.load(std::memory_order_relaxed))
             {
                 QueryPerformanceCounter(&tick);
                 profiler.record("wrap_race", tick.QuadPart,
                                 tick.QuadPart + 1, GetCurrentThreadId());
-            }
-        });
+            } });
     }
 
-    std::thread reader([&profiler, &stop, &malformed_detected]() {
+    std::thread reader([&profiler, &stop, &malformed_detected]()
+                       {
         // Event markers for scoped content parsing. `k_name_marker` locates
         // an event by name; `k_dur_marker` finds the corresponding duration
         // field within the same compact JSON object.
@@ -599,8 +602,7 @@ TEST_F(ProfilerRecordTest, ConcurrentRecord_WrapsBuffer_ExporterRemainsWellForme
                 }
                 pos += k_name_marker.size();
             }
-        }
-    });
+        } });
 
     // Run long enough for multiple full wraps (>= 3 * capacity samples).
     const auto deadline =

--- a/tests/test_rtti.cpp
+++ b/tests/test_rtti.cpp
@@ -49,7 +49,10 @@ namespace
         return p;
     }
 
-    void syn_reset() noexcept { g_syn_offset = 0; }
+    void syn_reset() noexcept
+    {
+        g_syn_offset = 0;
+    }
 
     /**
      * @class SyntheticVtable
@@ -171,7 +174,7 @@ namespace
     private:
         std::uintptr_t m_vtable;
     };
-}
+} // namespace
 
 class RttiTest : public ::testing::Test
 {
@@ -564,7 +567,10 @@ TEST_F(RttiTest, ResolveRejectsHeapAllocatedVtable)
     // A vtable whose address is not in any loaded module (here, a heap
     // allocation) must be rejected at the module_range_for step.
     auto buf = std::make_unique<std::array<std::uintptr_t, 4>>();
-    (*buf)[0] = 0; (*buf)[1] = 0; (*buf)[2] = 0; (*buf)[3] = 0;
+    (*buf)[0] = 0;
+    (*buf)[1] = 0;
+    (*buf)[2] = 0;
+    (*buf)[3] = 0;
     const std::uintptr_t fake_vt = reinterpret_cast<std::uintptr_t>(buf->data() + 2);
 
     EXPECT_FALSE(Rtti::type_name_of(fake_vt).has_value());

--- a/tests/test_rtti_dissect.cpp
+++ b/tests/test_rtti_dissect.cpp
@@ -52,11 +52,26 @@ void *operator new(std::size_t size)
     return p;
 }
 
-void *operator new[](std::size_t size) { return operator new(size); }
-void operator delete(void *p) noexcept { std::free(p); }
-void operator delete(void *p, std::size_t) noexcept { std::free(p); }
-void operator delete[](void *p) noexcept { std::free(p); }
-void operator delete[](void *p, std::size_t) noexcept { std::free(p); }
+void *operator new[](std::size_t size)
+{
+    return operator new(size);
+}
+void operator delete(void *p) noexcept
+{
+    std::free(p);
+}
+void operator delete(void *p, std::size_t) noexcept
+{
+    std::free(p);
+}
+void operator delete[](void *p) noexcept
+{
+    std::free(p);
+}
+void operator delete[](void *p, std::size_t) noexcept
+{
+    std::free(p);
+}
 
 namespace
 {
@@ -92,7 +107,10 @@ namespace
         return p;
     }
 
-    void syn_reset() noexcept { g_syn_offset = 0; }
+    void syn_reset() noexcept
+    {
+        g_syn_offset = 0;
+    }
 
     /**
      * @class SyntheticVtable
@@ -399,11 +417,11 @@ TEST_F(RttiDissectTest, ScanBlock_LabelsOnlyRealSlots)
     ASSERT_NE(obj, 0u);
 
     std::array<std::uintptr_t, 5> block{
-        0,                  // garbage null
-        direct.vtable(),    // direct object base
-        0x20000,            // unresolvable
-        obj,                // pointer-to-object
-        0,                  // garbage null
+        0,               // garbage null
+        direct.vtable(), // direct object base
+        0x20000,         // unresolvable
+        obj,             // pointer-to-object
+        0,               // garbage null
     };
     const std::uintptr_t start = reinterpret_cast<std::uintptr_t>(block.data());
 
@@ -451,9 +469,12 @@ TEST_F(RttiDissectTest, ScanBlock_CustomStrideLabelsInterleaved)
     // Layout: { vtable, filler, vtable, filler, vtable, filler }; a 16-byte
     // stride means only every other qword is a probed slot.
     std::array<std::uintptr_t, 6> block{
-        a.vtable(), 0xAAAAAAAAu,
-        b.vtable(), 0xBBBBBBBBu,
-        c.vtable(), 0xCCCCCCCCu,
+        a.vtable(),
+        0xAAAAAAAAu,
+        b.vtable(),
+        0xBBBBBBBBu,
+        c.vtable(),
+        0xCCCCCCCCu,
     };
     const std::uintptr_t start = reinterpret_cast<std::uintptr_t>(block.data());
 
@@ -1027,7 +1048,9 @@ TEST_F(RttiDissectTest, Fingerprint_SecondCopyIsAmbiguousAndOptionalBreaksTie)
     // An optional landmark present only at the delta-0 copy breaks the tie.
     st.put(FP_OD, syn_heap_object(d.vtable()));
     std::array<Rtti::Landmark, 4> fp4{
-        fp3[0], fp3[1], fp3[2],
+        fp3[0],
+        fp3[1],
+        fp3[2],
         Rtti::Landmark{.base = st.base(),
                        .nominal_offset = FP_OD,
                        .expected_mangled = ".?AVFpD@@",

--- a/tests/test_rtti_reverse.cpp
+++ b/tests/test_rtti_reverse.cpp
@@ -34,7 +34,10 @@ namespace
     alignas(8) std::array<std::byte, REV_BUF_SIZE * REV_POOL_FIXTURES> g_rev_pool{};
     std::size_t g_rev_used = 0;
 
-    void rev_reset() noexcept { g_rev_used = 0; }
+    void rev_reset() noexcept
+    {
+        g_rev_used = 0;
+    }
 
     template <typename T>
     void rev_write(std::byte *buf, std::size_t off, const T &value) noexcept
@@ -72,7 +75,7 @@ namespace
         rev_write<std::uint32_t>(buf, REV_COL_OFFSET + 8, 0);          // cd_offset
         rev_write<std::uint32_t>(buf, REV_COL_OFFSET + 12,
                                  static_cast<std::uint32_t>(buf_rva + REV_TD_OFFSET)); // p_type_descriptor
-        rev_write<std::uint32_t>(buf, REV_COL_OFFSET + 16, 0);         // p_class_descriptor
+        rev_write<std::uint32_t>(buf, REV_COL_OFFSET + 16, 0);                         // p_class_descriptor
         rev_write<std::uint32_t>(buf, REV_COL_OFFSET + 20,
                                  static_cast<std::uint32_t>(buf_rva + REV_COL_OFFSET)); // p_self
 

--- a/tests/test_scanner.cpp
+++ b/tests/test_scanner.cpp
@@ -1796,7 +1796,8 @@ TEST(ScannerTest, find_pattern_avx2_path_exact_32_bytes)
     std::string aob;
     for (size_t i = 16; i < 48; ++i)
     {
-        if (!aob.empty()) aob += ' ';
+        if (!aob.empty())
+            aob += ' ';
         aob += std::format("{:02X}", i & 0xFF);
     }
 
@@ -1819,7 +1820,8 @@ TEST(ScannerTest, find_pattern_avx2_path_48_bytes)
     std::string aob;
     for (size_t i = 8; i < 56; ++i)
     {
-        if (!aob.empty()) aob += ' ';
+        if (!aob.empty())
+            aob += ' ';
         aob += std::format("{:02X}", (i * 7) & 0xFF);
     }
 
@@ -1842,7 +1844,8 @@ TEST(ScannerTest, find_pattern_avx2_path_64_bytes)
     std::string aob;
     for (size_t i = 32; i < 96; ++i)
     {
-        if (!aob.empty()) aob += ' ';
+        if (!aob.empty())
+            aob += ' ';
         aob += std::format("{:02X}", i & 0xFF);
     }
 
@@ -1866,7 +1869,8 @@ TEST(ScannerTest, find_pattern_avx2_path_with_wildcards)
     std::string aob;
     for (size_t i = 16; i < 48; ++i)
     {
-        if (!aob.empty()) aob += ' ';
+        if (!aob.empty())
+            aob += ' ';
         if ((i - 16) % 8 == 4)
             aob += "??";
         else
@@ -1892,7 +1896,8 @@ TEST(ScannerTest, find_pattern_avx2_path_mismatch_in_second_chunk)
     std::string aob;
     for (size_t i = 32; i < 96; ++i)
     {
-        if (!aob.empty()) aob += ' ';
+        if (!aob.empty())
+            aob += ' ';
         aob += std::format("{:02X}", i & 0xFF);
     }
 
@@ -1914,7 +1919,8 @@ TEST(ScannerTest, find_pattern_avx2_path_not_found)
     std::string aob;
     for (int i = 0; i < 32; ++i)
     {
-        if (!aob.empty()) aob += ' ';
+        if (!aob.empty())
+            aob += ' ';
         aob += std::format("{:02X}", i);
     }
 
@@ -1931,7 +1937,7 @@ namespace
     {
         std::memcpy(dst, &value, sizeof(value));
     }
-}
+} // namespace
 
 TEST(ScannerRipResolveTest, resolve_rip_relative_null_input_returns_error)
 {
@@ -2387,7 +2393,8 @@ namespace
         std::uint8_t *base{nullptr};
         std::size_t size{0};
 
-        ExecBuffer(std::size_t s) : size(s)
+        ExecBuffer(std::size_t s)
+            : size(s)
         {
             base = static_cast<std::uint8_t *>(
                 VirtualAlloc(nullptr, s, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE));
@@ -2508,8 +2515,22 @@ TEST(ScannerCascade, PrologueFallbackRejectsAmbiguousTail)
     // prologue -- the only shape the fallback recognises before rebuilding
     // the AOB from the literal tail described above.
     constexpr std::uint8_t kAmbiguousTemplate[] = {
-        0xE9, 0x00, 0x00, 0x00, 0x00,
-        0xA5, 0xB6, 0xC7, 0xD8, 0xE9, 0xFA, 0x0B, 0x1C, 0x2D, 0x3E, 0x4F,
+        0xE9,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0xA5,
+        0xB6,
+        0xC7,
+        0xD8,
+        0xE9,
+        0xFA,
+        0x0B,
+        0x1C,
+        0x2D,
+        0x3E,
+        0x4F,
     };
 
     // Seed two copies so the rebuilt fallback pattern tallies >= 2 hits in
@@ -2576,8 +2597,22 @@ TEST(ScannerCascade, PrologueFallbackRejectsExactlyTwoMatches)
     // tail clears kPrologueFallbackMinTailLiterals so the test reaches
     // the uniqueness check rather than the literal-floor refusal.
     constexpr std::uint8_t kTemplate[] = {
-        0xE9, 0x00, 0x00, 0x00, 0x00,
-        0x71, 0x82, 0x93, 0xA4, 0xB5, 0xC6, 0xD7, 0xE8, 0xF9, 0x0A, 0x1B,
+        0xE9,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x71,
+        0x82,
+        0x93,
+        0xA4,
+        0xB5,
+        0xC6,
+        0xD7,
+        0xE8,
+        0xF9,
+        0x0A,
+        0x1B,
     };
 
     std::memcpy(buf.base + 0x000, kTemplate, sizeof(kTemplate));


### PR DESCRIPTION
## Summary

Repo-wide formatting and comment-convention cleanup with supporting tooling. No library behavior changes: the build stays -Werror clean and the full test suite stays green (1389/1389).

Highlights:
- clang-format 18 applied across all tracked C++ sources.
- Comment markers normalized: trailing ///< member docs moved above the member, multi-line /// converted to /** */, and the "document the interface, comment the implementation" rule codified in AGENTS.md.
- Two write-only dead members removed and four inaccurate technical comments corrected.
- Markdown docs un-wrapped (no hard 80-column wrapping), with GitHub alerts and fenced code preserved.
- New scripts/check_comment_style.py lint plus an advisory CI step guard the comment conventions; the IntelliSense config now points at the build's compile_commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added comment style enforcement tool for code quality checks.

* **Documentation**
  * Updated contribution guidelines with clarified comment conventions and formatting standards.
  * Improved sanitizer documentation with Windows ASan constraints and configuration details.
  * Enhanced testing and hot-reload documentation for clarity.

* **Chores**
  * Updated CI workflow configuration to validate comment formatting conventions.
  * Improved IDE/development environment configuration for consistent tooling setup.
  * Code formatting and documentation consistency improvements throughout codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->