### PR TITLE
fix: reset ConfigWatcher worker-thread id and finalize noexcept teardown

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,7 @@ ReflowComments: Always
 # ReflowComments: Always otherwise re-wraps the deep hang-indented continuation lines of a /** */ Doxygen block and
 # mangles them (collapsing the alignment under the @tag, occasionally emitting a stray "* *"). CommentPragmas marks
 # comment lines that must never be reflowed: matching 3+ leading content spaces (the hang indent under a Doxygen tag)
-# protects every continuation line, which inhibits reflow of the whole block, so hand-wrapped doc-blocks are left intact.
+# protects every continuation line, which inhibits reflow of the whole block, so hand-wrapped doc-blocks stay intact.
 # Plain // implementation comments carry no such indent and are still reflowed to the column limit. The IWYU default
 # pattern is preserved.
 CommentPragmas: '^ IWYU pragma:|^ {3,}'
@@ -40,6 +40,11 @@ AllowShortBlocksOnASingleLine: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
+# Single-statement control bodies stay optionally braced: InsertBraces is deliberately left unset, so a brace-less
+# guard clause (if (cond) return;) is preserved and never force-braced, while any multi-line or non-obvious body is
+# braced by hand. Enabling InsertBraces would mechanically rewrite every brace-less guard in the tree and is rejected
+# in favour of the by-hand convention recorded in AGENTS.md.
+# InsertBraces: <intentionally unset>
 # Includes are grouped by hand (project, then external, then standard); the
 # formatter must not reorder or regroup them.
 SortIncludes: Never

--- a/include/DetourModKit.hpp
+++ b/include/DetourModKit.hpp
@@ -91,6 +91,7 @@ using DMKProfileSample = DetourModKit::ProfileSample;
  *          this function, the singletons are in a safe state for destruction.
  *
  * @note This function is idempotent - calling it multiple times is safe.
+ * @note noexcept: every teardown step it invokes is itself noexcept, so the wrapper carries the no-throw guarantee.
  * @note Each subsystem detects if it is running under the Windows loader lock (e.g. from DllMain/DLL_PROCESS_DETACH or
  *       FreeLibrary) and will detach background threads instead of joining them to avoid deadlock. However, calling
  *       DMK_Shutdown() before DLL_PROCESS_DETACH is still the recommended practice for a clean orderly shutdown.
@@ -98,7 +99,7 @@ using DMKProfileSample = DetourModKit::ProfileSample;
  *       NOT reclaimed by this function; the OS releases the memory at process exit. See DetourModKit::StringPool for
  *       the rationale.
  */
-inline void DMK_Shutdown()
+inline void DMK_Shutdown() noexcept
 {
     // Shutdown in reverse dependency order:
     // 1. Config auto-reload watcher first: its background thread can fire the user on_reload callback at any moment, so

--- a/include/DetourModKit/config.hpp
+++ b/include/DetourModKit/config.hpp
@@ -464,8 +464,10 @@ namespace DetourModKit
          * @details Useful if the configuration system needs to be reset without restarting the application. This does
          *          NOT stop the auto-reload watcher; call disable_auto_reload() first (DMK_Shutdown() already does so
          *          in the correct order) so a watcher callback cannot fire against state torn down afterwards.
+         * @note noexcept: clearing the registry and dropping the cached path/hash and reload-servicer refs are all
+         *       no-throw, and any diagnostic logging routes through the best-effort no-throw log path.
          */
-        void clear_registered_items();
+        void clear_registered_items() noexcept;
 
     } // namespace Config
 } // namespace DetourModKit

--- a/include/DetourModKit/config_watcher.hpp
+++ b/include/DetourModKit/config_watcher.hpp
@@ -104,10 +104,11 @@ namespace DetourModKit
          * @brief Returns true if @p id names the background worker thread.
          * @details Lets callers (in particular Config::disable_auto_reload) detect setter-induced self-calls and avoid
          *          joining the worker from the worker itself, which would otherwise raise
-         *          std::system_error(resource_deadlock_would_occur). The worker publishes its id on entry and clears it
-         *          on exit, so this returns false before start() has posted the first overlapped read and after the
-         *          worker has exited (including after stop() has joined it); a later OS-recycled thread id therefore
-         *          cannot alias a dead worker and suppress a real stop.
+         *          std::system_error(resource_deadlock_would_occur). The worker publishes its id when its thread
+         *          starts (before the first overlapped read is issued) and clears it on exit, so this returns false
+         *          before the worker thread has started and after the worker has exited (including after stop() has
+         *          joined it); a later OS-recycled thread id therefore cannot alias a dead worker and suppress a real
+         *          stop.
          * @param id The thread id to compare against.
          * @return true only while the worker is running and @p id equals its thread id; the default (no-thread) id
          *         never matches.

--- a/include/DetourModKit/config_watcher.hpp
+++ b/include/DetourModKit/config_watcher.hpp
@@ -104,10 +104,13 @@ namespace DetourModKit
          * @brief Returns true if @p id names the background worker thread.
          * @details Lets callers (in particular Config::disable_auto_reload) detect setter-induced self-calls and avoid
          *          joining the worker from the worker itself, which would otherwise raise
-         *          std::system_error(resource_deadlock_would_occur). Returns false before start() has posted the first
-         *          overlapped read and after stop() has joined the worker.
+         *          std::system_error(resource_deadlock_would_occur). The worker publishes its id on entry and clears it
+         *          on exit, so this returns false before start() has posted the first overlapped read and after the
+         *          worker has exited (including after stop() has joined it); a later OS-recycled thread id therefore
+         *          cannot alias a dead worker and suppress a real stop.
          * @param id The thread id to compare against.
-         * @return true if @p id equals the worker's thread id.
+         * @return true only while the worker is running and @p id equals its thread id; the default (no-thread) id
+         *         never matches.
          */
         [[nodiscard]] bool is_worker_thread(std::thread::id id) const noexcept;
 

--- a/include/DetourModKit/memory.hpp
+++ b/include/DetourModKit/memory.hpp
@@ -212,11 +212,20 @@ namespace DetourModKit
          */
         [[nodiscard]] uintptr_t read_ptr_unsafe(uintptr_t base, ptrdiff_t offset) noexcept;
 
-        // Canonical x64 user-mode address window. The low 64 KiB is the reserved null-dereference region and is never a
-        // live pointer; mapped user addresses sit below the 47-bit canonical split at
-        // 0x0000'8000'0000'0000. A value outside this window cannot be a valid object pointer, so the bounds reject
-        // stale or sentinel values with no syscall and no memory access.
+        /**
+         * @brief Inclusive lower bound of the canonical x64 user-mode address window.
+         * @details The low 64 KiB is the reserved null-dereference region and is never a live pointer, so any value
+         *          below this bound cannot be a valid object pointer. Paired with @ref USERSPACE_PTR_MAX, the window
+         *          rejects stale or sentinel values with no syscall and no memory access.
+         */
         inline constexpr uintptr_t USERSPACE_PTR_MIN = 0x10000;
+
+        /**
+         * @brief Exclusive upper bound of the canonical x64 user-mode address window.
+         * @details Mapped user addresses sit below the 47-bit canonical split at 0x0000'8000'0000'0000; a value at or
+         *          above this bound is a kernel-range or non-canonical address and cannot be a valid user-mode object
+         *          pointer. Paired with @ref USERSPACE_PTR_MIN.
+         */
         inline constexpr uintptr_t USERSPACE_PTR_MAX = 0x0000800000000000ULL;
 
         /**

--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -293,30 +293,7 @@ namespace DetourModKit::Bootstrap
                     }
                 }
             }
-            try
-            {
-                DMK_Shutdown();
-            }
-            catch (const std::exception &e)
-            {
-                try
-                {
-                    Logger::get_instance().error("Bootstrap: DMK_Shutdown threw: {}", e.what());
-                }
-                catch (...)
-                {
-                }
-            }
-            catch (...)
-            {
-                try
-                {
-                    Logger::get_instance().error("Bootstrap: DMK_Shutdown threw unknown exception.");
-                }
-                catch (...)
-                {
-                }
-            }
+            DMK_Shutdown();
         }
         else if (s_shutdown_event)
         {
@@ -419,30 +396,7 @@ namespace DetourModKit::Bootstrap
         // enable_auto_reload() report AlreadyRunning instead of starting fresh. disable_auto_reload() is noexcept and a
         // no-op when no watcher is running.
         Config::disable_auto_reload();
-        try
-        {
-            Config::clear_registered_items();
-        }
-        catch (const std::exception &e)
-        {
-            try
-            {
-                logger.error("Bootstrap: on_logic_dll_unload caught exception in clear_registered_items: {}", e.what());
-            }
-            catch (...)
-            {
-            }
-        }
-        catch (...)
-        {
-            try
-            {
-                logger.error("Bootstrap: on_logic_dll_unload caught unknown exception in clear_registered_items.");
-            }
-            catch (...)
-            {
-            }
-        }
+        Config::clear_registered_items();
     }
 
     void on_logic_dll_unload_all() noexcept
@@ -526,30 +480,6 @@ namespace DetourModKit::Bootstrap
         // enable_auto_reload() report AlreadyRunning instead of starting fresh. disable_auto_reload() is noexcept and a
         // no-op when no watcher is running.
         Config::disable_auto_reload();
-        try
-        {
-            Config::clear_registered_items();
-        }
-        catch (const std::exception &e)
-        {
-            try
-            {
-                logger.error("Bootstrap: on_logic_dll_unload_all caught exception in clear_registered_items: {}",
-                             e.what());
-            }
-            catch (...)
-            {
-            }
-        }
-        catch (...)
-        {
-            try
-            {
-                logger.error("Bootstrap: on_logic_dll_unload_all caught unknown exception in clear_registered_items.");
-            }
-            catch (...)
-            {
-            }
-        }
+        Config::clear_registered_items();
     }
 } // namespace DetourModKit::Bootstrap

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1374,20 +1374,22 @@ void DetourModKit::Config::log_all()
     }
 }
 
-void DetourModKit::Config::clear_registered_items()
+void DetourModKit::Config::clear_registered_items() noexcept
 {
     std::lock_guard<std::mutex> lock(get_config_mutex());
 
     Logger &logger = Logger::get_instance();
     size_t count = get_registered_config_items().size();
+    // Logging routes through try_log (the no-throw, fail-closed path) rather than debug(): debug() formats through a
+    // potentially-throwing sink, which would break this noexcept contract on a format or sink failure.
     if (count > 0)
     {
         get_registered_config_items().clear();
-        logger.debug("Config: Cleared {} registered configuration items.", count);
+        (void)logger.try_log(LogLevel::Debug, "Config: Cleared {} registered configuration items.", count);
     }
     else
     {
-        logger.debug("Config: clear_registered_items called, but no items were registered.");
+        (void)logger.try_log(LogLevel::Debug, "Config: clear_registered_items called, but no items were registered.");
     }
 
     // Drop the remembered INI path too so reload() does not act on a

--- a/src/config_watcher.cpp
+++ b/src/config_watcher.cpp
@@ -134,6 +134,25 @@ namespace DetourModKit
             std::vector<BYTE> buffer;
             OVERLAPPED overlapped{};
         };
+
+        // Resets an atomic thread-id slot to the default (no-thread) id when the worker leaves its body, covering every
+        // exit path uniformly: a requested stop, a self-induced error exit, and the early CreateFileW/CreateEventW
+        // failures that return after the id was already published. The worker publishes its own id on entry so
+        // is_worker_thread() can detect setter-induced self-calls; clearing it as the worker exits keeps a later
+        // OS-recycled thread id from matching this dead worker and suppressing a real stop request. The store
+        // happens-before thread termination, so the slot is already cleared before the id can be reused.
+        class WorkerThreadIdGuard
+        {
+        public:
+            explicit WorkerThreadIdGuard(std::atomic<std::thread::id> &id_slot) noexcept : m_slot(id_slot) {}
+            ~WorkerThreadIdGuard() noexcept { m_slot.store(std::thread::id{}, std::memory_order_release); }
+
+            WorkerThreadIdGuard(const WorkerThreadIdGuard &) = delete;
+            WorkerThreadIdGuard &operator=(const WorkerThreadIdGuard &) = delete;
+
+        private:
+            std::atomic<std::thread::id> &m_slot;
+        };
     } // namespace
 
     struct ConfigWatcher::Impl
@@ -236,7 +255,11 @@ namespace DetourModKit
 
     bool ConfigWatcher::is_worker_thread(std::thread::id id) const noexcept
     {
-        return m_impl->worker_thread_id.load(std::memory_order_acquire) == id;
+        const std::thread::id worker = m_impl->worker_thread_id.load(std::memory_order_acquire);
+        // The default (no-thread) id means no worker is currently published -- before start() posts the first read or
+        // after the worker reset the slot on exit. Never report that state as a match, even when the caller passes a
+        // default-constructed id, so a reset slot can never alias a real stop request.
+        return worker != std::thread::id{} && worker == id;
     }
 
     bool ConfigWatcher::start()
@@ -285,8 +308,10 @@ namespace DetourModKit
              callback = std::move(callback), label = std::move(label), open_result, worker_id_slot](std::stop_token st)
             {
                 // Publish our thread id so is_worker_thread() can detect setter-invoked self-calls into
-                // disable_auto_reload().
+                // disable_auto_reload(). The guard, declared first so its destructor runs after the final flush
+                // callback on every exit path, clears the slot again as the worker exits (see WorkerThreadIdGuard).
                 worker_id_slot->store(std::this_thread::get_id(), std::memory_order_release);
+                const WorkerThreadIdGuard worker_id_guard{*worker_id_slot};
                 auto io = std::make_unique<WatchIoState>();
                 io->buffer.resize(BUFFER_BYTES);
 

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -18,6 +18,11 @@ using DetourModKit::gamepad_button;
 using DetourModKit::keyboard_key;
 using DetourModKit::mouse_button;
 
+// clear_registered_items() runs inside the noexcept DMK_Shutdown teardown chain, so a throw from it would terminate
+// the host. Its diagnostic logging routes through the no-throw try_log path to keep the contract honest; pin it here.
+static_assert(noexcept(Config::clear_registered_items()),
+              "Config::clear_registered_items() must be noexcept (it runs inside the noexcept teardown chain).");
+
 class ConfigTest : public ::testing::Test
 {
 protected:
@@ -2204,7 +2209,7 @@ namespace
     // RAII helper that redirects the global Logger to a temporary file and exposes the captured contents for
     // assertions. On destruction the Logger is parked on a stable per-process file so the capture file's handle is
     // released and remove() succeeds on Windows; subsequent tests overwrite the parking sink as needed via their own
-    // reconfigure() calls. Sync mode is forced because the tests inspect the file immediately after the logging call
+    // configure() calls. Sync mode is forced because the tests inspect the file immediately after the logging call
     // returns.
     class LoggerFileCapture
     {
@@ -2221,7 +2226,7 @@ namespace
             {
                 logger.disable_async_mode();
             }
-            logger.reconfigure("CAPTURE", m_capture_file.string(), "%H:%M:%S");
+            DetourModKit::Logger::configure("CAPTURE", m_capture_file.string(), "%H:%M:%S");
             m_previous_level = logger.get_log_level();
             logger.set_log_level(DetourModKit::LogLevel::Trace);
         }
@@ -2232,7 +2237,7 @@ namespace
             logger.flush();
             const auto parking =
                 std::filesystem::temp_directory_path() / ("dmk_capture_parked_" + std::to_string(_getpid()) + ".log");
-            logger.reconfigure("PARKED", parking.string(), "%H:%M:%S");
+            DetourModKit::Logger::configure("PARKED", parking.string(), "%H:%M:%S");
             logger.set_log_level(m_previous_level);
             if (m_previous_async)
             {

--- a/tests/test_config_watcher.cpp
+++ b/tests/test_config_watcher.cpp
@@ -144,6 +144,56 @@ namespace
         watcher.stop();
     }
 
+    TEST_F(ConfigWatcherTest, IsWorkerThreadFalseAfterStop)
+    {
+        // The worker publishes its thread id on entry and must clear it again as it exits. Otherwise the stored id
+        // outlives the worker, and a later OS-recycled thread id reusing that value would make is_worker_thread()
+        // return a false positive, suppressing a genuine stop request as a self-call.
+        std::atomic<bool> observed{false};
+        std::atomic<std::thread::id> cb_tid{};
+        ConfigWatcher watcher(m_ini_path.string(), 50ms,
+                              [&]()
+                              {
+                                  cb_tid.store(std::this_thread::get_id(), std::memory_order_release);
+                                  observed.store(true, std::memory_order_release);
+                              });
+        ASSERT_TRUE(watcher.start());
+        ASSERT_TRUE(wait_until([&]() { return watcher.is_running(); }, 1s));
+        std::this_thread::sleep_for(100ms);
+
+        write_ini("[S]\nK=2\n");
+        ASSERT_TRUE(wait_until([&]() { return observed.load(std::memory_order_acquire); }, 3s));
+
+        const std::thread::id worker_tid = cb_tid.load(std::memory_order_acquire);
+        ASSERT_NE(worker_tid, std::thread::id{});
+        EXPECT_TRUE(watcher.is_worker_thread(worker_tid)) << "the worker id must match while the watcher is running";
+
+        watcher.stop();
+        ASSERT_FALSE(watcher.is_running());
+
+        // stop() joins the worker, so by the time it returns the worker has run its exit guard and reset the slot to
+        // the no-thread id. The captured worker id must therefore no longer match.
+        EXPECT_FALSE(watcher.is_worker_thread(worker_tid))
+            << "the stored worker id must reset on worker exit so a recycled thread id cannot suppress a stop";
+        EXPECT_FALSE(watcher.is_worker_thread(std::thread::id{}))
+            << "a default (no-thread) id must never be reported as the worker";
+    }
+
+    TEST_F(ConfigWatcherTest, IsWorkerThreadFalseAfterEarlyExit)
+    {
+        // Covers the worker's early-return path: the id is published on entry, then CreateFileW fails for a
+        // non-existent parent directory and the worker returns before the pump loop. The same scope guard must clear
+        // the id on that return, and start()'s failure path joins the worker before returning, so by the time start()
+        // reports false the slot is back to the no-thread id. Complements IsWorkerThreadFalseAfterStop, which covers
+        // the normal-exit reset with a captured worker id.
+        ConfigWatcher watcher((m_temp_dir / "nonexistent_subdir" / "file.ini").string(), 50ms, []() {});
+
+        EXPECT_FALSE(watcher.start());
+        EXPECT_FALSE(watcher.is_running());
+        EXPECT_FALSE(watcher.is_worker_thread(std::this_thread::get_id()));
+        EXPECT_FALSE(watcher.is_worker_thread(std::thread::id{}));
+    }
+
     TEST_F(ConfigWatcherTest, StopWithoutStartIsSafe)
     {
         ConfigWatcher watcher(m_ini_path.string(), 50ms, []() {});

--- a/tests/test_shutdown.cpp
+++ b/tests/test_shutdown.cpp
@@ -15,6 +15,12 @@
 using namespace DetourModKit;
 using DetourModKit::keyboard_key;
 
+// DMK_Shutdown() is the documented teardown entry point and runs from loader-lock / DLL_PROCESS_DETACH paths where an
+// escaping exception would terminate the host. Every subsystem teardown it invokes is noexcept, so the wrapper is too;
+// pin that no-throw contract at compile time.
+static_assert(noexcept(DMK_Shutdown()),
+              "DMK_Shutdown() must be noexcept so teardown cannot throw into a host unwinding under the loader lock.");
+
 class DMKShutdownTest : public ::testing::Test
 {
 protected:


### PR DESCRIPTION
## Summary

Correctness and polish pass on teardown and the config watcher.

- ConfigWatcher clears its published worker-thread id on every exit path and is_worker_thread rejects the no-thread id, so a recycled OS thread id can no longer match a dead worker and suppress a real stop.
- DMK_Shutdown and Config::clear_registered_items are now noexcept (the latter logs through the no-throw try_log path), and Bootstrap teardown calls them directly and drops the now-dead try/catch wrappers.
- USERSPACE_PTR_MIN/MAX are documented as declaration doc-blocks, and the brace policy (InsertBraces left unset) is recorded in .clang-format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Shutdown and configuration clearing functions now guarantee no-throw behavior for improved stability.

* **Bug Fixes**
  * Fixed thread ID tracking in configuration watcher to prevent recycled OS thread IDs from causing false matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->