### PR TITLE
fix: resolve clang-tidy advisory-lane findings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,13 @@
 # Conservative, advisory static-analysis profile for DetourModKit.
 # Start from nothing and opt into high-signal families. Win32, SEH, and
 # low-level pointer idioms are intentional in this library, so the checks that
-# flag them are disabled rather than worked around at the call site.
+# flag them are disabled rather than worked around at the call site:
+#   - performance-no-int-to-ptr: integer <-> pointer conversion at Win32 and
+#     hook/scan boundaries is the library's core idiom (see the Address type),
+#     not an accidental pessimization.
+#   - bugprone-empty-catch: an empty catch(...) is the deliberate fail-closed
+#     swallow on noexcept teardown and best-effort paths (a sink or format
+#     failure must never escape into the host).
 Checks: >
   -*,
   bugprone-*,
@@ -14,9 +20,15 @@ Checks: >
   cppcoreguidelines-slicing,
   -bugprone-easily-swappable-parameters,
   -bugprone-reserved-identifier,
-  -bugprone-assignment-in-if-condition
+  -bugprone-assignment-in-if-condition,
+  -bugprone-empty-catch,
+  -performance-no-int-to-ptr
 # Advisory only: never fail a build on a tidy finding.
 WarningsAsErrors: ''
 # Only diagnose this project's own public headers, not external/ submodules.
 HeaderFilterRegex: 'include/DetourModKit/.*\.hpp$'
 FormatStyle: file
+CheckOptions:
+  # `(void)expr;` is the library's sanctioned discard of a [[nodiscard]] return (the deliberate
+  # release()-to-leak verbs, the fail-soft live-rebind). Honour it instead of flagging the cast.
+  bugprone-unused-return-value.AllowCastToVoid: 'true'

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,5 @@
+# Non-Markdown config files whose YAML/INI '#' comment lines markdownlint would
+# otherwise misread as Markdown '#' headings. These are not documentation.
+.clang-format
+.clang-tidy
+.editorconfig

--- a/include/DetourModKit.hpp
+++ b/include/DetourModKit.hpp
@@ -127,7 +127,7 @@ namespace DetourModKit
          * @note noexcept by contract: bootstrap() calls this under the loader lock, where an escaping exception is
          *       undefined behavior, so every throwing step is caught and mapped to a Result failure.
          */
-        [[nodiscard]] static Result<Session> start(ModInfo info) noexcept;
+        [[nodiscard]] static Result<Session> start(const ModInfo &info) noexcept;
 
         /** @brief Move-constructs, transferring the live teardown; the moved-from Session is left inert. */
         Session(Session &&other) noexcept;
@@ -222,7 +222,7 @@ namespace DetourModKit
      *       and starts a thread. noexcept by contract: it runs under the loader lock, so any internal throw is caught,
      *       the partial attach is rolled back, and a Result failure is returned rather than unwinding across the lock.
      */
-    [[nodiscard]] Result<void> bootstrap(ModInfo info,
+    [[nodiscard]] Result<void> bootstrap(const ModInfo &info,
                                          std::move_only_function<Result<void>(Session &)> on_ready) noexcept;
 
     /**

--- a/include/DetourModKit/address.hpp
+++ b/include/DetourModKit/address.hpp
@@ -8,9 +8,9 @@
  *          the one genuinely unsafe operation (integer <-> pointer punning) across the whole codebase and made
  *          "is this number a pointer, an offset, or a size?" a matter of reading the variable name. Address replaces
  *          that with a zero-overhead strong type: it is exactly a machine pointer wide (asserted below), every
- *          arithmetic helper is `constexpr`, and the reinterpret_cast story is confined to the three audited members
- *          (the templated pointer constructor, `as<T>()`, and `ptr<T>()`). Everything else is plain integer math on a
- *          value that cannot be silently confused with an int.
+ *          arithmetic helper is `constexpr`, and the reinterpret_cast story is confined to the four audited members
+ *          (the templated pointer constructor, `as<T>()`, `ptr<T>()`, and the RIP-relative read in `rip()`).
+ *          Everything else is plain integer math on a value that cannot be silently confused with an int.
  */
 
 #include "DetourModKit/defines.hpp"
@@ -62,7 +62,7 @@ namespace DetourModKit
          * @param pointer The pointer to capture as an address.
          * @details The `T*` parameter only deduces against an actual pointer argument, so a non-pointer is a deduction
          *          failure and never competes here, and `std::nullptr_t` is taken by the overload above. That keeps
-         *          this one of the three audited reinterpret_cast sites instead of letting pointer punning leak to
+         *          this one of the four audited reinterpret_cast sites instead of letting pointer punning leak to
          *          call sites.
          */
         template <class T> explicit Address(T *pointer) noexcept : m_value{reinterpret_cast<std::uintptr_t>(pointer)} {}
@@ -127,7 +127,7 @@ namespace DetourModKit
         /**
          * @brief Reinterprets the address as a value of type @p T.
          * @tparam T The destination type: an integral type, or any pointer / function-pointer type.
-         * @details One of the three audited cast sites. An integral @p T takes the value-preserving `static_cast`
+         * @details One of the four audited cast sites. An integral @p T takes the value-preserving `static_cast`
          *          path; any other @p T (pointer or function pointer) takes the single `reinterpret_cast`. This is how
          *          a resolved address is turned back into a typed function pointer to call or a typed data pointer to
          *          read, with the pun confined to here rather than the call site.

--- a/src/async_logger.cpp
+++ b/src/async_logger.cpp
@@ -224,6 +224,9 @@ namespace DetourModKit
             block->free_list = slot;
         }
 
+        // buffer is intentionally left uninitialized on this hot path (see async_logger_queue.hpp): only [0, length)
+        // is written before any read, so zero-filling it every message would be wasted work.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
         LogMessage::LogMessage(LogLevel lvl, std::string_view msg) noexcept
             : level(lvl), timestamp(std::chrono::system_clock::now()), thread_id(std::this_thread::get_id())
         {
@@ -241,7 +244,7 @@ namespace DetourModKit
                 {
                     try
                     {
-                        overflow->assign(msg.data(), msg_size);
+                        overflow->assign(msg.substr(0, msg_size));
                         length = overflow->size();
                     }
                     catch (...)
@@ -268,6 +271,7 @@ namespace DetourModKit
         // StringPool or m_heap_fallback_count. The allocation/deallocation balance is maintained because exactly one
         // LogMessage owns the pointer at any time, and only reset() (called by the eventual owner's destructor) returns
         // it to the pool.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init) buffer is filled by the length-guarded memcpy below
         LogMessage::LogMessage(LogMessage &&other) noexcept
             : level(other.level), timestamp(other.timestamp), thread_id(other.thread_id), length(other.length),
               overflow(other.overflow)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -807,11 +807,13 @@ namespace DetourModKit
                             }
                             catch (const std::exception &e)
                             {
-                                logger.error("Config: reload servicer caught exception: {}", e.what());
+                                (void)logger.try_log(LogLevel::Error, "Config: reload servicer caught exception: {}",
+                                                     e.what());
                             }
                             catch (...)
                             {
-                                logger.error("Config: reload servicer caught unknown exception.");
+                                (void)logger.try_log(LogLevel::Error,
+                                                     "Config: reload servicer caught unknown exception.");
                             }
                         }
                     }
@@ -903,7 +905,7 @@ namespace DetourModKit
                         std::string(section), std::string(ini_key), std::string(log_key_name), setter, default_value));
                     if (setter)
                     {
-                        deferred = [setter, val = default_value]() mutable
+                        deferred = [setter = std::move(setter), val = std::move(default_value)]() mutable
                         {
                             if constexpr (std::same_as<T, std::string>)
                             {
@@ -979,7 +981,7 @@ namespace DetourModKit
                     std::string(section), std::string(key), std::string(display_name), setter, default_combos));
                 if (setter)
                 {
-                    deferred = [setter, combos = std::move(default_combos)]() { setter(combos); };
+                    deferred = [setter = std::move(setter), combos = std::move(default_combos)]() { setter(combos); };
                 }
             }
             if (deferred)
@@ -1229,6 +1231,8 @@ namespace DetourModKit
                         // read.
                         if (auto &cached_hash = get_last_loaded_ini_hash(); cached_hash.has_value())
                         {
+                            // load_ini_into sets hash whenever read_succeeded, and this is the read_succeeded branch.
+                            // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
                             const std::uint64_t current_hash = *outcome.hash;
                             if (current_hash == *cached_hash)
                             {
@@ -1387,7 +1391,8 @@ namespace DetourModKit
                 // own disable flag.
                 if (watcher && watcher->is_worker_thread(std::this_thread::get_id()))
                 {
-                    log().error(
+                    (void)log().try_log(
+                        LogLevel::Error,
                         "Config: disable_auto_reload() called from the watcher thread; ignoring to avoid self-join "
                         "deadlock. Call from a different thread or disable the hotkey binding instead.");
                     return;

--- a/src/dmk.cpp
+++ b/src/dmk.cpp
@@ -11,6 +11,7 @@
 #include <windows.h>
 
 #include <atomic>
+#include <cstdint>
 #include <cwchar>
 #include <exception>
 #include <optional>
@@ -87,7 +88,7 @@ namespace DetourModKit
 
         // Outcome of a single-instance mutex acquisition. Distinguishing AlreadyHeld from SystemError lets
         // Session::start map each to its own ErrorCode (InstanceAlreadyRunning vs SystemCallFailed).
-        enum class MutexAcquire
+        enum class MutexAcquire : std::uint8_t
         {
             /// A fresh mutex was created; @p out holds the handle the Session must close.
             Acquired,
@@ -212,16 +213,17 @@ namespace DetourModKit
                     Result<void> ready = s_on_ready(session);
                     if (!ready)
                     {
-                        log().error("bootstrap: on_ready reported failure: {}", ready.error().message());
+                        (void)log().try_log(LogLevel::Error, "bootstrap: on_ready reported failure: {}",
+                                            ready.error().message());
                     }
                 }
                 catch (const std::exception &e)
                 {
-                    log().error("bootstrap: on_ready threw: {}", e.what());
+                    (void)log().try_log(LogLevel::Error, "bootstrap: on_ready threw: {}", e.what());
                 }
                 catch (...)
                 {
-                    log().error("bootstrap: on_ready threw an unknown exception.");
+                    (void)log().try_log(LogLevel::Error, "bootstrap: on_ready threw an unknown exception.");
                 }
             }
 
@@ -235,7 +237,7 @@ namespace DetourModKit
         }
 
         // The throwing core of bootstrap, separated so the public entry point stays noexcept under the loader lock.
-        [[nodiscard]] Result<void> bootstrap_core(ModInfo info,
+        [[nodiscard]] Result<void> bootstrap_core(const ModInfo &info,
                                                   std::move_only_function<Result<void>(Session &)> on_ready)
         {
             if (s_worker_thread || s_shutdown_event)
@@ -352,7 +354,7 @@ namespace DetourModKit
         s_session_active.store(false, std::memory_order_release);
     }
 
-    Result<Session> Session::start(ModInfo info) noexcept
+    Result<Session> Session::start(const ModInfo &info) noexcept
     {
         // Claim the single-session guard first; a mod DLL has one process lifetime, so a second start is a caller bug.
         bool expected = false;
@@ -439,7 +441,7 @@ namespace DetourModKit
 
     // --- Bootstrap free functions ----------------------------------------------------------------------------------
 
-    Result<void> bootstrap(ModInfo info, std::move_only_function<Result<void>(Session &)> on_ready) noexcept
+    Result<void> bootstrap(const ModInfo &info, std::move_only_function<Result<void>(Session &)> on_ready) noexcept
     {
         // Fail closed on any throw so nothing unwinds across the loader lock; the partial attach is rolled back.
         try

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -49,7 +49,7 @@ namespace DetourModKit
     namespace
     {
         /// Result of the foreign-inline-hook pre-flight: whether the target already redirects, and to where.
-        enum class PrehookState
+        enum class PrehookState : std::uint8_t
         {
             NotHooked,
             HookedBySameModule,
@@ -132,7 +132,7 @@ namespace DetourModKit
         }
 
         /// The flagged prologue shapes the inline/mid pre-flight refuses under Prologue::Fail.
-        enum class PrologueRisk
+        enum class PrologueRisk : std::uint8_t
         {
             None,
             LeadingCall, // 0xE8 call rel32
@@ -358,6 +358,7 @@ namespace DetourModKit
          * passes straight through; a deferred OwnedScanRequest is resolved through
          *          scan::resolve and its winning address returned (or its Error).
          */
+        // NOLINTNEXTLINE(bugprone-exception-escape): scan::resolve's throw is caught below; std::get is on a checked variant
         Result<std::uintptr_t> resolve_target(const hook::Target &target) noexcept
         {
             if (const Address *absolute = std::get_if<Address>(&target))
@@ -704,6 +705,7 @@ namespace DetourModKit
             return inline_backend->original<void *>();
         }
 
+        // NOLINTNEXTLINE(bugprone-exception-escape): only mutex-lock and std::visit throw (catastrophic/impossible)
         Result<void> Hook::enable() noexcept
         {
             if (!m_impl)
@@ -744,6 +746,7 @@ namespace DetourModKit
             return std::unexpected(Error{ErrorCode::EnableFailed, "hook::enable"});
         }
 
+        // NOLINTNEXTLINE(bugprone-exception-escape): only mutex-lock and std::visit throw (catastrophic/impossible)
         Result<void> Hook::disable() noexcept
         {
             if (!m_impl)

--- a/src/input_codes.cpp
+++ b/src/input_codes.cpp
@@ -21,12 +21,12 @@ namespace DetourModKit
     {
         struct NameEntry
         {
-            const char *name;
+            const char *name = nullptr;
             InputCode code;
         };
 
         // clang-format off
-        constexpr NameEntry name_table[] = {
+        constexpr NameEntry NAME_TABLE[] = {
             // --- Keyboard: Modifiers ---
             {"Ctrl",        {InputSource::Keyboard, 0x11}},
             {"LCtrl",       {InputSource::Keyboard, 0xA2}},
@@ -212,7 +212,7 @@ namespace DetourModKit
         };
         // clang-format on
 
-        constexpr size_t name_table_size = sizeof(name_table) / sizeof(name_table[0]);
+        constexpr size_t NAME_TABLE_SIZE = sizeof(NAME_TABLE) / sizeof(NAME_TABLE[0]);
 
         int icompare(std::string_view a, std::string_view b) noexcept
         {
@@ -299,17 +299,17 @@ namespace DetourModKit
 
         struct SortedNameIndex
         {
-            size_t indices[name_table_size]{};
-            size_t count = name_table_size;
+            size_t indices[NAME_TABLE_SIZE]{};
+            size_t count = NAME_TABLE_SIZE;
 
             SortedNameIndex()
             {
-                for (size_t i = 0; i < name_table_size; ++i)
+                for (size_t i = 0; i < NAME_TABLE_SIZE; ++i)
                 {
                     indices[i] = i;
                 }
                 std::sort(indices, indices + count,
-                          [](size_t a, size_t b) { return icompare(name_table[a].name, name_table[b].name) < 0; });
+                          [](size_t a, size_t b) { return icompare(NAME_TABLE[a].name, NAME_TABLE[b].name) < 0; });
             }
         };
 
@@ -325,10 +325,10 @@ namespace DetourModKit
 
             CodeNameMap()
             {
-                map.reserve(name_table_size);
-                for (size_t i = 0; i < name_table_size; ++i)
+                map.reserve(NAME_TABLE_SIZE);
+                for (size_t i = 0; i < NAME_TABLE_SIZE; ++i)
                 {
-                    map.emplace(name_table[i].code, name_table[i].name);
+                    map.emplace(NAME_TABLE[i].code, NAME_TABLE[i].name);
                 }
             }
         };
@@ -360,7 +360,7 @@ namespace DetourModKit
         while (lo < hi)
         {
             const size_t mid = lo + (hi - lo) / 2;
-            const int cmp = icompare(name_table[idx.indices[mid]].name, name);
+            const int cmp = icompare(NAME_TABLE[idx.indices[mid]].name, name);
             if (cmp < 0)
             {
                 lo = mid + 1;
@@ -371,7 +371,7 @@ namespace DetourModKit
             }
             else
             {
-                return name_table[idx.indices[mid]].code;
+                return NAME_TABLE[idx.indices[mid]].code;
             }
         }
         return std::nullopt;

--- a/src/internal/config_watcher.cpp
+++ b/src/internal/config_watcher.cpp
@@ -308,7 +308,7 @@ namespace DetourModKit
                 "ConfigWatcher",
                 [directory = std::move(directory), filename = std::move(filename), debounce_ms,
                  callback = std::move(callback), label = std::move(label), open_result,
-                 worker_id_slot](std::stop_token st)
+                 worker_id_slot](const std::stop_token &st)
                 {
                     // Publish our thread id so is_worker_thread() can detect setter-invoked self-calls into
                     // disable_auto_reload(). The guard, declared first so its destructor runs after the final flush

--- a/src/internal/memory_guarded.cpp
+++ b/src/internal/memory_guarded.cpp
@@ -159,7 +159,9 @@ namespace DetourModKit
         // the handler to target.
         [[noreturn]] __attribute__((noinline)) void veh_perform_longjmp(void *env) noexcept
         {
-            __builtin_longjmp(env, 1);
+            // __builtin_longjmp is typed void(void **, int); env points at the VehAccessGuard::env[5] buffer. The
+            // explicit cast matches that signature (GCC accepts the bare void *, clang's frontend rejects it).
+            __builtin_longjmp(static_cast<void **>(env), 1);
         }
 
         // Vectored exception handler, installed at the front of the list. It claims a fault only when the current
@@ -273,7 +275,7 @@ namespace DetourModKit
         __attribute__((noinline)) bool veh_guarded_copy(void *out, const void *src, std::size_t len) noexcept
         {
             const DWORD slot = s_veh_tls_index.load(std::memory_order_acquire);
-            VehAccessGuard guard;
+            VehAccessGuard guard{};
             guard.guard_lo = reinterpret_cast<std::uintptr_t>(src);
             guard.guard_hi = guard.guard_lo + len;
 
@@ -310,7 +312,7 @@ namespace DetourModKit
                                                           void (*fn)(void *) noexcept, void *ctx) noexcept
         {
             const DWORD slot = s_veh_tls_index.load(std::memory_order_acquire);
-            VehAccessGuard guard;
+            VehAccessGuard guard{};
             guard.guard_lo = lo;
             guard.guard_hi = hi;
 

--- a/src/internal/worker.cpp
+++ b/src/internal/worker.cpp
@@ -17,7 +17,7 @@ namespace DetourModKit
         }
 
         m_thread = std::jthread(
-            [fn = std::move(body), label = m_name](std::stop_token st)
+            [fn = std::move(body), label = m_name](const std::stop_token &st)
             {
                 try
                 {

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -26,7 +26,7 @@ namespace DetourModKit
 
         struct AsyncLoggerLeakSlot
         {
-            alignas(std::shared_ptr<AsyncLogger>) unsigned char storage[sizeof(std::shared_ptr<AsyncLogger>)];
+            alignas(std::shared_ptr<AsyncLogger>) unsigned char storage[sizeof(std::shared_ptr<AsyncLogger>)]{};
             std::atomic<bool> occupied{false};
         };
 
@@ -584,6 +584,7 @@ namespace DetourModKit
         }
     }
 
+    // NOLINTNEXTLINE(bugprone-exception-escape): OOM constructing the logger deliberately terminates (see below)
     Logger &log() noexcept
     {
         // The process-default logger, allocated once and INTENTIONALLY never destroyed. A plain function-local static
@@ -594,6 +595,7 @@ namespace DetourModKit
         // explicitly, so the deliberate leak costs only the object's storage, never a lost flush. Constructing it
         // can allocate; under true out-of-memory at first use the noexcept boundary turns that throw into termination,
         // the only sane outcome when the logger itself cannot start.
+        // NOLINTNEXTLINE(bugprone-unhandled-exception-at-new): first-use OOM deliberately terminates (see above)
         static Logger *const instance = new Logger();
         return *instance;
     }

--- a/src/memory_cache.cpp
+++ b/src/memory_cache.cpp
@@ -470,7 +470,7 @@ namespace DetourModKit
                     new_entry.lru_key = new_lru_key;
                     new_entry.valid = true;
 
-                    shard.entries.insert_or_assign(base_addr, std::move(new_entry));
+                    shard.entries.insert_or_assign(base_addr, new_entry);
                     shard.lru_index.emplace(new_lru_key, base_addr);
                     insert_sorted_range(shard, base_addr, mbi.RegionSize);
                 }

--- a/src/rtti_dissect.cpp
+++ b/src/rtti_dissect.cpp
@@ -625,9 +625,10 @@ namespace DetourModKit
         bool expected = false;
         if (m_drift_warned.compare_exchange_strong(expected, true, std::memory_order_relaxed))
         {
-            log().warning("Self-heal: layout drifted (first change: {} by {:+#x}); pointer offsets recovered. "
-                          "Re-verify non-healable scalars.",
-                          label, delta);
+            (void)log().try_log(LogLevel::Warning,
+                                "Self-heal: layout drifted (first change: {} by {:+#x}); pointer offsets recovered. "
+                                "Re-verify non-healable scalars.",
+                                label, delta);
         }
     }
 
@@ -645,12 +646,13 @@ namespace DetourModKit
             if (delta != 0)
             {
                 warn_drift_once(label, delta);
-                logger.info("Self-heal: {} moved {:+#x} ({:#x} -> {:#x})", label, delta, landmark.nominal_offset,
-                            result->healed_offset);
+                (void)logger.try_log(LogLevel::Info, "Self-heal: {} moved {:+#x} ({:#x} -> {:#x})", label, delta,
+                                     landmark.nominal_offset, result->healed_offset);
             }
             else
             {
-                logger.debug("Self-heal: {} confirmed at nominal {:#x}", label, landmark.nominal_offset);
+                (void)logger.try_log(LogLevel::Debug, "Self-heal: {} confirmed at nominal {:#x}", label,
+                                     landmark.nominal_offset);
             }
             return result;
         }
@@ -661,13 +663,13 @@ namespace DetourModKit
         const std::string_view reason = to_string(result.error().code);
         if (required && m_config.escalate == HealEscalation::WarnRequired)
         {
-            logger.warning("Self-heal: {} unresolved ({}); kept nominal {:#x} (re-author if drifted)", label, reason,
-                           landmark.nominal_offset);
+            (void)logger.try_log(LogLevel::Warning, "Self-heal: {} unresolved ({}); kept nominal {:#x} (re-author "
+                                 "if drifted)", label, reason, landmark.nominal_offset);
         }
         else
         {
-            logger.debug("Self-heal: {} not resolvable now ({}); keeping nominal {:#x}", label, reason,
-                         landmark.nominal_offset);
+            (void)logger.try_log(LogLevel::Debug, "Self-heal: {} not resolvable now ({}); keeping nominal {:#x}", label,
+                                 reason, landmark.nominal_offset);
         }
         return result;
     }
@@ -680,11 +682,12 @@ namespace DetourModKit
         if (delta != 0)
         {
             warn_drift_once(label, delta);
-            logger.info("Self-heal: {} moved {:+#x} ({:#x} -> {:#x})", label, delta, nominal_offset, healed_offset);
+            (void)logger.try_log(LogLevel::Info, "Self-heal: {} moved {:+#x} ({:#x} -> {:#x})", label, delta,
+                                 nominal_offset, healed_offset);
         }
         else
         {
-            logger.debug("Self-heal: {} confirmed at nominal {:#x}", label, nominal_offset);
+            (void)logger.try_log(LogLevel::Debug, "Self-heal: {} confirmed at nominal {:#x}", label, nominal_offset);
         }
     }
 } // namespace DetourModKit

--- a/src/scan_resolution.cpp
+++ b/src/scan_resolution.cpp
@@ -146,7 +146,7 @@ namespace DetourModKit
                         DetourModKit::rtti::vtable_for_type(rtti->mangled, request.scope);
                     if (vtable && range.contains(vtable->raw()))
                     {
-                        const Hit hit{*vtable, candidate.name()};
+                        Hit hit{*vtable, candidate.name()};
                         log_resolved(request, hit, false);
                         return hit;
                     }
@@ -166,7 +166,7 @@ namespace DetourModKit
                     const Result<Address> site = find_string_xref(query, request.scope);
                     if (site && range.contains(site->raw()))
                     {
-                        const Hit hit{*site, candidate.name()};
+                        Hit hit{*site, candidate.name()};
                         log_resolved(request, hit, false);
                         return hit;
                     }
@@ -221,7 +221,7 @@ namespace DetourModKit
                     // module); reject it here so the ladder falls through instead of committing out of scope.
                     continue;
                 }
-                const Hit hit{Address{*resolved}, candidate.name()};
+                Hit hit{Address{*resolved}, candidate.name()};
                 log_resolved(request, hit, false);
                 return hit;
             }

--- a/src/win_file_stream.cpp
+++ b/src/win_file_stream.cpp
@@ -10,7 +10,7 @@ namespace DetourModKit::detail
 {
     // --- WinFileStreamBuf ---
 
-    WinFileStreamBuf::WinFileStreamBuf() noexcept : m_handle(INVALID_HANDLE_VALUE)
+    WinFileStreamBuf::WinFileStreamBuf() noexcept : m_handle(INVALID_HANDLE_VALUE), m_buffer{}
     {
         setp(m_buffer.data(), m_buffer.data() + BUFFER_SIZE);
     }


### PR DESCRIPTION
## Summary
Clears the clang-tidy advisory lane, which had a hard parse error plus 94 warnings on the library's own sources.

## Changes
- Fix 10 `noexcept` functions that could throw via `logger.*` and terminate the host; they now route through the no-throw `try_log`.
- Fix a clang-only `__builtin_longjmp` diagnostic that aborted the tidy run.
- Apply safe lint fixes (enum size, member init, redundant moves, string_view usage).
- Tune `.clang-tidy`: disable the intentional Win32/SEH pointer idioms, honor the sanctioned `(void)` discard, and NOLINT a few reviewed false positives.
- Add `.markdownlintignore` so markdownlint skips the YAML config dotfiles.
