### PR TITLE
style: clear clang-format advisory-lane violations

### DIFF
--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -358,7 +358,7 @@ namespace DetourModKit
          * passes straight through; a deferred OwnedScanRequest is resolved through
          *          scan::resolve and its winning address returned (or its Error).
          */
-        // NOLINTNEXTLINE(bugprone-exception-escape): scan::resolve's throw is caught below; std::get is on a checked variant
+        // NOLINTNEXTLINE(bugprone-exception-escape): scan::resolve throw is caught; std::get is on a checked variant
         Result<std::uintptr_t> resolve_target(const hook::Target &target) noexcept
         {
             if (const Address *absolute = std::get_if<Address>(&target))

--- a/src/rtti_dissect.cpp
+++ b/src/rtti_dissect.cpp
@@ -663,8 +663,10 @@ namespace DetourModKit
         const std::string_view reason = to_string(result.error().code);
         if (required && m_config.escalate == HealEscalation::WarnRequired)
         {
-            (void)logger.try_log(LogLevel::Warning, "Self-heal: {} unresolved ({}); kept nominal {:#x} (re-author "
-                                 "if drifted)", label, reason, landmark.nominal_offset);
+            (void)logger.try_log(LogLevel::Warning,
+                                 "Self-heal: {} unresolved ({}); kept nominal {:#x} (re-author "
+                                 "if drifted)",
+                                 label, reason, landmark.nominal_offset);
         }
         else
         {


### PR DESCRIPTION
## Summary

Follow-up to #155: fixes the three clang-format 20 violations the advisory lane flagged after merge.

## Changes
- Shorten an over-120 `NOLINTNEXTLINE` comment in `resolve_target`, kept on one line so the suppression still applies.
- Let clang-format reflow the wrapped `try_log` call in `heal_into`.

Formatting only, no behavior change. The full clang-format sweep and clang-tidy are both clean, and CRLF line endings are preserved.
