### PR TITLE
chore(scan): suppress false-positive uninit warning on the back-scan window

### DIFF
--- a/src/scan_string_xref.cpp
+++ b/src/scan_string_xref.cpp
@@ -628,6 +628,7 @@ namespace DetourModKit
                 // guarded_read_bytes, and both probe loops below read only indices within that filled span (they are
                 // bounded by valid_lo / instr_addr), so no unwritten byte is ever observed. Value-initializing the full
                 // 8 KiB every call would be dead work on this control-plane path.
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init) filled before any read, see above
                 std::array<std::uint8_t, static_cast<std::size_t>(back_scan_window)> window;
                 std::uintptr_t valid_lo = instr_addr;
                 // Windows x86/x64 base page size; guarded_read_bytes faults at this granularity. Chunks are


### PR DESCRIPTION
## Summary

The 8 KiB enclosing_function_start window is intentionally left uninitialized (a landed optimization): the chunk-read loop fills exactly [valid_lo, instr_addr) and both probe loops read only within that span, so no unwritten byte is observed. Add a NOLINTNEXTLINE for cppcoreguidelines-pro-type-member-init, matching the same suppression on the length-guarded buffer in async_logger.cpp.