### PR TITLE
feat: atomic module identity and explicit session lifecycle context

### DIFF
--- a/cmake/source_manifest.txt
+++ b/cmake/source_manifest.txt
@@ -45,6 +45,7 @@ src/internal/async_logger.cpp
 src/internal/config_watcher.cpp
 src/internal/input_intercept.cpp
 src/internal/input_poller.cpp
+src/internal/lifecycle_context.cpp
 src/internal/memory_guarded.cpp
 src/internal/scan_batch.cpp
 src/internal/scan_engine.cpp

--- a/include/DetourModKit/session.hpp
+++ b/include/DetourModKit/session.hpp
@@ -239,6 +239,8 @@ namespace DetourModKit
     /**
      * @brief The module handle captured at bootstrap() time, or nullptr before bootstrap() / after detach or when only
      *        the synchronous Session::start path was used.
+     * @note Callback-safe: published and read through a lock-free atomic, so a reader on any thread observes only the
+     *       current identity or null and never races a concurrent detach-path clear.
      */
     [[nodiscard]] ModuleHandle module_handle() noexcept;
 

--- a/src/internal/lifecycle_context.cpp
+++ b/src/internal/lifecycle_context.cpp
@@ -1,43 +1,47 @@
 #include "lifecycle_context.hpp"
 
-namespace DetourModKit::detail
+namespace DetourModKit
 {
-    namespace
+    namespace detail
     {
-        // Constant initialization avoids a dynamic-initialization-order dependency between translation units.
-        constinit LifecycleContext s_lifecycle;
-    } // namespace
-
-    LifecycleContext &lifecycle() noexcept
-    {
-        return s_lifecycle;
-    }
-
-    bool LifecycleContext::begin_start() noexcept
-    {
-        LifecycleState expected = LifecycleState::Stopped;
-        if (!m_state.compare_exchange_strong(expected, LifecycleState::Starting, std::memory_order_acq_rel))
+        namespace
         {
-            return false;
+            // Constant initialization avoids a dynamic-initialization-order dependency between translation units.
+            constinit LifecycleContext s_lifecycle;
+        } // namespace
+
+        LifecycleContext &lifecycle() noexcept
+        {
+            return s_lifecycle;
         }
-        // Publish the new generation and neutral loader context before mark_running() releases the admitted session.
-        m_generation.fetch_add(1, std::memory_order_acq_rel);
-        m_loader_context.store(LoaderContext::Normal, std::memory_order_release);
-        return true;
-    }
 
-    void LifecycleContext::mark_running() noexcept
-    {
-        m_state.store(LifecycleState::Running, std::memory_order_release);
-    }
+        bool LifecycleContext::begin_start() noexcept
+        {
+            LifecycleState expected = LifecycleState::Stopped;
+            if (!m_state.compare_exchange_strong(expected, LifecycleState::Starting, std::memory_order_acq_rel))
+            {
+                return false;
+            }
+            // Publish the new generation and neutral loader context before mark_running() releases the admitted
+            // session.
+            m_generation.fetch_add(1, std::memory_order_acq_rel);
+            m_loader_context.store(LoaderContext::Normal, std::memory_order_release);
+            return true;
+        }
 
-    void LifecycleContext::begin_stop() noexcept
-    {
-        m_state.store(LifecycleState::Stopping, std::memory_order_release);
-    }
+        void LifecycleContext::mark_running() noexcept
+        {
+            m_state.store(LifecycleState::Running, std::memory_order_release);
+        }
 
-    void LifecycleContext::mark_stopped() noexcept
-    {
-        m_state.store(LifecycleState::Stopped, std::memory_order_release);
-    }
-} // namespace DetourModKit::detail
+        void LifecycleContext::begin_stop() noexcept
+        {
+            m_state.store(LifecycleState::Stopping, std::memory_order_release);
+        }
+
+        void LifecycleContext::mark_stopped() noexcept
+        {
+            m_state.store(LifecycleState::Stopped, std::memory_order_release);
+        }
+    } // namespace detail
+} // namespace DetourModKit

--- a/src/internal/lifecycle_context.cpp
+++ b/src/internal/lifecycle_context.cpp
@@ -1,0 +1,43 @@
+#include "lifecycle_context.hpp"
+
+namespace DetourModKit::detail
+{
+    namespace
+    {
+        // Constant initialization avoids a dynamic-initialization-order dependency between translation units.
+        constinit LifecycleContext s_lifecycle;
+    } // namespace
+
+    LifecycleContext &lifecycle() noexcept
+    {
+        return s_lifecycle;
+    }
+
+    bool LifecycleContext::begin_start() noexcept
+    {
+        LifecycleState expected = LifecycleState::Stopped;
+        if (!m_state.compare_exchange_strong(expected, LifecycleState::Starting, std::memory_order_acq_rel))
+        {
+            return false;
+        }
+        // Publish the new generation and neutral loader context before mark_running() releases the admitted session.
+        m_generation.fetch_add(1, std::memory_order_acq_rel);
+        m_loader_context.store(LoaderContext::Normal, std::memory_order_release);
+        return true;
+    }
+
+    void LifecycleContext::mark_running() noexcept
+    {
+        m_state.store(LifecycleState::Running, std::memory_order_release);
+    }
+
+    void LifecycleContext::begin_stop() noexcept
+    {
+        m_state.store(LifecycleState::Stopping, std::memory_order_release);
+    }
+
+    void LifecycleContext::mark_stopped() noexcept
+    {
+        m_state.store(LifecycleState::Stopped, std::memory_order_release);
+    }
+} // namespace DetourModKit::detail

--- a/src/internal/lifecycle_context.hpp
+++ b/src/internal/lifecycle_context.hpp
@@ -1,0 +1,93 @@
+#ifndef DETOURMODKIT_INTERNAL_LIFECYCLE_CONTEXT_HPP
+#define DETOURMODKIT_INTERNAL_LIFECYCLE_CONTEXT_HPP
+
+#include <atomic>
+#include <cstdint>
+
+// Keep the lifecycle control block independent of the Win32 headers while retaining HMODULE's exact pointer type.
+struct HINSTANCE__;
+
+namespace DetourModKit::detail
+{
+    /// Represents the serialized session phase.
+    enum class LifecycleState : std::uint8_t
+    {
+        Stopped,
+        Starting,
+        Running,
+        Stopping
+    };
+
+    /**
+     * @brief Identifies the loader phase published by the controlled bootstrap path.
+     * @note This context authorizes teardown behavior; loader-lock detection may only veto blocking work.
+     */
+    enum class LoaderContext : std::uint8_t
+    {
+        Normal,
+        Attach,
+        Detach,
+        ProcessExit
+    };
+
+    /**
+     * @class LifecycleContext
+     * @brief The session lifecycle control block. All fields are lock-free atomics so any getter is race-free against a
+     *        concurrent detach-path write.
+     */
+    class LifecycleContext
+    {
+    public:
+        using Module = ::HINSTANCE__ *;
+
+        /// Returns the atomically published module identity, or null.
+        [[nodiscard]] Module module() const noexcept { return m_module.load(std::memory_order_acquire); }
+        /// Publishes the module identity.
+        void publish_module(Module module) noexcept { m_module.store(module, std::memory_order_release); }
+        /// Clears the module identity.
+        void clear_module() noexcept { m_module.store(nullptr, std::memory_order_release); }
+
+        /// Returns the current session phase.
+        [[nodiscard]] LifecycleState state() const noexcept { return m_state.load(std::memory_order_acquire); }
+        /// Returns the monotonically increasing session generation.
+        [[nodiscard]] std::uint64_t generation() const noexcept { return m_generation.load(std::memory_order_acquire); }
+
+        /**
+         * @brief Claims the single-session slot: Stopped -> Starting, bumping the generation and resetting the loader
+         *        context to Normal for the new epoch.
+         * @return true if the slot was free; false if a session is already Starting, Running, or Stopping (the caller
+         *         reports SessionAlreadyActive).
+         */
+        [[nodiscard]] bool begin_start() noexcept;
+        /// Starting -> Running once setup has succeeded.
+        void mark_running() noexcept;
+        /// Running -> Stopping at the start of teardown; a concurrent start stays rejected through the whole teardown.
+        void begin_stop() noexcept;
+        /// -> Stopped from any state (teardown complete, or a start-setup failure rollback).
+        void mark_stopped() noexcept;
+
+        [[nodiscard]] LoaderContext loader_context() const noexcept
+        {
+            return m_loader_context.load(std::memory_order_acquire);
+        }
+        void set_loader_context(LoaderContext context) noexcept
+        {
+            m_loader_context.store(context, std::memory_order_release);
+        }
+
+    private:
+        std::atomic<Module> m_module{nullptr};
+        std::atomic<LifecycleState> m_state{LifecycleState::Stopped};
+        std::atomic<std::uint64_t> m_generation{0};
+        std::atomic<LoaderContext> m_loader_context{LoaderContext::Normal};
+    };
+
+    // module_handle() is callback-safe and therefore cannot use an atomic implementation backed by a hidden lock.
+    static_assert(std::atomic<LifecycleContext::Module>::is_always_lock_free,
+                  "the module identity must be a lock-free atomic pointer.");
+
+    /// The one process-global session control block.
+    [[nodiscard]] LifecycleContext &lifecycle() noexcept;
+} // namespace DetourModKit::detail
+
+#endif // DETOURMODKIT_INTERNAL_LIFECYCLE_CONTEXT_HPP

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -16,6 +16,8 @@ namespace DetourModKit::detail
      *       function assumes the lock IS held and returns true. A spurious true only leaks a detached thread (bounded,
      *       with the thread's module reference held); a spurious false would join a thread under the loader lock and
      *       deadlock the host on unload, so uncertainty must bias toward true.
+     * @note This is a fail-closed diagnostic only. A true or indeterminate result may veto a join, but a false result
+     *       never authorizes blocking teardown; that permission comes from the explicit loader context.
      * @return true if the current thread holds the loader lock, or if ownership cannot be determined.
      */
     [[nodiscard]] inline bool is_loader_lock_held() noexcept

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -7,6 +7,7 @@
 #include "DetourModKit/memory.hpp"
 
 #include "internal/config_reload_gate.hpp"
+#include "internal/lifecycle_context.hpp"
 #include "platform.hpp"
 
 #include <windows.h>
@@ -34,15 +35,14 @@ namespace DetourModKit
         // handle rather than close it (see bootstrap_detach).
         std::atomic<HANDLE> s_shutdown_event{nullptr};
         HANDLE s_worker_thread = nullptr;
-        HMODULE s_module = nullptr;
 
         // Idempotency gate for bootstrap_detach; re-armed by a successful bootstrap so attach/detach cycles repeat.
         std::atomic<bool> s_detach_called{false};
 
-        // Single-session-per-process guard, shared by both construction paths. Set by Session::start on success,
-        // cleared by ~Session or abandon(). A mod DLL has one process lifetime, so a second start()/bootstrap() is
-        // rejected.
-        std::atomic<bool> s_session_active{false};
+        // Module identity, the serialized single-session state machine, generation, and loader context all live in the
+        // one lifecycle control block (detail::lifecycle()). The module identity is a lock-free atomic so
+        // module_handle() never races a detach-path clear; the state machine (begin_start / mark_running / begin_stop /
+        // mark_stopped) is the single-session-per-process guard, admitting a new start only from Stopped.
 
         // The Session built (under the loader lock) by bootstrap, waiting for the worker to adopt it.
         std::optional<Session> s_pending_session;
@@ -232,7 +232,7 @@ namespace DetourModKit
             // DllMain returns FALSE, so a later destruction (a retry's overwrite, or the process-exit static dtor)
             // would fault into freed pages.
             s_on_ready = nullptr;
-            s_module = nullptr;
+            detail::lifecycle().clear_module();
         }
 
         // The bootstrap worker. Adopts the Session built under the loader lock, runs on_ready OFF the loader lock, then
@@ -316,14 +316,17 @@ namespace DetourModKit
             // consumer's DllMain forward attach without threading the handle through. UNCHANGED_REFCOUNT is required:
             // this handle is for identity only (module_handle()), so it must NOT take a reference on the module. The
             // keepalive that protects the worker's code from a premature FreeLibrary is a SEPARATE counted reference
-            // acquired immediately before CreateThread and handed to lifecycle_thread; keeping that concern out of
-            // s_module lets module_handle() name the module without holding it mapped, and confines the "the module
-            // stays mapped past a bare FreeLibrary" behavior to the worker's own lifetime.
+            // acquired immediately before CreateThread and handed to lifecycle_thread; keeping that concern out of the
+            // identity lets module_handle() name the module without holding it mapped, and confines the "the module
+            // stays mapped past a bare FreeLibrary" behavior to the worker's own lifetime. Capture into a local because
+            // a Win32 out-parameter cannot target the std::atomic identity slot, then publish it with a release store.
             constexpr DWORD CAPTURE_FLAGS =
                 GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
-            if (GetModuleHandleExW(CAPTURE_FLAGS, reinterpret_cast<LPCWSTR>(&bootstrap_core), &s_module))
+            HMODULE captured_module = nullptr;
+            if (GetModuleHandleExW(CAPTURE_FLAGS, reinterpret_cast<LPCWSTR>(&bootstrap_core), &captured_module))
             {
-                DisableThreadLibraryCalls(s_module);
+                DisableThreadLibraryCalls(captured_module);
+                detail::lifecycle().publish_module(captured_module);
             }
 
             // Run the same synchronous setup as the direct path (process gate, single-instance mutex, logger). On
@@ -331,9 +334,13 @@ namespace DetourModKit
             Result<Session> session = Session::start(info);
             if (!session)
             {
-                s_module = nullptr;
+                detail::lifecycle().clear_module();
                 return std::unexpected(session.error());
             }
+
+            // This session was established through the loader/attach path; record it explicitly so the matching detach
+            // decision reads a controlled context rather than inferring the phase from a heuristic.
+            detail::lifecycle().set_loader_context(detail::LoaderContext::Attach);
 
             // Stage the Session and the init callback for the worker to adopt.
             s_pending_session.emplace(std::move(*session));
@@ -424,6 +431,8 @@ namespace DetourModKit
             return;
         }
 
+        // Enter Stopping so a start racing this teardown stays rejected until the slot is fully released.
+        detail::lifecycle().begin_stop();
         // 1. Release this session's input bindings first, in reverse insertion order (a Hold binding's release edge
         //    fires before the bindings it may depend on).
         m_scope.clear();
@@ -436,23 +445,22 @@ namespace DetourModKit
             m_instance_mutex = nullptr;
         }
         m_active = false;
-        s_session_active.store(false, std::memory_order_release);
+        detail::lifecycle().mark_stopped();
     }
 
     Result<Session> Session::start(const ModInfo &info) noexcept
     {
-        // Claim the single-session guard first; a mod DLL has one process lifetime, so a second start is a caller bug.
-        bool expected = false;
-        if (!s_session_active.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+        // Claim the single-session slot first (Stopped -> Starting, bumping the generation); a mod DLL has one process
+        // lifetime, so a second start while one is Starting, Running, or Stopping is a caller bug.
+        if (!detail::lifecycle().begin_start())
         {
             return std::unexpected(Error{ErrorCode::SessionAlreadyActive, "Session::start"});
         }
 
         if (!is_target_process(info.game_process_name))
         {
-            // A clean "not for this process" outcome, not a fault: release the guard and let the caller decline to
-            // load.
-            s_session_active.store(false, std::memory_order_release);
+            // A clean "not for this process" outcome, not a fault: release the slot and let the caller decline to load.
+            detail::lifecycle().mark_stopped();
             return std::unexpected(Error{ErrorCode::ProcessMismatch, "Session::start"});
         }
 
@@ -461,10 +469,10 @@ namespace DetourModKit
         switch (acquire_instance_mutex(info.instance_mutex_prefix, mutex, err))
         {
         case MutexAcquire::AlreadyHeld:
-            s_session_active.store(false, std::memory_order_release);
+            detail::lifecycle().mark_stopped();
             return std::unexpected(Error{ErrorCode::InstanceAlreadyRunning, "Session::start"});
         case MutexAcquire::SystemError:
-            s_session_active.store(false, std::memory_order_release);
+            detail::lifecycle().mark_stopped();
             return std::unexpected(Error{ErrorCode::SystemCallFailed, "Session::start", err});
         case MutexAcquire::NoGuard:
         case MutexAcquire::Acquired:
@@ -485,11 +493,13 @@ namespace DetourModKit
             {
                 CloseHandle(mutex);
             }
-            s_session_active.store(false, std::memory_order_release);
+            detail::lifecycle().mark_stopped();
             return std::unexpected(Error{ErrorCode::OutOfMemory, "Session::start"});
         }
 
-        // The Session now owns the guard (cleared by ~Session) and the mutex handle (closed by ~Session).
+        // Setup succeeded: the session is Running. It now owns the single-session slot (released by ~Session) and the
+        // mutex handle (closed by ~Session).
+        detail::lifecycle().mark_running();
         return Session(mutex);
     }
 
@@ -528,7 +538,7 @@ namespace DetourModKit
         m_scope.abandon();
         m_active = false;
         m_instance_mutex = nullptr;
-        s_session_active.store(false, std::memory_order_release);
+        detail::lifecycle().mark_stopped();
     }
 
     // Bootstrap free functions
@@ -555,7 +565,14 @@ namespace DetourModKit
             return;
         }
 
-        if (reserved != nullptr)
+        // Publish the explicit loader context from DllMain's own lpReserved, then branch on the controlled context
+        // rather than re-deriving it. lpReserved != nullptr is process termination (ProcessExit); nullptr is an
+        // explicit FreeLibrary (Detach). This is the authoritative signal for whether teardown may block.
+        const detail::LoaderContext context =
+            (reserved != nullptr) ? detail::LoaderContext::ProcessExit : detail::LoaderContext::Detach;
+        detail::lifecycle().set_loader_context(context);
+
+        if (context == detail::LoaderContext::ProcessExit)
         {
             // PROCESS TERMINATION (abandon). The OS has already killed the worker; its adopted Session lives in that
             // dead frame and is leaked untouched -- running teardown against a dying process is a use-after-free. If
@@ -571,23 +588,26 @@ namespace DetourModKit
                 CloseHandle(s_worker_thread);
                 s_worker_thread = nullptr;
             }
-            // Process termination: with reserved != nullptr the OS has already terminated every other thread before
-            // this DllMain notification, so no request_shutdown() can be in flight and closing the event is safe.
+            // Process termination: the OS has already terminated every other thread before this DllMain notification,
+            // so no request_shutdown() can be in flight and closing the event is safe.
             if (HANDLE event = s_shutdown_event.exchange(nullptr, std::memory_order_acq_rel))
             {
                 CloseHandle(event);
             }
-            s_module = nullptr;
+            detail::lifecycle().clear_module();
             diagnostics::record_intentional_leak(diagnostics::LeakSubsystem::Bootstrap);
             return;
         }
 
-        // EXPLICIT FreeLibrary. Signal the worker so its ~Session teardown runs OFF the loader lock (leaves JOIN).
+        // EXPLICIT FreeLibrary (Detach). Signal the worker so its ~Session teardown runs OFF the loader lock (leaves
+        // JOIN).
         if (HANDLE event = s_shutdown_event.load(std::memory_order_acquire))
         {
             SetEvent(event);
         }
 
+        // A held or indeterminate diagnostic forces the non-blocking leak path. A false result cannot authorize this
+        // branch on its own; the explicit Detach context supplies that authorization.
         if (detail::is_loader_lock_held())
         {
             // Under the loader lock: never wait or join here -- blocking would deadlock any peer DllMain. Crucially, do
@@ -605,7 +625,7 @@ namespace DetourModKit
             // its reference first). Both cases are loader-lock contexts, so this path only records the intentional
             // handle leak.
             diagnostics::record_intentional_leak(diagnostics::LeakSubsystem::Bootstrap);
-            s_module = nullptr;
+            detail::lifecycle().clear_module();
             return;
         }
 
@@ -629,7 +649,7 @@ namespace DetourModKit
         // The worker has joined, so the init callback is no longer in use. Off the loader lock its captured state's
         // destructors are safe to run, so drop it here rather than leaking it until the next bootstrap overwrites it.
         s_on_ready = nullptr;
-        s_module = nullptr;
+        detail::lifecycle().clear_module();
     }
 
     void request_shutdown() noexcept
@@ -647,7 +667,9 @@ namespace DetourModKit
 
     ModuleHandle module_handle() noexcept
     {
-        return s_module;
+        // Lock-free atomic acquire load: race-free against a concurrent detach-path clear, so a reader observes only
+        // the current published identity or null, never a torn value.
+        return detail::lifecycle().module();
     }
 
     // Test-only accessor for the bootstrap shutdown event handle (the atomic load). A test captures it before an

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -20,6 +20,7 @@
 #include "DetourModKit.hpp"
 
 #include "internal/input_intercept.hpp"
+#include "internal/lifecycle_context.hpp"
 
 using namespace DetourModKit;
 using namespace DetourModKit::hook;
@@ -1234,4 +1235,134 @@ TEST(SessionShutdownEventRace, RequestShutdownRacingOffLoaderLockDetachLeaksNotC
     // The atomic was retired to null, so request_shutdown() is now a safe no-op, and the module handle was cleared.
     EXPECT_EQ(bootstrap_shutdown_event_for_test(), nullptr) << "detach must retire the event pointer to null";
     EXPECT_EQ(module_handle(), nullptr) << "off-loader-lock detach must clear the module handle";
+}
+
+// A stress run cannot prove race freedom, so the runtime checks are paired with a compile-time lock-free requirement.
+static_assert(std::atomic<ModuleHandle>::is_always_lock_free, "module identity must be a lock-free atomic pointer.");
+
+class SessionLifecycleContext : public SessionBootstrapTest
+{
+};
+
+TEST_F(SessionLifecycleContext, ModuleIdentityIsLockFreeAtomic)
+{
+    // Runtime companion to the static gate above, following the AGENTS.md is_lock_free() probe convention.
+    std::atomic<ModuleHandle> probe{nullptr};
+    EXPECT_TRUE(probe.is_lock_free());
+}
+
+TEST_F(SessionLifecycleContext, GenerationAdvancesOnlyOnAdmittedStart)
+{
+    const std::uint64_t before = DetourModKit::detail::lifecycle().generation();
+
+    {
+        Result<Session> first = Session::start(ModInfo{.name = "GEN_A", .log_file = "sess_ctx_gen.log"});
+        ASSERT_TRUE(first.has_value()) << first.error().message();
+        EXPECT_EQ(DetourModKit::detail::lifecycle().generation(), before + 1) << "an admitted start opens a new epoch";
+        EXPECT_EQ(DetourModKit::detail::lifecycle().state(), DetourModKit::detail::LifecycleState::Running);
+
+        // A second start while one is Running is rejected and must not advance the generation.
+        Result<Session> second = Session::start(ModInfo{.name = "GEN_B"});
+        ASSERT_FALSE(second.has_value());
+        EXPECT_EQ(second.error().code, ErrorCode::SessionAlreadyActive);
+        EXPECT_EQ(DetourModKit::detail::lifecycle().generation(), before + 1) << "a rejected start opens no epoch";
+    }
+
+    // ~Session ran the ordered teardown, so the slot is Stopped again and a fresh start opens the next epoch.
+    EXPECT_EQ(DetourModKit::detail::lifecycle().state(), DetourModKit::detail::LifecycleState::Stopped);
+    Result<Session> third = Session::start(ModInfo{.name = "GEN_C", .log_file = "sess_ctx_gen.log"});
+    ASSERT_TRUE(third.has_value()) << third.error().message();
+    EXPECT_EQ(DetourModKit::detail::lifecycle().generation(), before + 2);
+}
+
+TEST_F(SessionLifecycleContext, SynchronousStartLeavesLoaderContextNormal)
+{
+    Result<Session> session = Session::start(ModInfo{.name = "CTX_SYNC", .log_file = "sess_ctx_sync.log"});
+    ASSERT_TRUE(session.has_value()) << session.error().message();
+    // A synchronously-hosted session was never inside a loader callback, whatever a prior bootstrap cycle left behind.
+    EXPECT_EQ(DetourModKit::detail::lifecycle().loader_context(), DetourModKit::detail::LoaderContext::Normal);
+}
+
+TEST_F(SessionLifecycleContext, BootstrapRecordsAttachThenDetachContext)
+{
+    CallbackSignals sig;
+    Result<void> started = bootstrap(ModInfo{.name = "CTX_BOOT", .log_file = "sess_ctx_boot.log"},
+                                     [&sig](Session &) -> Result<void>
+                                     {
+                                         sig.signal_ready();
+                                         return {};
+                                     });
+    ASSERT_TRUE(started.has_value()) << started.error().message();
+    m_bootstrapped = true;
+    ASSERT_TRUE(sig.wait_for_ready(kTestTimeout));
+
+    // The bootstrap/attach path published the explicit Attach context.
+    EXPECT_EQ(DetourModKit::detail::lifecycle().loader_context(), DetourModKit::detail::LoaderContext::Attach);
+
+    // An explicit off-loader-lock FreeLibrary publishes Detach and drives the branch. ProcessExit requires subprocess
+    // isolation because Windows terminates the peer worker before issuing that notification.
+    request_shutdown();
+    bootstrap_detach(nullptr);
+    m_bootstrapped = false;
+    EXPECT_EQ(DetourModKit::detail::lifecycle().loader_context(), DetourModKit::detail::LoaderContext::Detach);
+    EXPECT_EQ(module_handle(), nullptr);
+}
+
+TEST_F(SessionLifecycleContext, ConcurrentModuleHandleReadsDuringDetachSeeCurrentOrNull)
+{
+    // The one identity module_handle() may ever publish here: the test binary that links DetourModKit statically.
+    HMODULE expected = nullptr;
+    ASSERT_TRUE(
+        GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           reinterpret_cast<LPCWSTR>(&current_exe_basename), &expected));
+    ASSERT_NE(expected, nullptr);
+
+    std::atomic<bool> saw_bad{false};
+    std::vector<std::jthread> readers;
+    for (int i = 0; i < 4; ++i)
+    {
+        readers.emplace_back(
+            [&saw_bad, expected](std::stop_token stop_token)
+            {
+                while (!stop_token.stop_requested())
+                {
+                    const ModuleHandle handle = module_handle();
+                    if (handle != nullptr && handle != expected)
+                    {
+                        saw_bad.store(true, std::memory_order_release);
+                    }
+                }
+            });
+    }
+
+    // Drive repeated bootstrap generations while the readers hammer the getter across each off-loader-lock detach.
+    for (int cycle = 0; cycle < 8; ++cycle)
+    {
+        CallbackSignals sig;
+        Result<void> started = bootstrap(ModInfo{.name = "CTX_RACE", .log_file = "sess_ctx_race.log"},
+                                         [&sig](Session &) -> Result<void>
+                                         {
+                                             sig.signal_ready();
+                                             return {};
+                                         });
+        ASSERT_TRUE(started.has_value()) << "cycle " << cycle << ": " << started.error().message();
+        m_bootstrapped = true;
+        ASSERT_TRUE(sig.wait_for_ready(kTestTimeout)) << "cycle " << cycle;
+        EXPECT_EQ(module_handle(), expected) << "cycle " << cycle;
+        request_shutdown();
+        bootstrap_detach(nullptr);
+        m_bootstrapped = false;
+        EXPECT_EQ(module_handle(), nullptr) << "cycle " << cycle;
+    }
+
+    for (auto &reader : readers)
+    {
+        reader.request_stop();
+    }
+    readers.clear();
+
+    EXPECT_FALSE(saw_bad.load()) << "a module_handle() reader observed a value that was neither the current identity "
+                                    "nor null";
+    EXPECT_EQ(module_handle(), nullptr);
+    EXPECT_EQ(DetourModKit::detail::lifecycle().state(), DetourModKit::detail::LifecycleState::Stopped);
 }


### PR DESCRIPTION
## Summary

Foundation for a loader-safe session lifecycle: one process-global control block that owns the module identity, the serialized session state, and the explicit loader phase.

## Changes

- The non-owning module identity is now a lock-free atomic, so `module_handle()` readers on any thread observe only the current identity or null and never race a detach-path write.
- The single-session boolean guard becomes a `Stopped/Starting/Running/Stopping` state machine with a monotonic generation, admitting a new start only from `Stopped`.
- An explicit loader context (`Normal/Attach/Detach/ProcessExit`) is recorded and drives the detach decision, and `is_loader_lock_held()` is demoted to a fail-closed diagnostic that may veto a join but never authorize one.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session lifecycle tracking to prevent conflicting starts and ensure clean state transitions during startup and shutdown.
  - Improved module-handle visibility during concurrent detach operations, preventing readers from observing stale identities.
  - Added safer handling for loader-context-specific teardown, including process exit and explicit unload scenarios.

- **Tests**
  - Added coverage for lifecycle generations, loader contexts, concurrent module-handle access, and final stopped-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->