### PR TITLE
fix(hook): fault-contain inline-hook decode and trust backend relocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,9 +712,9 @@ dmk::Result<void> InitializeMyMod(dmk::Session &session)
         .require_executable_result = true,
     };
 
-    // inline_at performs the single audited function-to-void* cast for you; the call site writes no reinterpret_cast.
-    // Options::prologue defaults to Prologue::Fail (v4 safe-by-default: an E8/CC/CD prologue is refused with
-    // ErrorCode::TargetPrologueUnsafe). Pass Options{.prologue = dmk::hook::Prologue::Relocate} for the old install-anyway.
+    // inline_at performs the function-to-void* cast internally; the call site writes no reinterpret_cast.
+    // Options::prologue defaults to Prologue::Fail: a CC/CD breakpoint prologue is refused with
+    // ErrorCode::TargetPrologueUnsafe. Pass Options{.prologue = dmk::hook::Prologue::Relocate} to install anyway.
     auto result = dmk::hook::inline_at(
         dmk::hook::InlineRequest{
             .name = "GameFunction_PrintMessage_Hook",

--- a/cmake/source_manifest.txt
+++ b/cmake/source_manifest.txt
@@ -43,6 +43,7 @@ src/worker.cpp
 
 src/internal/async_logger.cpp
 src/internal/config_watcher.cpp
+src/internal/hook_fault_boundary.cpp
 src/internal/input_intercept.cpp
 src/internal/input_poller.cpp
 src/internal/lifecycle_context.cpp

--- a/docs/guides/hooking/hook-type-coverage.md
+++ b/docs/guides/hooking/hook-type-coverage.md
@@ -24,6 +24,8 @@ All four surfaces are declared in [`hook.hpp`](../../../include/DetourModKit/hoo
 
 Together these cover the two dominant interception needs in game modding: redirecting a concrete internal function (inline / mid) and redirecting virtual dispatch (VMT).
 
+`inline_at` and `mid_at` require the target to be readable, committed, executable memory across the whole span the backend decodes, and refuse it with a typed `Error` otherwise -- under every `Options::prologue` policy, because relocating a prologue that is not code is never valid. A target that begins with a relative call is relocated by the backend and is not refused; only a breakpoint prologue is subject to `Options::prologue`. A target the backend cannot relocate fails with the backend's own typed error rather than a guess made from its first byte.
+
 ## 2. The install model and its one honest limitation
 
 The inline and mid paths run on the SafetyHook backend, which guards every create and delete by removing execute access from the pages holding the target and trampoline bytes and letting a process-global vectored exception handler (registered on first use) fix up the instruction pointer of any thread that faults inside the region being rewritten -- no thread is suspended. This trap-plus-IP-fixup model is a correct one for installing and removing inline patches in a live process, achieving the same safety goal as the suspend-and-fixup discipline of Microsoft Detours and MinHook without stopping the world.

--- a/docs/guides/hooking/hook-type-coverage.md
+++ b/docs/guides/hooking/hook-type-coverage.md
@@ -24,7 +24,9 @@ All four surfaces are declared in [`hook.hpp`](../../../include/DetourModKit/hoo
 
 Together these cover the two dominant interception needs in game modding: redirecting a concrete internal function (inline / mid) and redirecting virtual dispatch (VMT).
 
-`inline_at` and `mid_at` require the target to be readable, committed, executable memory across the whole span the backend decodes, and refuse it with a typed `Error` otherwise -- under every `Options::prologue` policy, because relocating a prologue that is not code is never valid. A target that begins with a relative call is relocated by the backend and is not refused; only a breakpoint prologue is subject to `Options::prologue`. A target the backend cannot relocate fails with the backend's own typed error rather than a guess made from its first byte.
+`inline_at` and `mid_at` require the target to be readable, committed, executable memory across the whole span the backend decodes, and refuse it with a typed `Error` otherwise -- under every `Options::prologue` policy, because relocating a prologue that is not code is never valid. A target that begins with a relative call is not refused by the pre-flight; whether it can be relocated is left to the backend rather than guessed from its first byte, and only a breakpoint prologue is subject to `Options::prologue`. A target the backend cannot relocate fails with `ErrorCode::BackendFailed`: the backend distinguishes causes such as an undecodable instruction, an out-of-range relative operand, or a trampoline allocation failure, but callers receive the single generic code and the specific reason is written to the log rather than returned.
+
+The pre-flight also refuses a target whose unwind metadata declares a function too short for the backend's larger patch form. Which form the backend uses is decided after the pre-flight, so a function that only the smaller form could hook is refused rather than risk the larger one overwriting the code that follows it.
 
 ## 2. The install model and its one honest limitation
 

--- a/docs/guides/minimal-core.md
+++ b/docs/guides/minimal-core.md
@@ -126,7 +126,7 @@ if (installed)
 }
 ```
 
-`inline_at` performs the single audited function-to-`void*` cast for you, so the call site writes no `reinterpret_cast`. By default an unsafe prologue (an `E8` / `CC` / `CD` first byte) is refused with `ErrorCode::TargetPrologueUnsafe`; pass `Options{.prologue = dmk::hook::Prologue::Relocate}` to install anyway. The mid-function, VMT, and per-method hook shapes are covered in the [Hook Type Coverage](hooking/hook-type-coverage.md) guide.
+`inline_at` performs the function-to-`void*` cast internally, so the call site writes no `reinterpret_cast`. By default a breakpoint prologue (a `CC` / `CD` first byte) is refused with `ErrorCode::TargetPrologueUnsafe`; pass `Options{.prologue = dmk::hook::Prologue::Relocate}` to install anyway. A target whose bytes are not readable executable committed memory is refused under both policies, and a relative call prologue is relocated by the backend rather than refused. The mid-function, VMT, and per-method hook shapes are covered in the [Hook Type Coverage](hooking/hook-type-coverage.md) guide.
 
 ## Where to go next
 

--- a/docs/guides/minimal-core.md
+++ b/docs/guides/minimal-core.md
@@ -126,7 +126,7 @@ if (installed)
 }
 ```
 
-`inline_at` performs the function-to-`void*` cast internally, so the call site writes no `reinterpret_cast`. By default a breakpoint prologue (a `CC` / `CD` first byte) is refused with `ErrorCode::TargetPrologueUnsafe`; pass `Options{.prologue = dmk::hook::Prologue::Relocate}` to install anyway. A target whose bytes are not readable executable committed memory is refused under both policies, and a relative call prologue is relocated by the backend rather than refused. The mid-function, VMT, and per-method hook shapes are covered in the [Hook Type Coverage](hooking/hook-type-coverage.md) guide.
+`inline_at` performs the function-to-`void*` cast internally, so the call site writes no `reinterpret_cast`. By default a breakpoint prologue (a `CC` / `CD` first byte) is refused with `ErrorCode::TargetPrologueUnsafe`; pass `Options{.prologue = dmk::hook::Prologue::Relocate}` to install anyway. A target whose bytes are not readable executable committed memory is refused under both policies. A relative call prologue is no longer rejected by the pre-flight on sight; whether it can actually be relocated is left to the backend, so the install may still fail with `ErrorCode::BackendFailed` (the backend's specific reason is logged rather than returned). The mid-function, VMT, and per-method hook shapes are covered in the [Hook Type Coverage](hooking/hook-type-coverage.md) guide.
 
 ## Where to go next
 

--- a/include/DetourModKit/hook.hpp
+++ b/include/DetourModKit/hook.hpp
@@ -182,16 +182,14 @@ namespace DetourModKit
 
         /**
          * @enum Prologue
-         * @brief Escalation policy for the inline/mid hook prologue pre-flight.
-         * @details The pre-flight fault-guard-reads the target's first byte. A leading 0xE8 (call rel32) means the
-         *          5-byte E9 patch would steal a relative call whose displacement was computed from the original
-         *          site, so the relocated trampoline copy can dispatch the call to the wrong absolute target; a
-         *          leading 0xCC/0xCD (int3 / int n breakpoint) means the slot is already a breakpoint stub, a patched
-         *          byte, or alignment padding, not a real function body. @ref Relocate logs and installs anyway;
-         *          @ref Fail refuses the create with @ref ErrorCode::TargetPrologueUnsafe.
-         * @note The library DEFAULT is Fail (safe-by-default): a non-relocatable prologue fails the install rather
-         *       than installing a hook that can dispatch to the wrong target. Opt into install-anyway with
-         *       `Options{.prologue = Prologue::Relocate}`.
+         * @brief Escalation policy for a target whose prologue is a breakpoint rather than a function body.
+         * @details A leading 0xCC/0xCD (int3 / int n) means the slot is a breakpoint stub, a patched byte, or alignment
+         *          padding. @ref Fail refuses the create with @ref ErrorCode::TargetPrologueUnsafe; @ref Relocate logs
+         *          and installs anyway.
+         * @note This policy governs only the prologue's shape. Whether the prologue can be relocated at all is decided
+         *       by the backend's own decode, which reports its own typed failure; a relative call is relocated
+         *       correctly and is not refused. A target whose bytes are not readable executable committed memory is
+         *       refused under BOTH policies: @ref Relocate cannot authorize decoding non-code.
          */
         enum class Prologue : std::uint8_t
         {

--- a/include/DetourModKit/hook.hpp
+++ b/include/DetourModKit/hook.hpp
@@ -186,10 +186,12 @@ namespace DetourModKit
          * @details A leading 0xCC/0xCD (int3 / int n) means the slot is a breakpoint stub, a patched byte, or alignment
          *          padding. @ref Fail refuses the create with @ref ErrorCode::TargetPrologueUnsafe; @ref Relocate logs
          *          and installs anyway.
-         * @note This policy governs only the prologue's shape. Whether the prologue can be relocated at all is decided
-         *       by the backend's own decode, which reports its own typed failure; a relative call is relocated
-         *       correctly and is not refused. A target whose bytes are not readable executable committed memory is
-         *       refused under BOTH policies: @ref Relocate cannot authorize decoding non-code.
+         * @note This policy governs only the prologue's shape. Whether the prologue can be relocated at all is left to
+         *       the backend's own decode rather than guessed from its first byte, so a relative call is not refused
+         *       here; if the backend cannot relocate it, the create fails with @ref ErrorCode::BackendFailed and the
+         *       backend's specific reason is logged rather than returned. A target whose bytes are not readable
+         *       executable committed memory is refused under BOTH policies: @ref Relocate cannot authorize decoding
+         *       non-code.
          */
         enum class Prologue : std::uint8_t
         {

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -686,6 +686,13 @@ namespace DetourModKit
          * @brief Whether the target's first bytes still match the prologue the backend saved before patching.
          * @details @ref Original means no patch is installed, @ref Patched means one is, and @ref Indeterminate means
          *          neither can be asserted.
+         * @note Only a positive witness publishes a state. An @ref Indeterminate result fails the operation and leaves
+         *       the hook in the state that assumes the WORSE outcome: a failed enable reports Disabled (never claim an
+         *       armed hook), and a failed disable reports Active (never claim a disarmed target). Those are deliberate
+         *       conservative answers rather than a report of what the bytes are, so neither is a lie a caller can act
+         *       on unsafely: both paths also return a typed failure, and a retry re-witnesses. A distinct unknown state
+         *       would describe reality more precisely, but it belongs to the publication state machine rather than
+         *       here, and it must not weaken the rule that a terminal state requires a positive witness.
          */
         enum class PatchWitness : std::uint8_t
         {
@@ -1248,7 +1255,12 @@ namespace DetourModKit
                         return std::unexpected(Error{ErrorCode::BackendFailed, "hook::inline_at", target});
                     }
                     auto backend_hook = std::move(created.value());
-                    const HookState state = backend_hook.enabled() ? HookState::Active : HookState::Disabled;
+                    // The backend creates enabled, and its enable reports success without confirming the patch landed
+                    // (the same reason Hook::enable witnesses), so an unverified create must not publish Active.
+                    const HookState state =
+                        (backend_hook.enabled() && witness_patch(backend_hook) == PatchWitness::Patched)
+                            ? HookState::Active
+                            : HookState::Disabled;
                     // Store the reserved ledger id in the Impl (its teardown releases it). make_unique, the gate
                     // allocation, and the info log are the only steps that can still throw under OOM; the catch below
                     // rolls the reservation back, and `impl` (if built) unwinds through ~Impl to restore the prologue.
@@ -1340,7 +1352,10 @@ namespace DetourModKit
                     return std::unexpected(Error{ErrorCode::BackendFailed, "hook::mid_at", target});
                 }
                 auto backend_hook = std::move(created.value());
-                const HookState state = backend_hook.enabled() ? HookState::Active : HookState::Disabled;
+                // Witnessed for the same reason as inline_at_raw: a backend success is not proof the patch landed.
+                const HookState state = (backend_hook.enabled() && witness_patch(backend_hook) == PatchWitness::Patched)
+                                            ? HookState::Active
+                                            : HookState::Disabled;
                 // Store the reserved ledger id in the Impl (see inline_at_raw). make_unique, the gate allocation, and
                 // the info log are the only steps that can throw under OOM; the catch below rolls the reservation back
                 // and `impl` (if built) unwinds to restore the prologue.

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -11,6 +11,7 @@
 #include "DetourModKit/hook.hpp"
 
 #include "internal/hook_backend.hpp"
+#include "internal/hook_fault_boundary.hpp"
 #include "internal/hook_ledger.hpp"
 #include "internal/memory_guarded.hpp"
 
@@ -23,6 +24,7 @@
 
 #include <windows.h>
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -190,22 +192,17 @@ namespace DetourModKit
             return result;
         }
 
-        /// The flagged prologue shapes the inline/mid pre-flight refuses under Prologue::Fail.
+        /// The inline/mid pre-flight's classification of the target's first byte.
         enum class PrologueRisk : std::uint8_t
         {
             None,
-            LeadingCall, // 0xE8 call rel32
-            Breakpoint   // 0xCC int3 / 0xCD int n
+            Breakpoint, // 0xCC int3 / 0xCD int n; refused under Prologue::Fail
+            Unreadable  // the byte could not be read; refused under every policy
         };
 
-        // Classifies the first opcode byte of an inline/mid hook target. A leading E8 (call rel32) means the prologue
-        // is a relative call whose displacement is computed from the original site; the backend relocates the stolen
-        // prologue into a trampoline at a different address, so the relocated call can dispatch to the wrong absolute
-        // target. A leading 0xCC (int3) or 0xCD (int n) means the entry is already a breakpoint -- a foreign hook's
-        // stub, a patched slot, or alignment padding -- not a real function body. The E9 / FF 25 redirect shapes are
-        // handled separately by detect_existing_inline_hook, and EB rel8 is ordinary short-jump code; this classifier
-        // intentionally flags only the call and breakpoint shapes. The read is fault-guarded so an unmapped or guarded
-        // page yields None rather than faulting the host (the backend create validates separately).
+        // A leading breakpoint is not a function body. A leading rel32 call is left to the backend, which relocates its
+        // destination or returns a typed failure. The target can change after the window validation, so an unreadable
+        // first byte remains a distinct fail-closed result.
         PrologueRisk classify_prologue_risk(std::uintptr_t target_address) noexcept
         {
             if (target_address == 0)
@@ -215,12 +212,10 @@ namespace DetourModKit
             std::uint8_t first_byte = 0;
             if (!detail::guarded_read_bytes(target_address, &first_byte, sizeof(first_byte)))
             {
-                return PrologueRisk::None;
+                return PrologueRisk::Unreadable;
             }
             switch (first_byte)
             {
-            case 0xE8:
-                return PrologueRisk::LeadingCall;
             case 0xCC:
             case 0xCD:
                 return PrologueRisk::Breakpoint;
@@ -234,10 +229,10 @@ namespace DetourModKit
         {
             switch (risk)
             {
-            case PrologueRisk::LeadingCall:
-                return "a call (E8)";
             case PrologueRisk::Breakpoint:
                 return "a breakpoint (0xCC/0xCD)";
+            case PrologueRisk::Unreadable:
+                return "an unreadable byte";
             case PrologueRisk::None:
                 return "an unremarkable byte";
             }
@@ -604,6 +599,22 @@ namespace DetourModKit
                 return std::unexpected(Error{ErrorCode::InvalidTargetAddress, where});
             }
 
+            // Backend capability floor, checked before anything is reserved so a refusal needs no rollback. The backend
+            // decodes forward from the target with no readability or protection check of its own, so a target it cannot
+            // safely decode must never reach it. This gate is deliberately not subject to Options::prologue: relocating
+            // a prologue that is not readable executable memory is not a policy choice, and Prologue::Relocate must not
+            // be able to authorize it.
+            const detail::TargetWindowResult window = detail::validate_backend_steal_window(address);
+            if (window.verdict != detail::TargetWindowVerdict::Ok)
+            {
+                (void)log().try_log(LogLevel::Warning, "hook: '{}' refused target {}: {}.", name,
+                                    format::format_address(address), detail::target_window_description(window.verdict));
+                return std::unexpected(Error{window.verdict == detail::TargetWindowVerdict::Unreadable
+                                                 ? ErrorCode::ReadFaulted
+                                                 : ErrorCode::TargetPrologueUnsafe,
+                                             where, window.detail});
+            }
+
             // Atomic check-and-reserve. try_reserve_hook folds the exact same-kit duplicate check and the id record
             // into one locked step, so a concurrent same-target install cannot slip between them. A reservation on an
             // already-tracked target reports preexisting == true (this kit layered on its own prior hook); the
@@ -651,7 +662,12 @@ namespace DetourModKit
             // Prologue pre-flight, independent of the layering checks: a target can be unhooked yet still begin with a
             // call thunk or a patched int3. On a Fail-policy refusal, roll the reservation back before failing.
             const PrologueRisk risk = classify_prologue_risk(address);
-            if (risk != PrologueRisk::None)
+            if (risk == PrologueRisk::Unreadable)
+            {
+                (void)detail::HookLedger::instance().release_hook(address, reservation.id);
+                return std::unexpected(Error{ErrorCode::ReadFaulted, where, address});
+            }
+            if (risk == PrologueRisk::Breakpoint)
             {
                 if (options.prologue == hook::Prologue::Fail)
                 {
@@ -664,6 +680,67 @@ namespace DetourModKit
                     format::format_address(address), prologue_risk_description(risk));
             }
             return PreflightResult{address, reservation.id};
+        }
+
+        /**
+         * @brief Whether the target's first bytes still match the prologue the backend saved before patching.
+         * @details @ref Original means no patch is installed, @ref Patched means one is, and @ref Indeterminate means
+         *          neither can be asserted.
+         */
+        enum class PatchWitness : std::uint8_t
+        {
+            Original,
+            Patched,
+            Indeterminate
+        };
+
+        /**
+         * @brief Reads @p backend's target and reports whether its prologue is still the saved original.
+         * @details The backend reports success from enable()/disable() without confirming the target bytes changed, and
+         *          its protection transaction can silently decline to run. Comparing against the prologue it saved at
+         *          create time is the only way to learn whether the patch it claimed to write is actually there.
+         */
+        template <class Backend> [[nodiscard]] PatchWitness witness_patch(const Backend &backend) noexcept
+        {
+            const auto &original = backend.original_bytes();
+            std::array<std::uint8_t, detail::BACKEND_MAX_STEAL_WINDOW> current{};
+            if (original.empty() || original.size() > current.size() || backend.target() == nullptr)
+            {
+                return PatchWitness::Indeterminate;
+            }
+            const std::size_t count = original.size();
+            if (!detail::guarded_read_bytes(reinterpret_cast<std::uintptr_t>(backend.target()), current.data(), count))
+            {
+                return PatchWitness::Indeterminate;
+            }
+            return std::equal(original.begin(), original.begin() + static_cast<std::ptrdiff_t>(count), current.begin())
+                       ? PatchWitness::Original
+                       : PatchWitness::Patched;
+        }
+
+        /**
+         * @brief Re-checks the backend steal window immediately before patching, releasing @p ledger_id if it fails.
+         * @return The Error that should fail the install, or nullopt to proceed.
+         * @details Re-runs @ref detail::validate_backend_steal_window, which @ref preflight_target already ran. The
+         *          interval between them is not empty: acquiring the self-reference takes the loader lock, which is
+         *          exactly when another thread can complete an unload. Re-checking here attributes such a target to a
+         *          typed failure instead of leaving the backend to fault on it.
+         * @warning This narrows the window; it does not close it. The pages can be withdrawn after this returns and
+         *          during the backend's own decode, and DMK cannot guard the backend call itself (see
+         *          hook_fault_boundary.hpp). Treat this as error attribution, not as a safety property.
+         */
+        std::optional<Error> revalidate_before_patch(std::uintptr_t target, std::uint64_t ledger_id,
+                                                     const char *where) noexcept
+        {
+            const detail::TargetWindowResult window = detail::validate_backend_steal_window(target);
+            if (window.verdict == detail::TargetWindowVerdict::Ok)
+            {
+                return std::nullopt;
+            }
+            (void)DetourModKit::detail::HookLedger::instance().release_hook(target, ledger_id);
+            return Error{window.verdict == detail::TargetWindowVerdict::Unreadable ? ErrorCode::ReadFaulted
+                                                                                   : ErrorCode::TargetPrologueUnsafe,
+                         where, window.detail};
         }
     } // namespace
 
@@ -1011,7 +1088,13 @@ namespace DetourModKit
                 }
                 return std::unexpected(Error{ErrorCode::InvalidHookState, "hook::enable"});
             }
-            if (std::visit([](auto &backend) { return backend.enable().has_value(); }, m_impl->backend))
+            // A backend success is not proof the target was patched: its protection transaction can decline to run and
+            // still report success, leaving the prologue untouched while the hook claims to be armed. Require the bytes
+            // to have actually changed before publishing Active, so a silent no-op fails typed instead of leaving a
+            // caller believing an unarmed hook is live.
+            if (std::visit([](auto &backend) { return backend.enable().has_value(); }, m_impl->backend) &&
+                std::visit([](auto &backend) { return witness_patch(backend); }, m_impl->backend) ==
+                    PatchWitness::Patched)
             {
                 m_impl->status.store(HookState::Active, std::memory_order_release);
                 // Publish the callable trampoline under the gate mutex so a guarded call() dispatches to the freshly
@@ -1065,7 +1148,12 @@ namespace DetourModKit
                 }
                 return std::unexpected(Error{ErrorCode::InvalidHookState, "hook::disable"});
             }
-            if (std::visit([](auto &backend) { return backend.disable().has_value(); }, m_impl->backend))
+            // The mirror of enable()'s witness: require the saved prologue to be back before publishing Disabled. The
+            // backend's disable() reports success unconditionally, so without this a restore that never landed would
+            // leave a live patch behind a hook reporting itself disarmed.
+            if (std::visit([](auto &backend) { return backend.disable().has_value(); }, m_impl->backend) &&
+                std::visit([](auto &backend) { return witness_patch(backend); }, m_impl->backend) ==
+                    PatchWitness::Original)
             {
                 m_impl->status.store(HookState::Disabled, std::memory_order_release);
                 // Clear the callable under the gate mutex so a call() that arrives after this stops dispatching
@@ -1142,8 +1230,14 @@ namespace DetourModKit
                     (void)DetourModKit::detail::HookLedger::instance().release_hook(target, ledger_id);
                     return std::unexpected(Error{ErrorCode::SystemCallFailed, "hook::inline_at", acquire_error});
                 }
+                if (const std::optional<Error> stale = revalidate_before_patch(target, ledger_id, "hook::inline_at"))
+                {
+                    return std::unexpected(*stale);
+                }
                 try
                 {
+                    // Deliberately not wrapped in a fault boundary: the backend holds locks across its patch and DMK's
+                    // guards recover by abandoning the frame without unwinding. See hook_fault_boundary.hpp.
                     auto created = safetyhook::InlineHook::create(allocator, reinterpret_cast<void *>(target), detour,
                                                                   safetyhook::InlineHook::Default);
                     if (!created)
@@ -1228,8 +1322,14 @@ namespace DetourModKit
                 (void)DetourModKit::detail::HookLedger::instance().release_hook(target, ledger_id);
                 return std::unexpected(Error{ErrorCode::SystemCallFailed, "hook::mid_at", acquire_error});
             }
+            if (const std::optional<Error> stale = revalidate_before_patch(target, ledger_id, "hook::mid_at"))
+            {
+                return std::unexpected(*stale);
+            }
             try
             {
+                // Deliberately not wrapped in a fault boundary; MidHook::create patches through InlineHook. See the
+                // note in inline_at_raw and hook_fault_boundary.hpp.
                 auto created = safetyhook::MidHook::create(allocator, reinterpret_cast<void *>(target),
                                                            to_backend_detour(detour), safetyhook::MidHook::Default);
                 if (!created)

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -51,6 +51,10 @@ namespace DetourModKit::detail
     // captured detail matches error.hpp's `detail = GetLastError()` contract. Plain function pointer because it is set
     // and cleared on a single thread inside a test fixture; null in production, so zero behaviour change there.
     HMODULE (*g_hook_module_ref_override)() noexcept = nullptr;
+
+#if defined(DMK_ENABLE_TEST_SEAMS)
+    bool (*g_hook_create_witness_override)(bool) noexcept = nullptr;
+#endif
 } // namespace DetourModKit::detail
 
 namespace DetourModKit
@@ -686,13 +690,9 @@ namespace DetourModKit
          * @brief Whether the target's first bytes still match the prologue the backend saved before patching.
          * @details @ref Original means no patch is installed, @ref Patched means one is, and @ref Indeterminate means
          *          neither can be asserted.
-         * @note Only a positive witness publishes a state. An @ref Indeterminate result fails the operation and leaves
-         *       the hook in the state that assumes the WORSE outcome: a failed enable reports Disabled (never claim an
-         *       armed hook), and a failed disable reports Active (never claim a disarmed target). Those are deliberate
-         *       conservative answers rather than a report of what the bytes are, so neither is a lie a caller can act
-         *       on unsafely: both paths also return a typed failure, and a retry re-witnesses. A distinct unknown state
-         *       would describe reality more precisely, but it belongs to the publication state machine rather than
-         *       here, and it must not weaken the rule that a terminal state requires a positive witness.
+         * @note Only a positive witness publishes a state. Failure assumes the worse outcome (enable reports Disabled,
+         *       disable reports Active) and returns a typed error, so a retry re-witnesses rather than acting on a
+         *       guess.
          */
         enum class PatchWitness : std::uint8_t
         {
@@ -723,6 +723,25 @@ namespace DetourModKit
             return std::equal(original.begin(), original.begin() + static_cast<std::ptrdiff_t>(count), current.begin())
                        ? PatchWitness::Original
                        : PatchWitness::Patched;
+        }
+
+        /**
+         * @brief Whether a freshly created backend hook is actually armed at its target.
+         * @details The backend creates enabled yet reports success without confirming the patch reached the target, so
+         *          a create publishes only on a positive witness. No in-process input can reach the unconfirmed branch,
+         *          so a test drives it through g_hook_create_witness_override; the seam compiles out of a shipping
+         *          build.
+         */
+        template <class Backend> [[nodiscard]] bool create_patch_is_confirmed(const Backend &backend) noexcept
+        {
+            const bool confirmed = backend.enabled() && witness_patch(backend) == PatchWitness::Patched;
+#if defined(DMK_ENABLE_TEST_SEAMS)
+            if (auto *override_fn = DetourModKit::detail::g_hook_create_witness_override)
+            {
+                return override_fn(confirmed);
+            }
+#endif
+            return confirmed;
         }
 
         /**
@@ -1255,24 +1274,25 @@ namespace DetourModKit
                         return std::unexpected(Error{ErrorCode::BackendFailed, "hook::inline_at", target});
                     }
                     auto backend_hook = std::move(created.value());
-                    // The backend creates enabled, and its enable reports success without confirming the patch landed
-                    // (the same reason Hook::enable witnesses), so an unverified create must not publish Active.
-                    const HookState state =
-                        (backend_hook.enabled() && witness_patch(backend_hook) == PatchWitness::Patched)
-                            ? HookState::Active
-                            : HookState::Disabled;
+                    // A backend success is not proof the patch landed. Restore and fail before releasing the ledger
+                    // reservation so another install cannot race the rollback.
+                    if (!create_patch_is_confirmed(backend_hook))
+                    {
+                        backend_hook.reset();
+                        (void)DetourModKit::detail::HookLedger::instance().release_hook(target, ledger_id);
+                        (void)log().try_log(LogLevel::Error,
+                                            "hook::inline_at: backend create left '{}' at {} unconfirmed.",
+                                            request.name, format::format_address(target));
+                        return std::unexpected(Error{ErrorCode::BackendFailed, "hook::inline_at", target});
+                    }
                     // Store the reserved ledger id in the Impl (its teardown releases it). make_unique, the gate
                     // allocation, and the info log are the only steps that can still throw under OOM; the catch below
                     // rolls the reservation back, and `impl` (if built) unwinds through ~Impl to restore the prologue.
                     auto impl = std::make_unique<Hook::Impl>(std::move(backend_hook), std::move(request.name), target,
-                                                             ledger_id, state);
+                                                             ledger_id, HookState::Active);
                     auto gate = std::make_shared<Hook::CallGate>();
-                    // Publish the callable trampoline for an already-armed inline hook so a guarded call() dispatches
-                    // immediately; a disabled create leaves it null until enable() publishes it.
-                    if (state == HookState::Active)
-                    {
-                        gate->callable = inline_trampoline(impl->backend);
-                    }
+                    // The positive witness above proves this create is armed, so publish its callable trampoline.
+                    gate->callable = inline_trampoline(impl->backend);
                     const std::string_view created_name = impl->name;
                     log().info("hook::inline_at: created inline hook '{}' at {}.", created_name,
                                format::format_address(target));
@@ -1352,15 +1372,19 @@ namespace DetourModKit
                     return std::unexpected(Error{ErrorCode::BackendFailed, "hook::mid_at", target});
                 }
                 auto backend_hook = std::move(created.value());
-                // Witnessed for the same reason as inline_at_raw: a backend success is not proof the patch landed.
-                const HookState state = (backend_hook.enabled() && witness_patch(backend_hook) == PatchWitness::Patched)
-                                            ? HookState::Active
-                                            : HookState::Disabled;
+                if (!create_patch_is_confirmed(backend_hook))
+                {
+                    backend_hook.reset();
+                    (void)DetourModKit::detail::HookLedger::instance().release_hook(target, ledger_id);
+                    (void)log().try_log(LogLevel::Error, "hook::mid_at: backend create left '{}' at {} unconfirmed.",
+                                        request.name, format::format_address(target));
+                    return std::unexpected(Error{ErrorCode::BackendFailed, "hook::mid_at", target});
+                }
                 // Store the reserved ledger id in the Impl (see inline_at_raw). make_unique, the gate allocation, and
                 // the info log are the only steps that can throw under OOM; the catch below rolls the reservation back
                 // and `impl` (if built) unwinds to restore the prologue.
                 auto impl = std::make_unique<Hook::Impl>(std::move(backend_hook), std::move(request.name), target,
-                                                         ledger_id, state);
+                                                         ledger_id, HookState::Active);
                 // A mid hook has no callable original, so its gate stays null-callable (a guarded call() returns the
                 // inactive default); it still carries the gate so enable/disable/teardown serialize through it.
                 auto gate = std::make_shared<Hook::CallGate>();

--- a/src/internal/hook_fault_boundary.cpp
+++ b/src/internal/hook_fault_boundary.cpp
@@ -84,11 +84,14 @@ namespace DetourModKit
             return TargetWindowResult{TargetWindowVerdict::Unreadable, fault_address};
         }
 
-        // A declared function shorter than the smallest patch cannot be hooked without overwriting what follows it.
-        // The backend decides its instruction-rounded steal extent only after trampoline allocation, so a larger
-        // pre-flight bound would reject short functions that the near-jump path hooks safely.
+        // A declared function must be long enough for EITHER patch form, because which one runs is decided inside the
+        // backend after this returns: the near jump needs BACKEND_MIN_PATCH bytes, the indirect fallback needs
+        // BACKEND_FALLBACK_MIN_PATCH. Checking only the near jump would admit a function the fallback overwrites past
+        // its end, silently corrupting whatever follows, and the fallback is chosen exactly when the trampoline cannot
+        // be allocated nearby -- a condition this code cannot predict. Requiring the larger minimum refuses a short
+        // function the near jump would have hooked safely; that costs a typed error, where guessing costs the host.
         const std::optional<FunctionBound> bound = unwind_bound(target);
-        if (bound && target + BACKEND_MIN_PATCH > bound->hi)
+        if (bound && target + BACKEND_FALLBACK_MIN_PATCH > bound->hi)
         {
             return TargetWindowResult{TargetWindowVerdict::BoundOverrun, bound->hi};
         }

--- a/src/internal/hook_fault_boundary.cpp
+++ b/src/internal/hook_fault_boundary.cpp
@@ -1,0 +1,114 @@
+#include "internal/hook_fault_boundary.hpp"
+
+#include "internal/memory_guarded.hpp"
+#include "internal/scan_pages.hpp"
+
+#include <windows.h>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace DetourModKit
+{
+    namespace
+    {
+        /// A function's half-open extent as declared by its unwind metadata.
+        struct FunctionBound
+        {
+            std::uintptr_t lo{0};
+            std::uintptr_t hi{0};
+        };
+
+        // Resolves the unwind-declared extent of the function containing target, or nullopt when the target declares
+        // none. Absence is the normal case for a leaf function or JIT-emitted code and is never treated as a refusal.
+        //
+        // The RUNTIME_FUNCTION the loader hands back points into the image's exception directory, which is ordinary
+        // process memory that a concurrent unload can withdraw; it is copied under the fault guard rather than
+        // dereferenced. A record whose extent is inverted or empty is discarded as untrustworthy.
+        //
+        // Only the directly registered entry is honoured. A chained entry names the primary fragment of a
+        // hot/cold-split function, which is a different, non-contiguous span that does not contain target and is
+        // therefore not a containment bound for it.
+        std::optional<FunctionBound> unwind_bound(std::uintptr_t target) noexcept
+        {
+            DWORD64 image_base = 0;
+            const PRUNTIME_FUNCTION entry = RtlLookupFunctionEntry(target, &image_base, nullptr);
+            if (entry == nullptr || image_base == 0)
+            {
+                return std::nullopt;
+            }
+
+            RUNTIME_FUNCTION record{};
+            if (!detail::guarded_read_bytes(reinterpret_cast<std::uintptr_t>(entry), &record, sizeof(record)))
+            {
+                return std::nullopt;
+            }
+            if (record.EndAddress <= record.BeginAddress)
+            {
+                return std::nullopt;
+            }
+            const auto base = static_cast<std::uintptr_t>(image_base);
+            if (record.BeginAddress > UINTPTR_MAX - base || record.EndAddress > UINTPTR_MAX - base)
+            {
+                return std::nullopt;
+            }
+            const FunctionBound bound{base + record.BeginAddress, base + record.EndAddress};
+            if (target < bound.lo || target >= bound.hi)
+            {
+                return std::nullopt;
+            }
+            return bound;
+        }
+    } // namespace
+
+    detail::TargetWindowResult detail::validate_backend_steal_window(std::uintptr_t target) noexcept
+    {
+        // Executable and committed across the whole window. Stricter than testing the first byte: the backend decodes
+        // forward without a region bound, so a prologue whose tail runs off the end of its executable region would let
+        // the decoder consume an adjacent data page (or unmapped space) as instruction bytes.
+        if (!is_executable_range(target, BACKEND_MAX_STEAL_WINDOW))
+        {
+            return TargetWindowResult{TargetWindowVerdict::NotExecutable, target};
+        }
+
+        // Executable-and-committed is not readable. VirtualQuery reports the protection the OS recorded; it cannot
+        // report that a guard page will trap the first touch, or that a section's backing store will fail to fault in.
+        // Touching the bytes under the guard is the only way to learn that, and it consults no protection cache, so it
+        // cannot answer from a stale snapshot.
+        std::array<std::uint8_t, BACKEND_MAX_STEAL_WINDOW> window{};
+        volatile std::uintptr_t fault_address = target;
+        if (!guarded_read_bytes(target, window.data(), window.size(), &fault_address))
+        {
+            return TargetWindowResult{TargetWindowVerdict::Unreadable, fault_address};
+        }
+
+        // A declared function shorter than the smallest patch cannot be hooked without overwriting what follows it.
+        // The backend decides its instruction-rounded steal extent only after trampoline allocation, so a larger
+        // pre-flight bound would reject short functions that the near-jump path hooks safely.
+        const std::optional<FunctionBound> bound = unwind_bound(target);
+        if (bound && target + BACKEND_MIN_PATCH > bound->hi)
+        {
+            return TargetWindowResult{TargetWindowVerdict::BoundOverrun, bound->hi};
+        }
+
+        return TargetWindowResult{TargetWindowVerdict::Ok, target};
+    }
+
+    std::string_view detail::target_window_description(TargetWindowVerdict verdict) noexcept
+    {
+        switch (verdict)
+        {
+        case TargetWindowVerdict::NotExecutable:
+            return "the bytes the backend decodes are not all executable committed memory";
+        case TargetWindowVerdict::Unreadable:
+            return "the bytes the backend decodes are not all readable";
+        case TargetWindowVerdict::BoundOverrun:
+            return "the target function is shorter than the smallest patch the backend writes";
+        case TargetWindowVerdict::Ok:
+            return "the target is hookable";
+        }
+        return "the target is hookable";
+    }
+} // namespace DetourModKit

--- a/src/internal/hook_fault_boundary.cpp
+++ b/src/internal/hook_fault_boundary.cpp
@@ -84,12 +84,8 @@ namespace DetourModKit
             return TargetWindowResult{TargetWindowVerdict::Unreadable, fault_address};
         }
 
-        // A declared function must be long enough for EITHER patch form, because which one runs is decided inside the
-        // backend after this returns: the near jump needs BACKEND_MIN_PATCH bytes, the indirect fallback needs
-        // BACKEND_FALLBACK_MIN_PATCH. Checking only the near jump would admit a function the fallback overwrites past
-        // its end, silently corrupting whatever follows, and the fallback is chosen exactly when the trampoline cannot
-        // be allocated nearby -- a condition this code cannot predict. Requiring the larger minimum refuses a short
-        // function the near jump would have hooked safely; that costs a typed error, where guessing costs the host.
+        // Which patch form runs is decided after this check. The fallback can overwrite more bytes than the near jump,
+        // so an unwind-bounded target must accommodate the fallback minimum even when the near form might be selected.
         const std::optional<FunctionBound> bound = unwind_bound(target);
         if (bound && target + BACKEND_FALLBACK_MIN_PATCH > bound->hi)
         {
@@ -108,7 +104,7 @@ namespace DetourModKit
         case TargetWindowVerdict::Unreadable:
             return "the bytes the backend decodes are not all readable";
         case TargetWindowVerdict::BoundOverrun:
-            return "the target function is shorter than the smallest patch the backend writes";
+            return "the target function is shorter than the largest patch minimum the backend may select";
         case TargetWindowVerdict::Ok:
             return "the target is hookable";
         }

--- a/src/internal/hook_fault_boundary.hpp
+++ b/src/internal/hook_fault_boundary.hpp
@@ -42,11 +42,8 @@ namespace DetourModKit
          */
         inline constexpr std::size_t BACKEND_MAX_STEAL_WINDOW = 28;
 
-        /// Smallest patch the backend's near-jump form (E9 rel32) writes.
-        inline constexpr std::size_t BACKEND_MIN_PATCH = 5;
-
         /**
-         * @brief Smallest patch the backend's indirect-jump fallback writes, and so the shortest function it can hook.
+         * @brief Bytes written by the indirect-jump fallback and the conservative minimum for a bounded target.
          * @details The fallback stores its 8-byte absolute destination inside the target, immediately after the 6-byte
          *          jump, and NOP-fills to its stolen extent, so it writes at least 14 bytes at the target. Which form
          *          runs is decided by whether the trampoline allocation lands within near-jump reach, which happens
@@ -79,9 +76,9 @@ namespace DetourModKit
         /**
          * @brief Decides whether @p target can be handed to the backend without risking a host fault.
          * @details Requires [target, target + @ref BACKEND_MAX_STEAL_WINDOW) to be executable, committed and readable,
-         *          and requires a @ref BACKEND_MIN_PATCH patch to fit inside the target's unwind-declared function
-         *          bound where one exists. Code that declares no unwind bound (a leaf function, or JIT-emitted code) is
-         *          accepted: absence of metadata is not evidence of an unsafe target.
+         *          and requires @ref BACKEND_FALLBACK_MIN_PATCH bytes to fit inside the target's unwind-declared
+         *          function bound where one exists. Code that declares no unwind bound (a leaf function, or JIT-emitted
+         *          code) is accepted: absence of metadata is not evidence of an unsafe target.
          * @return @ref TargetWindowVerdict::Ok when the backend may proceed, else the refusal and its address.
          * @note Conservative by construction. The window is a worst-case bound, so a valid function entry lying within
          *       @ref BACKEND_MAX_STEAL_WINDOW of the end of its executable region is refused even though the backend

--- a/src/internal/hook_fault_boundary.hpp
+++ b/src/internal/hook_fault_boundary.hpp
@@ -1,0 +1,89 @@
+#ifndef DETOURMODKIT_INTERNAL_HOOK_FAULT_BOUNDARY_HPP
+#define DETOURMODKIT_INTERNAL_HOOK_FAULT_BOUNDARY_HPP
+
+/**
+ * @file hook_fault_boundary.hpp
+ * @brief Range-confined validation of a hook target's backend steal window.
+ *
+ * The hooking backend decodes a target's prologue with no readability or protection check of its own, so an invalid or
+ * concurrently unmapped target faults inside backend code and kills the host. This boundary proves the window the
+ * backend may touch is executable, committed and readable before the backend is ever called, and reports which byte
+ * failed. These declarations are internal to the build and are never installed.
+ *
+ * @warning No function here may span a call into the hooking backend (safetyhook::InlineHook::create / enable /
+ *          disable, safetyhook::MidHook::create). DMK's guarded primitives recover from a fault by abandoning the
+ *          faulting frame -- __builtin_longjmp on MinGW, an asynchronous unwind under /EHsc on MSVC -- and neither
+ *          runs destructors. InlineHook::enable holds its own mutex and the backend's virtual_protect_mutex across the
+ *          patch, so a claimed fault would abandon both locked for the life of the process and strand the target page
+ *          writable-executable. Validate before the backend call; never around it.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace DetourModKit
+{
+    namespace detail
+    {
+        static_assert(sizeof(void *) == 8, "BACKEND_MAX_STEAL_WINDOW is derived from the x86-64 backend layout: the "
+                                           "JmpFF fallback it accounts for does not exist on 32-bit.");
+
+        /**
+         * @brief Largest byte offset the backend may read from a target before the target is known to be safe.
+         * @details The backend hands its decoder a fixed 15-byte buffer at each instruction pointer, unclamped by any
+         *          region bound, and walks until it has covered a jump's worth of prologue. Its indirect-jump fallback
+         *          (6-byte jump plus an 8-byte absolute address = 14) is the deeper of the two walks, so the last
+         *          instruction it decodes can begin at target + 13 and read through target + 27. The fallback is
+         *          reachable whenever the near-jump attempt fails after a clean decode, so this bound is not
+         *          hypothetical. These sizes are private to the backend's implementation and are not exported by its
+         *          headers, so they cannot be queried and must be mirrored here; re-derive them when the backend is
+         *          repinned. @ref InlineHookFaultProof.WindowBoundaryMatchesBackendSteal pins the value.
+         */
+        inline constexpr std::size_t BACKEND_MAX_STEAL_WINDOW = 28;
+
+        /// Smallest patch a successful inline install writes: the backend's near jump (E9 rel32).
+        inline constexpr std::size_t BACKEND_MIN_PATCH = 5;
+
+        /// Why @ref validate_backend_steal_window refused a target, or @ref TargetWindowVerdict::Ok if it did not.
+        enum class TargetWindowVerdict : std::uint8_t
+        {
+            Ok,
+            NotExecutable,
+            Unreadable,
+            BoundOverrun
+        };
+
+        /**
+         * @brief A window verdict and the address that explains it.
+         * @details @p detail is the faulting address for @ref TargetWindowVerdict::Unreadable, the function's end for
+         *          @ref TargetWindowVerdict::BoundOverrun, and the target itself otherwise.
+         */
+        struct TargetWindowResult
+        {
+            TargetWindowVerdict verdict{TargetWindowVerdict::Ok};
+            std::uintptr_t detail{0};
+        };
+
+        /**
+         * @brief Decides whether @p target can be handed to the backend without risking a host fault.
+         * @details Requires [target, target + @ref BACKEND_MAX_STEAL_WINDOW) to be executable, committed and readable,
+         *          and requires a @ref BACKEND_MIN_PATCH patch to fit inside the target's unwind-declared function
+         *          bound where one exists. Code that declares no unwind bound (a leaf function, or JIT-emitted code) is
+         *          accepted: absence of metadata is not evidence of an unsafe target.
+         * @return @ref TargetWindowVerdict::Ok when the backend may proceed, else the refusal and its address.
+         * @note Conservative by construction. The window is a worst-case bound, so a valid function entry lying within
+         *       @ref BACKEND_MAX_STEAL_WINDOW of the end of its executable region is refused even though the backend
+         *       might have decoded it in fewer bytes. Refusing a hookable target returns a typed error; admitting an
+         *       unreadable one kills the host.
+         * @warning A verdict describes the moment it was taken. A concurrent unmap can invalidate it before the caller
+         *          acts on it; this narrows the window and attributes failures, and does not eliminate the race.
+         */
+        [[nodiscard]] TargetWindowResult validate_backend_steal_window(std::uintptr_t target) noexcept;
+
+        /// Human-readable fragment naming a window refusal, for diagnostic log lines.
+        [[nodiscard]] std::string_view target_window_description(TargetWindowVerdict verdict) noexcept;
+    } // namespace detail
+} // namespace DetourModKit
+
+#endif // DETOURMODKIT_INTERNAL_HOOK_FAULT_BOUNDARY_HPP

--- a/src/internal/hook_fault_boundary.hpp
+++ b/src/internal/hook_fault_boundary.hpp
@@ -42,8 +42,19 @@ namespace DetourModKit
          */
         inline constexpr std::size_t BACKEND_MAX_STEAL_WINDOW = 28;
 
-        /// Smallest patch a successful inline install writes: the backend's near jump (E9 rel32).
+        /// Smallest patch the backend's near-jump form (E9 rel32) writes.
         inline constexpr std::size_t BACKEND_MIN_PATCH = 5;
+
+        /**
+         * @brief Smallest patch the backend's indirect-jump fallback writes, and so the shortest function it can hook.
+         * @details The fallback stores its 8-byte absolute destination inside the target, immediately after the 6-byte
+         *          jump, and NOP-fills to its stolen extent, so it writes at least 14 bytes at the target. Which form
+         *          runs is decided by whether the trampoline allocation lands within near-jump reach, which happens
+         *          inside the backend after this validation, so a target must satisfy the LARGER of the two minimums to
+         *          be safe under either. A function shorter than this would be hooked correctly by the near jump but
+         *          overwritten past its end by the fallback.
+         */
+        inline constexpr std::size_t BACKEND_FALLBACK_MIN_PATCH = 14;
 
         /// Why @ref validate_backend_steal_window refused a target, or @ref TargetWindowVerdict::Ok if it did not.
         enum class TargetWindowVerdict : std::uint8_t

--- a/src/internal/memory_guarded.cpp
+++ b/src/internal/memory_guarded.cpp
@@ -722,7 +722,8 @@ namespace DetourModKit
         // TLS slot so a read fault is claimable, and the handler longjmps back here so the setjmp expression returns
         // non-zero and the function reports failure. noinline keeps the read and its setjmp anchor in one
         // self-contained frame.
-        __attribute__((noinline)) bool veh_guarded_copy(void *out, const void *src, std::size_t len) noexcept
+        __attribute__((noinline)) bool veh_guarded_copy(void *out, const void *src, std::size_t len,
+                                                        volatile std::uintptr_t *fault_out) noexcept
         {
             const DWORD slot = s_veh_tls_index.load(std::memory_order_acquire);
             VehAccessGuard guard{};
@@ -732,7 +733,11 @@ namespace DetourModKit
             if (__builtin_setjmp(guard.env) != 0)
             {
                 // Reached only when the handler longjmped here after swallowing a read fault; the handler already
-                // cleared the TLS slot. Report the failure.
+                // cleared the TLS slot and recorded which address faulted. Report the failure.
+                if (fault_out != nullptr)
+                {
+                    *fault_out = guard.fault_address;
+                }
                 return false;
             }
 
@@ -802,7 +807,8 @@ namespace DetourModKit
         // Counts the read in the drain epoch around the path decision so a read on the guarded path is always visible
         // to release_guarded_engine's drain. Falls back to a VirtualQuery plus ReadProcessMemory copy when the handler
         // is unavailable.
-        bool veh_read_bytes(std::uintptr_t addr, void *out, std::size_t bytes) noexcept
+        bool veh_read_bytes(std::uintptr_t addr, void *out, std::size_t bytes,
+                            volatile std::uintptr_t *fault_out) noexcept
         {
             if (addr < memory::USERSPACE_PTR_MIN || addr + bytes < addr)
                 return false;
@@ -812,7 +818,9 @@ namespace DetourModKit
             const std::size_t stripe = veh_in_flight_stripe_index();
             s_veh_in_flight_stripes[stripe].count.fetch_add(1, std::memory_order_seq_cst);
             const bool armed = s_veh_handle.load(std::memory_order_seq_cst) != nullptr;
-            const bool ok = armed ? veh_guarded_copy(out, reinterpret_cast<const void *>(addr), bytes)
+            // The VirtualQuery fallback never faults, so it leaves fault_out untouched: it rejects the span up front
+            // rather than discovering an unreadable byte, and has no faulting address to report.
+            const bool ok = armed ? veh_guarded_copy(out, reinterpret_cast<const void *>(addr), bytes, fault_out)
                                   : virtualquery_validated_copy(addr, out, bytes);
             s_veh_in_flight_stripes[stripe].count.fetch_sub(1, std::memory_order_release);
             return ok;
@@ -883,7 +891,8 @@ namespace DetourModKit
     }
 #endif // !_MSC_VER && _WIN64
 
-    bool detail::guarded_read_bytes(std::uintptr_t address, void *out, std::size_t bytes) noexcept
+    bool detail::guarded_read_bytes(std::uintptr_t address, void *out, std::size_t bytes,
+                                    volatile std::uintptr_t *fault_address_out) noexcept
     {
         if (bytes == 0)
             return true;
@@ -913,14 +922,14 @@ namespace DetourModKit
         }
         // Range-aware: swallow only a fault whose address lies in the foreign SOURCE span. A fault on the caller-owned
         // destination buffer (or any address outside [address, address + bytes)) is a caller/DMK defect and propagates.
-        __except (guarded_range_fault_filter(GetExceptionInformation(), address, address + bytes))
+        __except (guarded_range_fault_filter(GetExceptionInformation(), address, address + bytes, fault_address_out))
         {
             return false;
         }
 #else
         // MinGW lacks __try/__except. Read through the process-wide vectored fault guard: the success path is a single
         // rep movsb with no syscall, and any read fault across the span is swallowed and reported as failure.
-        return veh_read_bytes(address, out, bytes);
+        return veh_read_bytes(address, out, bytes, fault_address_out);
 #endif
     }
 

--- a/src/internal/memory_guarded.hpp
+++ b/src/internal/memory_guarded.hpp
@@ -97,9 +97,14 @@ namespace DetourModKit
          *                rejected without a read.
          * @param out Destination buffer; null is rejected.
          * @param bytes Byte count; zero is a successful no-op.
+         * @param fault_address_out When non-null and the read faults, receives the faulting address, letting a caller
+         *                          report which byte of the span was unreadable rather than only that some byte was.
+         *                          Left untouched when the span is rejected without a read, and on the MinGW fallback
+         *                          path that validates through VirtualQuery instead of faulting.
          * @return true on full success; false on any fault or rejected argument (then @p out is unspecified).
          */
-        [[nodiscard]] bool guarded_read_bytes(std::uintptr_t address, void *out, std::size_t bytes) noexcept;
+        [[nodiscard]] bool guarded_read_bytes(std::uintptr_t address, void *out, std::size_t bytes,
+                                              volatile std::uintptr_t *fault_address_out = nullptr) noexcept;
 
         /**
          * @brief Guarded typed read for engine code: a representation-safe @p T at @p address, or nullopt on fault.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,12 +64,8 @@ if(DMK_BUILD_TESTS)
   # test TU needs the same gate active to reference them. Only ever set in a test build.
   target_compile_definitions(DetourModKit_tests PRIVATE DMK_ENABLE_TEST_SEAMS)
 
-  # The hook tests hook one named function per scenario and require each to have its OWN address. Identical-COMDAT
-  # folding merges functions with identical machine code into a single address, which silently aliases distinct test
-  # targets onto each other: a test that deliberately leaks a hook on its own dedicated target would then leave an
-  # unrelated test's target permanently hooked. MSVC enables /OPT:ICF by default in Release, where it defeats exactly
-  # that isolation, so turn it off for this executable (the linker's own documentation notes that /OPT:ICF makes
-  # distinct functions share an address). HookTargetIsolation.DistinctTargetsDoNotShareAnAddress pins the requirement.
+  # Hook scenarios require distinct target addresses because some intentionally retain their patch for process life.
+  # MSVC Release folds identical functions by default, so disable folding for this proof executable.
   if(MSVC)
     target_link_options(DetourModKit_tests PRIVATE /OPT:NOICF)
   endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,16 @@ if(DMK_BUILD_TESTS)
   # test TU needs the same gate active to reference them. Only ever set in a test build.
   target_compile_definitions(DetourModKit_tests PRIVATE DMK_ENABLE_TEST_SEAMS)
 
+  # The hook tests hook one named function per scenario and require each to have its OWN address. Identical-COMDAT
+  # folding merges functions with identical machine code into a single address, which silently aliases distinct test
+  # targets onto each other: a test that deliberately leaks a hook on its own dedicated target would then leave an
+  # unrelated test's target permanently hooked. MSVC enables /OPT:ICF by default in Release, where it defeats exactly
+  # that isolation, so turn it off for this executable (the linker's own documentation notes that /OPT:ICF makes
+  # distinct functions share an address). HookTargetIsolation.DistinctTargetsDoNotShareAnAddress pins the requirement.
+  if(MSVC)
+    target_link_options(DetourModKit_tests PRIVATE /OPT:NOICF)
+  endif()
+
   # The integration tests load the fixture from the test executable's directory.
   add_custom_command(TARGET hook_target_lib POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/tests/fixtures/scratch_page.hpp
+++ b/tests/fixtures/scratch_page.hpp
@@ -1,0 +1,105 @@
+#ifndef DETOURMODKIT_TESTS_FIXTURES_SCRATCH_PAGE_HPP
+#define DETOURMODKIT_TESTS_FIXTURES_SCRATCH_PAGE_HPP
+
+/**
+ * @file scratch_page.hpp
+ * @brief A committed executable scratch page for tests that must plant bytes where DMK's code-only gates accept them.
+ *
+ * Several DMK gates key on the execute bit -- the scanner's executable page class, and the hook pre-flight's steal
+ * window -- so a test that plants synthetic instruction bytes in a static array cannot reach them: a const array lands
+ * in read-only data and a mutable one in read-write data, and both are refused before the code under test runs. Tests
+ * may decode, patch, or execute the planted bytes.
+ */
+
+#include "DetourModKit/region.hpp"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <initializer_list>
+
+namespace dmk_test
+{
+    /**
+     * @brief One committed PAGE_EXECUTE_READWRITE page, filled with 0xCC and freed on destruction unless leaked.
+     * @details Fills with int3 so any offset not explicitly planted is an obvious breakpoint rather than zeroes that
+     *          decode as a valid instruction. A page this process has inline-hooked must be kept out of the destructor
+     *          via @ref leak.
+     */
+    class ScratchPage
+    {
+    public:
+        static constexpr std::size_t PAGE_SIZE = 0x1000;
+
+        ScratchPage() noexcept
+        {
+            m_base = VirtualAlloc(nullptr, PAGE_SIZE, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+            if (m_base != nullptr)
+            {
+                std::memset(m_base, 0xCC, PAGE_SIZE);
+            }
+        }
+
+        ~ScratchPage() noexcept
+        {
+            if (m_base != nullptr && m_owned)
+            {
+                VirtualFree(m_base, 0, MEM_RELEASE);
+            }
+        }
+
+        ScratchPage(const ScratchPage &) = delete;
+        ScratchPage &operator=(const ScratchPage &) = delete;
+        ScratchPage(ScratchPage &&) = delete;
+        ScratchPage &operator=(ScratchPage &&) = delete;
+
+        /// Whether the page was committed; a false here means the test cannot run, not that it failed.
+        [[nodiscard]] bool ok() const noexcept { return m_base != nullptr; }
+
+        /// Writes @p bytes at @p offset. The caller keeps the write within @ref PAGE_SIZE.
+        void put(std::size_t offset, std::initializer_list<std::uint8_t> bytes) noexcept
+        {
+            auto *destination = static_cast<std::uint8_t *>(m_base);
+            std::size_t i = 0;
+            for (const std::uint8_t b : bytes)
+            {
+                destination[offset + i++] = b;
+            }
+        }
+
+        [[nodiscard]] std::uintptr_t addr(std::size_t offset = 0) const noexcept
+        {
+            return reinterpret_cast<std::uintptr_t>(m_base) + offset;
+        }
+
+        [[nodiscard]] void *base() const noexcept { return m_base; }
+
+        [[nodiscard]] DetourModKit::Region range() const noexcept
+        {
+            return DetourModKit::Region{DetourModKit::Address{addr()}, PAGE_SIZE};
+        }
+
+        /**
+         * @brief Abandons the page so it is never freed, and so its address can never be handed out again.
+         * @details Required of any page this process has inline-hooked. The hooking backend records a hooked page in a
+         *          process-wide trap table it never prunes, and its exception handler resumes -- without fixing
+         *          anything -- on any later fault anywhere in a recorded page, which spins forever. Freeing a hooked
+         *          page lets a subsequent VirtualAlloc hand the same address to unrelated memory, at which point a
+         *          legitimate fault there hangs the process. Leaking the page keeps the address permanently retired.
+         *          The same leak-on-purpose reasoning governs NoAccessPage in fault_injection.hpp.
+         * @note The page stays usable after this call; only the free is suppressed.
+         */
+        void leak() noexcept { m_owned = false; }
+
+    private:
+        void *m_base{nullptr};
+        bool m_owned{true};
+    };
+} // namespace dmk_test
+
+#endif // DETOURMODKIT_TESTS_FIXTURES_SCRATCH_PAGE_HPP

--- a/tests/test_anchor.cpp
+++ b/tests/test_anchor.cpp
@@ -1,10 +1,13 @@
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #include <gtest/gtest.h>
 
 #include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <initializer_list>
 #include <limits>
 #include <span>
 #include <string>
@@ -13,8 +16,8 @@
 #include "DetourModKit/anchor.hpp"
 #include "DetourModKit/scan.hpp"
 
-// windows.h after project headers to avoid macro conflicts.
-#define WIN32_LEAN_AND_MEAN
+#include "fixtures/scratch_page.hpp"
+
 #include <windows.h>
 
 namespace dmk = DetourModKit;
@@ -29,59 +32,7 @@ namespace
         return sc::Pattern::compile(dsl).value();
     }
 
-    // A committed 0xCC-filled page into which a test plants known x86-64 instructions / markers, so the cascade- and
-    // decode-backed anchor kinds have a real, uniquely-matchable site to resolve. PAGE_EXECUTE_READWRITE, not
-    // PAGE_READWRITE: a CodeOperand site is an instruction and read_code_constant scans Pages::Executable, so the
-    // planted bytes must live on an execute-readable page (the bytes are still only decoded, never executed; the
-    // execute bit is what the page-class gate keys on). RipGlobal markers resolve on this superset page too.
-    class ScratchPage
-    {
-    public:
-        ScratchPage()
-        {
-            m_base = VirtualAlloc(nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
-            if (m_base != nullptr)
-            {
-                std::memset(m_base, 0xCC, 0x1000);
-            }
-        }
-
-        ~ScratchPage()
-        {
-            if (m_base != nullptr)
-            {
-                VirtualFree(m_base, 0, MEM_RELEASE);
-            }
-        }
-
-        ScratchPage(const ScratchPage &) = delete;
-        ScratchPage &operator=(const ScratchPage &) = delete;
-
-        [[nodiscard]] bool ok() const noexcept { return m_base != nullptr; }
-
-        void put(std::size_t off, std::initializer_list<std::uint8_t> bytes) noexcept
-        {
-            auto *p = static_cast<std::uint8_t *>(m_base);
-            std::size_t i = 0;
-            for (const std::uint8_t b : bytes)
-            {
-                p[off + i++] = b;
-            }
-        }
-
-        [[nodiscard]] std::uintptr_t addr(std::size_t off) const noexcept
-        {
-            return reinterpret_cast<std::uintptr_t>(m_base) + off;
-        }
-
-        [[nodiscard]] dmk::Region range() const noexcept
-        {
-            return dmk::Region{dmk::Address{reinterpret_cast<std::uintptr_t>(m_base)}, 0x1000};
-        }
-
-    private:
-        void *m_base = nullptr;
-    };
+    using dmk_test::ScratchPage;
 
     // A committed RWX page that hosts a string literal plus a RIP-relative lea that references it, so the StringXref
     // backend has a real string (phase 1) and a real reference (phase 2) inside one Region.

--- a/tests/test_hook.cpp
+++ b/tests/test_hook.cpp
@@ -102,6 +102,18 @@ namespace
         return r;
     }
 
+    DMK_TEST_NOINLINE int witness_failure_inline_target(int value)
+    {
+        const volatile int result = value + 17;
+        return result;
+    }
+
+    DMK_TEST_NOINLINE int witness_failure_mid_target(int a, int b)
+    {
+        const volatile int result = a - b;
+        return result;
+    }
+
     std::atomic<int> s_real_detour_calls{0};
 
     DMK_TEST_NOINLINE int real_hook_detour_add(int a, int b)
@@ -174,15 +186,10 @@ TEST(HookInline, CreateEmptyName)
     EXPECT_EQ(r.error().code, ErrorCode::InvalidArg);
 }
 
-// Every hookable target above must occupy its own address. Several have identical bodies by nature (a leak target is a
-// deliberate copy of the target it stands in for), and a linker that folds identical machine code would collapse them
-// onto one address: the tests that deliberately leak a hook on their own dedicated target would then leave a target
-// another test expects clean permanently hooked, and that test would observe the leaked detour instead of the original.
-// The failure is silent, appears only in optimized builds, and looks like a trampoline defect rather than a test-setup
-// defect, so it is pinned here rather than left to be rediscovered. tests/CMakeLists.txt disables the folding.
+// Leak-on-purpose scenarios require dedicated function addresses so their retained patches cannot alias another target.
 TEST(HookTargetIsolation, DistinctTargetsDoNotShareAnAddress)
 {
-    const std::array<std::pair<const char *, std::uintptr_t>, 8> targets{{
+    const std::array<std::pair<const char *, std::uintptr_t>, 10> targets{{
         {"echo", reinterpret_cast<std::uintptr_t>(&echo)},
         {"real_hook_target_add", reinterpret_cast<std::uintptr_t>(&real_hook_target_add)},
         {"real_hook_target_mul", reinterpret_cast<std::uintptr_t>(&real_hook_target_mul)},
@@ -191,6 +198,8 @@ TEST(HookTargetIsolation, DistinctTargetsDoNotShareAnAddress)
         {"leak_target_mid", reinterpret_cast<std::uintptr_t>(&leak_target_mid)},
         {"leak_target_lifecycle", reinterpret_cast<std::uintptr_t>(&leak_target_lifecycle)},
         {"leak_target_layered", reinterpret_cast<std::uintptr_t>(&leak_target_layered)},
+        {"witness_failure_inline_target", reinterpret_cast<std::uintptr_t>(&witness_failure_inline_target)},
+        {"witness_failure_mid_target", reinterpret_cast<std::uintptr_t>(&witness_failure_mid_target)},
     }};
 
     for (std::size_t i = 0; i < targets.size(); ++i)
@@ -1726,6 +1735,9 @@ TEST(HookVmt, PreflightGuardsHeaderPrefixBelowVptr)
 namespace DetourModKit::detail
 {
     extern HMODULE (*g_hook_module_ref_override)() noexcept;
+#if defined(DMK_ENABLE_TEST_SEAMS)
+    extern bool (*g_hook_create_witness_override)(bool) noexcept;
+#endif
 } // namespace DetourModKit::detail
 
 namespace
@@ -1736,6 +1748,11 @@ namespace
     {
         ::SetLastError(INJECTED_ACQUIRE_ERROR);
         return nullptr;
+    }
+
+    bool reject_create_witness(bool) noexcept
+    {
+        return false;
     }
 
     // RAII installer so a failed assertion still clears the override before the next test runs.
@@ -1749,7 +1766,57 @@ namespace
         HookModuleRefFailureScope(const HookModuleRefFailureScope &) = delete;
         HookModuleRefFailureScope &operator=(const HookModuleRefFailureScope &) = delete;
     };
+
+    class HookCreateWitnessFailureScope
+    {
+    public:
+        HookCreateWitnessFailureScope() noexcept
+        {
+            DetourModKit::detail::g_hook_create_witness_override = &reject_create_witness;
+        }
+        ~HookCreateWitnessFailureScope() noexcept { DetourModKit::detail::g_hook_create_witness_override = nullptr; }
+        HookCreateWitnessFailureScope(const HookCreateWitnessFailureScope &) = delete;
+        HookCreateWitnessFailureScope &operator=(const HookCreateWitnessFailureScope &) = delete;
+    };
 } // namespace
+
+TEST(HookCreateWitness, InlineFailureReturnsTypedErrorAndRollsBack)
+{
+    const Address target = addr_of(&witness_failure_inline_target);
+    {
+        const HookCreateWitnessFailureScope fail_scope;
+        const Result<Hook> failed =
+            inline_at(InlineRequest{.name = "InlineWitnessFailure", .target = target}, &echo_detour);
+        ASSERT_FALSE(failed.has_value());
+        EXPECT_EQ(failed.error().code, ErrorCode::BackendFailed);
+    }
+
+    EXPECT_FALSE(is_target_hooked(target));
+    EXPECT_EQ(call_unfolded(&witness_failure_inline_target, 7), 24);
+
+    const Result<Hook> retry = inline_at(InlineRequest{.name = "InlineWitnessRetry", .target = target}, &echo_detour);
+    ASSERT_TRUE(retry.has_value()) << retry.error().message();
+    EXPECT_EQ(call_unfolded(&witness_failure_inline_target, 7), 107);
+}
+
+TEST(HookCreateWitness, MidFailureReturnsTypedErrorAndRollsBack)
+{
+    const Address target = addr_of(&witness_failure_mid_target);
+    const auto detour = [](MidContext &ctx) { gpr(ctx, Gpr::Rcx) = 100; };
+    {
+        const HookCreateWitnessFailureScope fail_scope;
+        const Result<Hook> failed = mid_at(MidRequest{.name = "MidWitnessFailure", .target = target}, detour);
+        ASSERT_FALSE(failed.has_value());
+        EXPECT_EQ(failed.error().code, ErrorCode::BackendFailed);
+    }
+
+    EXPECT_FALSE(is_target_hooked(target));
+    EXPECT_EQ(call_unfolded(&witness_failure_mid_target, 9, 4), 5);
+
+    const Result<Hook> retry = mid_at(MidRequest{.name = "MidWitnessRetry", .target = target}, detour);
+    ASSERT_TRUE(retry.has_value()) << retry.error().message();
+    EXPECT_EQ(call_unfolded(&witness_failure_mid_target, 9, 4), 96);
+}
 
 TEST(HookModuleRef, InlineAtAcquireFailurePopulatesErrorDetail)
 {

--- a/tests/test_hook.cpp
+++ b/tests/test_hook.cpp
@@ -21,11 +21,14 @@
 #include "DetourModKit/diagnostics.hpp"
 #include "DetourModKit/hook.hpp"
 #include "DetourModKit/logger.hpp"
+#include "DetourModKit/memory.hpp"
 #include "DetourModKit/region.hpp"
 #include "DetourModKit/scan.hpp"
 
+#include "internal/hook_fault_boundary.hpp"
 #include "internal/hook_ledger.hpp"
 
+#include "fixtures/scratch_page.hpp"
 #include "test_alloc_probe.hpp"
 
 using namespace DetourModKit;
@@ -123,6 +126,13 @@ namespace
     {
         return Address{reinterpret_cast<std::uintptr_t>(fn)};
     }
+
+    // A volatile indirection forces the call to reach the patched entry even when the optimizer can see the callee.
+    template <class Fn, class... Args> auto call_unfolded(Fn *fn, Args... args)
+    {
+        Fn *const volatile indirect = fn;
+        return indirect(args...);
+    }
 } // namespace
 
 // INLINE create + validation
@@ -173,7 +183,7 @@ TEST(HookInline, TypedTrampolineCallsOriginal)
     Hook h = std::move(*r);
 
     // The detour is active: echo(7) routes through echo_detour -> 107.
-    EXPECT_EQ(echo(7), 107);
+    EXPECT_EQ(call_unfolded(&echo, 7), 107);
 
     // The typed trampoline reaches the original body, so it yields the unmodified 7.
     auto *orig = h.original<EchoFn>();
@@ -188,15 +198,15 @@ TEST(HookInline, EnableDisableTogglesDetour)
     Hook h = std::move(*r);
 
     EXPECT_TRUE(h.is_enabled());
-    EXPECT_EQ(echo(7), 107);
+    EXPECT_EQ(call_unfolded(&echo, 7), 107);
 
     ASSERT_TRUE(h.disable().has_value());
     EXPECT_FALSE(h.is_enabled());
-    EXPECT_EQ(echo(7), 7); // original body restored while disabled
+    EXPECT_EQ(call_unfolded(&echo, 7), 7); // original body restored while disabled
 
     ASSERT_TRUE(h.enable().has_value());
     EXPECT_TRUE(h.is_enabled());
-    EXPECT_EQ(echo(7), 107);
+    EXPECT_EQ(call_unfolded(&echo, 7), 107);
 }
 
 TEST(HookInline, EnableDisableAreIdempotent)
@@ -230,38 +240,63 @@ TEST(HookInline, OriginalNullForDisengagedHandle)
 // INLINE prologue policy
 namespace
 {
-    // Synthetic prologue buffers for the inline/mid prologue pre-flight. const (read-only) and alignas(16) so the
-    // planted first byte sits at a deterministic, readable address across toolchains. The Fail-policy create refuses at
-    // the prologue pre-flight, so these need not be relocatable code -- only the first byte is classified, and the hook
-    // target is the buffer's address.
-    alignas(16) const std::uint8_t CALL_PROLOGUE_BYTES[] = {0xE8, 0x00, 0x00, 0x00, 0x00, 0xC3, 0x90, 0x90};
-    alignas(16) const std::uint8_t INT3_PROLOGUE_BYTES[] = {0xCC, 0xC3, 0x90, 0x90};
-    alignas(16) const std::uint8_t INTN_PROLOGUE_BYTES[] = {0xCD, 0x03, 0xC3, 0x90};
-    // Dedicated buffer for the Relocate-leak test: it installs and releases (leaks) a hook here, which patches the
-    // first byte, so it must not share a buffer with the prologue-refusal tests that need a clean leading 0xE8.
-    alignas(16) std::uint8_t RELOCATE_CALL_PROLOGUE_BYTES[] = {0xE8, 0x00, 0x00, 0x00, 0x00, 0xC3, 0x90, 0x90,
-                                                               0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
-
+    // Synthetic prologue targets live on a committed executable page, not in a static array: the pre-flight's steal
+    // window requires the bytes the backend decodes to be executable committed memory, so a prologue planted in
+    // read-only or read-write data is refused for that reason before its first byte is ever classified. A static buffer
+    // would make every test below pass for the wrong reason.
     void noop_detour() noexcept {}
+
+    // Plants a prologue at the start of a fresh executable page and returns the install result.
+    Result<Hook> install_on_planted_prologue(dmk_test::ScratchPage &page, const char *name,
+                                             std::initializer_list<std::uint8_t> prologue, Options options = {})
+    {
+        page.put(0, prologue);
+        return inline_at(InlineRequest{.name = name, .target = Address{page.addr(0)}, .options = options},
+                         reinterpret_cast<void (*)()>(&noop_detour));
+    }
+
+    // A function whose first instruction is a rel32 call is assembled on an executable page:
+    //
+    //   +0x000  E8 <rel32 to +0x100>   call callee
+    //   +0x005  C3                     ret            (returns the callee's EAX)
+    //   +0x100  B8 <imm32> C3          mov eax, MAGIC; ret
+    //
+    // The callee lives on the SAME page as the target so the backend's trampoline, which it allocates near the target,
+    // is necessarily within rel32 reach of the callee's absolute address. Splitting them across a VirtualAlloc page and
+    // the test image would make relocation reach depend on where the OS happened to place the page.
+    constexpr std::size_t LEADING_CALL_CALLEE_OFFSET = 0x100;
+    constexpr int LEADING_CALL_CALLEE_VALUE = 0x00C0FFEE;
+    constexpr int LEADING_CALL_DETOUR_VALUE = 0x00BADA55;
+
+    void plant_leading_call_fixture(dmk_test::ScratchPage &page) noexcept
+    {
+        const std::int32_t disp =
+            static_cast<std::int32_t>(LEADING_CALL_CALLEE_OFFSET) - 5; // rel32 is relative to the next instruction
+        page.put(0, {0xE8, static_cast<std::uint8_t>(disp & 0xFF), static_cast<std::uint8_t>((disp >> 8) & 0xFF),
+                     static_cast<std::uint8_t>((disp >> 16) & 0xFF), static_cast<std::uint8_t>((disp >> 24) & 0xFF),
+                     0xC3});
+        page.put(LEADING_CALL_CALLEE_OFFSET,
+                 {0xB8, static_cast<std::uint8_t>(LEADING_CALL_CALLEE_VALUE & 0xFF),
+                  static_cast<std::uint8_t>((LEADING_CALL_CALLEE_VALUE >> 8) & 0xFF),
+                  static_cast<std::uint8_t>((LEADING_CALL_CALLEE_VALUE >> 16) & 0xFF),
+                  static_cast<std::uint8_t>((LEADING_CALL_CALLEE_VALUE >> 24) & 0xFF), 0xC3});
+        FlushInstructionCache(GetCurrentProcess(), page.base(), dmk_test::ScratchPage::PAGE_SIZE);
+    }
+
+    int leading_call_detour() noexcept
+    {
+        return LEADING_CALL_DETOUR_VALUE;
+    }
 } // namespace
 
-// The default policy is Prologue::Fail (safe-by-default). A leading 0xE8 (call rel32) prologue is unsafe to
-// inline-hook: the relocated trampoline copy can dispatch a relative call to the wrong absolute target. The default
-// create must refuse with TargetPrologueUnsafe.
-TEST(HookInlinePrologue, DefaultFailsOnLeadingCallPrologue)
-{
-    Result<Hook> r = inline_at(InlineRequest{.name = "CallPrologue", .target = addr_of(CALL_PROLOGUE_BYTES)},
-                               reinterpret_cast<void (*)()>(&noop_detour));
-    ASSERT_FALSE(r.has_value());
-    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
-}
-
 // A leading 0xCC (int3) prologue is already a breakpoint -- a foreign hook's stub, a patched byte, or padding -- not a
-// real function body. The default Fail policy must refuse.
+// real function body. The default Fail policy must refuse. Planted on an executable page so the refusal is proven to
+// come from the breakpoint classifier and not from the steal-window gate ahead of it.
 TEST(HookInlinePrologue, DefaultFailsOnInt3Prologue)
 {
-    Result<Hook> r = inline_at(InlineRequest{.name = "Int3Prologue", .target = addr_of(INT3_PROLOGUE_BYTES)},
-                               reinterpret_cast<void (*)()>(&noop_detour));
+    dmk_test::ScratchPage page;
+    ASSERT_TRUE(page.ok());
+    Result<Hook> r = install_on_planted_prologue(page, "Int3Prologue", {0xCC, 0xC3, 0x90, 0x90});
     ASSERT_FALSE(r.has_value());
     EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
 }
@@ -269,8 +304,9 @@ TEST(HookInlinePrologue, DefaultFailsOnInt3Prologue)
 // A leading 0xCD (int n) prologue is the two-byte breakpoint form; classifying on the first byte alone is sufficient.
 TEST(HookInlinePrologue, DefaultFailsOnIntNPrologue)
 {
-    Result<Hook> r = inline_at(InlineRequest{.name = "IntNPrologue", .target = addr_of(INTN_PROLOGUE_BYTES)},
-                               reinterpret_cast<void (*)()>(&noop_detour));
+    dmk_test::ScratchPage page;
+    ASSERT_TRUE(page.ok());
+    Result<Hook> r = install_on_planted_prologue(page, "IntNPrologue", {0xCD, 0x03, 0xC3, 0x90});
     ASSERT_FALSE(r.has_value());
     EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
 }
@@ -284,18 +320,406 @@ TEST(HookInlinePrologue, DefaultInstallsOnNormalTarget)
     EXPECT_TRUE(static_cast<bool>(*r));
 }
 
-// Prologue::Relocate opts back in to the install-anyway behaviour: it logs and installs even on a leading-call
-// prologue.
-TEST(HookInlinePrologue, RelocateInstallsOnUnsafePrologue)
+// A leading rel32 call is relocatable: the backend rewrites its displacement against the trampoline, so both the
+// patched entry and trampoline must preserve their respective behavior under the default policy.
+TEST(HookInlinePrologue, LeadingRel32CallUsesBackendCapability)
 {
-    Result<Hook> r = inline_at(InlineRequest{.name = "RelocateCall",
-                                             .target = addr_of(RELOCATE_CALL_PROLOGUE_BYTES),
+    dmk_test::ScratchPage page;
+    ASSERT_TRUE(page.ok());
+    page.leak(); // this page gets inline-hooked; its address must never be reused (see ScratchPage::leak)
+    plant_leading_call_fixture(page);
+
+    auto target = reinterpret_cast<int (*)()>(page.addr(0));
+
+    // Control: unhooked, the leading call reaches the callee and the target returns its value.
+    ASSERT_EQ(target(), LEADING_CALL_CALLEE_VALUE);
+
+    Result<Hook> r = inline_at(InlineRequest{.name = "LeadingRel32Call", .target = Address{page.addr(0)}},
+                               reinterpret_cast<void (*)()>(&leading_call_detour));
+    ASSERT_TRUE(r.has_value()) << "A backend-relocatable leading E8 rel32 call must not be refused by DMK under the "
+                                  "default policy: "
+                               << r.error().message();
+    Hook h = std::move(*r);
+    ASSERT_TRUE(static_cast<bool>(h));
+
+    // The detour runs instead of the target, proving the patch is live rather than merely reported.
+    EXPECT_EQ(target(), LEADING_CALL_DETOUR_VALUE);
+
+    // The relocated prologue still dispatches its call to the same callee.
+    auto original = h.original<int (*)()>();
+    ASSERT_NE(original, nullptr);
+    EXPECT_EQ(original(), LEADING_CALL_CALLEE_VALUE)
+        << "The relocated leading call must still dispatch to its original callee.";
+
+    // Restoring must put the original prologue back and re-expose the callee's value.
+    ASSERT_TRUE(h.disable().has_value());
+    EXPECT_EQ(target(), LEADING_CALL_CALLEE_VALUE);
+}
+
+// A target whose bytes are not executable committed memory is refused under EVERY policy: Prologue::Relocate opts in to
+// relocating a risky prologue shape, not to letting the backend decode non-code.
+TEST(HookInlinePrologue, RelocatePolicyStillRefusesNonExecutableTarget)
+{
+    alignas(16) static std::uint8_t data_prologue[32] = {0x90, 0x90, 0x90, 0x90, 0x90, 0xC3};
+    Result<Hook> r = inline_at(InlineRequest{.name = "RelocateData",
+                                             .target = addr_of(data_prologue),
                                              .options = Options{.prologue = Prologue::Relocate}},
                                reinterpret_cast<void (*)()>(&noop_detour));
-    ASSERT_TRUE(r.has_value()) << r.error().message();
+    ASSERT_FALSE(r.has_value()) << "Prologue::Relocate must not authorize a non-executable target.";
+    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+}
+
+// Each case hands inline_at a target the backend would decode straight into an access violation, and asserts DMK
+// returns a typed Error instead. These in-process tests exercise both the MinGW VEH and MSVC SEH implementations.
+namespace
+{
+    // Reserves two adjacent pages and commits only the first as executable, so the target's window runs off the end of
+    // committed memory partway through. The uncommitted tail is the fault the backend would have taken.
+    class SplitExecutableRegion
+    {
+    public:
+        SplitExecutableRegion() noexcept
+        {
+            m_base = VirtualAlloc(nullptr, REGION_SIZE, MEM_RESERVE, PAGE_NOACCESS);
+            if (m_base == nullptr)
+            {
+                return;
+            }
+            if (VirtualAlloc(m_base, dmk_test::ScratchPage::PAGE_SIZE, MEM_COMMIT, PAGE_EXECUTE_READWRITE) == nullptr)
+            {
+                (void)VirtualFree(m_base, 0, MEM_RELEASE);
+                m_base = nullptr;
+                return;
+            }
+            std::memset(m_base, 0x90, dmk_test::ScratchPage::PAGE_SIZE);
+        }
+
+        ~SplitExecutableRegion() noexcept
+        {
+            if (m_base != nullptr && m_owned)
+            {
+                (void)VirtualFree(m_base, 0, MEM_RELEASE);
+            }
+        }
+
+        SplitExecutableRegion(const SplitExecutableRegion &) = delete;
+        SplitExecutableRegion &operator=(const SplitExecutableRegion &) = delete;
+        SplitExecutableRegion(SplitExecutableRegion &&) = delete;
+        SplitExecutableRegion &operator=(SplitExecutableRegion &&) = delete;
+
+        [[nodiscard]] bool ok() const noexcept { return m_base != nullptr; }
+
+        [[nodiscard]] std::uintptr_t committed_end() const noexcept
+        {
+            return reinterpret_cast<std::uintptr_t>(m_base) + dmk_test::ScratchPage::PAGE_SIZE;
+        }
+
+        /// Abandons the region so it is never freed; required once anything here has been hooked (ScratchPage::leak).
+        void retire() noexcept { m_owned = false; }
+
+    private:
+        static constexpr std::size_t REGION_SIZE = dmk_test::ScratchPage::PAGE_SIZE * 2;
+
+        void *m_base{nullptr};
+        bool m_owned{true};
+    };
+
+    // Two adjacent committed executable pages, so a planted instruction can genuinely span the boundary between them
+    // while every byte the pre-flight window covers remains valid. Two separate ScratchPages would not do: nothing
+    // makes them adjacent.
+    class AdjacentExecutablePages
+    {
+    public:
+        AdjacentExecutablePages() noexcept
+        {
+            m_base = VirtualAlloc(nullptr, REGION_SIZE, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+            if (m_base != nullptr)
+            {
+                std::memset(m_base, 0xCC, REGION_SIZE);
+            }
+        }
+
+        ~AdjacentExecutablePages() noexcept
+        {
+            if (m_base != nullptr && m_owned)
+            {
+                (void)VirtualFree(m_base, 0, MEM_RELEASE);
+            }
+        }
+
+        AdjacentExecutablePages(const AdjacentExecutablePages &) = delete;
+        AdjacentExecutablePages &operator=(const AdjacentExecutablePages &) = delete;
+        AdjacentExecutablePages(AdjacentExecutablePages &&) = delete;
+        AdjacentExecutablePages &operator=(AdjacentExecutablePages &&) = delete;
+
+        [[nodiscard]] bool ok() const noexcept { return m_base != nullptr; }
+
+        /// The first byte of the second page: an instruction planted before it and long enough spans the boundary.
+        [[nodiscard]] std::uintptr_t boundary() const noexcept
+        {
+            return reinterpret_cast<std::uintptr_t>(m_base) + dmk_test::ScratchPage::PAGE_SIZE;
+        }
+
+        void put(std::uintptr_t address, std::initializer_list<std::uint8_t> bytes) noexcept
+        {
+            auto *destination = reinterpret_cast<std::uint8_t *>(address);
+            std::size_t i = 0;
+            for (const std::uint8_t b : bytes)
+            {
+                destination[i++] = b;
+            }
+        }
+
+        void retire() noexcept { m_owned = false; }
+
+    private:
+        static constexpr std::size_t REGION_SIZE = dmk_test::ScratchPage::PAGE_SIZE * 2;
+
+        void *m_base{nullptr};
+        bool m_owned{true};
+    };
+
+    class RuntimeFunctionRegistration
+    {
+    public:
+        RuntimeFunctionRegistration(std::uintptr_t image_base, DWORD begin, DWORD end) noexcept
+        {
+            m_record.BeginAddress = begin;
+            m_record.EndAddress = end;
+            m_record.UnwindData = 0;
+            m_registered = RtlAddFunctionTable(&m_record, 1, image_base) != FALSE;
+        }
+
+        ~RuntimeFunctionRegistration() noexcept
+        {
+            if (m_registered)
+            {
+                (void)RtlDeleteFunctionTable(&m_record);
+            }
+        }
+
+        RuntimeFunctionRegistration(const RuntimeFunctionRegistration &) = delete;
+        RuntimeFunctionRegistration &operator=(const RuntimeFunctionRegistration &) = delete;
+        RuntimeFunctionRegistration(RuntimeFunctionRegistration &&) = delete;
+        RuntimeFunctionRegistration &operator=(RuntimeFunctionRegistration &&) = delete;
+
+        [[nodiscard]] bool ok() const noexcept { return m_registered; }
+
+    private:
+        RUNTIME_FUNCTION m_record{};
+        bool m_registered{false};
+    };
+
+    Result<Hook> try_install_at(std::uintptr_t target, const char *name)
+    {
+        return inline_at(InlineRequest{.name = name, .target = Address{target}},
+                         reinterpret_cast<void (*)()>(&noop_detour));
+    }
+} // namespace
+
+// An address in reserved-but-uncommitted memory is not executable committed memory.
+TEST(InlineHookFaultProof, ReservedTargetReturnsTypedFailure)
+{
+    void *reserved = VirtualAlloc(nullptr, 0x1000, MEM_RESERVE, PAGE_NOACCESS);
+    ASSERT_NE(reserved, nullptr);
+    Result<Hook> r = try_install_at(reinterpret_cast<std::uintptr_t>(reserved), "ReservedTarget");
+    EXPECT_FALSE(r.has_value()) << "a reserved (uncommitted) target must not be hooked";
+    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+    VirtualFree(reserved, 0, MEM_RELEASE);
+}
+
+// A freed (unmapped) address has no region at all.
+TEST(InlineHookFaultProof, UnmappedTargetReturnsTypedFailure)
+{
+    void *page = VirtualAlloc(nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+    ASSERT_NE(page, nullptr);
+    const auto address = reinterpret_cast<std::uintptr_t>(page);
+    ASSERT_NE(VirtualFree(page, 0, MEM_RELEASE), 0);
+
+    Result<Hook> r = try_install_at(address, "UnmappedTarget");
+    EXPECT_FALSE(r.has_value()) << "an unmapped target must not be hooked";
+    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+}
+
+// PAGE_NOACCESS is committed but neither readable nor executable.
+TEST(InlineHookFaultProof, PageNoAccessReturnsTypedFailure)
+{
+    void *page = VirtualAlloc(nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_NOACCESS);
+    ASSERT_NE(page, nullptr);
+    Result<Hook> r = try_install_at(reinterpret_cast<std::uintptr_t>(page), "NoAccessTarget");
+    EXPECT_FALSE(r.has_value()) << "a PAGE_NOACCESS target must not be hooked";
+    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+    VirtualFree(page, 0, MEM_RELEASE);
+}
+
+// Committed and readable, but not executable: the backend would decode a data page as instructions.
+TEST(InlineHookFaultProof, CommittedNonExecutableReturnsTypedFailure)
+{
+    void *page = VirtualAlloc(nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    ASSERT_NE(page, nullptr);
+    std::memset(page, 0x90, 0x1000);
+    Result<Hook> r = try_install_at(reinterpret_cast<std::uintptr_t>(page), "NonExecutableTarget");
+    EXPECT_FALSE(r.has_value()) << "a committed non-executable target must not be hooked";
+    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+    VirtualFree(page, 0, MEM_RELEASE);
+}
+
+// PAGE_GUARD is the case a protection-bit check alone cannot catch: the region reports execute access, and the fault
+// only appears when the bytes are touched. The gate touches them under the guard, so this must fail closed rather than
+// arm a trap the backend would spring.
+TEST(InlineHookFaultProof, PageGuardReturnsTypedFailure)
+{
+    void *page = VirtualAlloc(nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+    ASSERT_NE(page, nullptr);
+    std::memset(page, 0x90, 0x1000);
+    DWORD old = 0;
+    ASSERT_NE(VirtualProtect(page, 0x1000, PAGE_EXECUTE_READWRITE | PAGE_GUARD, &old), 0);
+
+    Result<Hook> r = try_install_at(reinterpret_cast<std::uintptr_t>(page), "GuardPageTarget");
+    ASSERT_FALSE(r.has_value()) << "a PAGE_GUARD target must not be hooked";
+    // Refused on the protection verdict, not by tripping the guard: the executable-range gate reads PAGE_GUARD out of
+    // the region's protection and rejects before the window is touched. That ordering matters -- touching a guard page
+    // consumes the host's fence, and a pre-flight must not have that side effect on a target it goes on to refuse.
+    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+    VirtualFree(page, 0, MEM_RELEASE);
+}
+
+// A target whose required patch crosses into an uncommitted page must be refused before backend decode.
+TEST(InlineHookFaultProof, FinalBytePageSplitReturnsTypedFailure)
+{
+    SplitExecutableRegion region;
+    ASSERT_TRUE(region.ok());
+
+    Result<Hook> r = try_install_at(region.committed_end() - 4, "PageSplitTarget");
+    EXPECT_FALSE(r.has_value()) << "a target whose decode window crosses into uncommitted memory must not be hooked";
+    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+}
+
+// An instruction that spans a page boundary is ordinary code when both pages are valid, so the window gate must admit
+// it rather than refuse on the boundary alone. This is the false-refusal control for the page-crossing cases above:
+// those prove a window running into an INVALID page is refused, and this proves the crossing itself is not the reason.
+// The prologue's `mov eax, imm32` starts three bytes before the boundary and ends one byte after it, so the backend
+// steals and relocates an instruction that no single page contains.
+TEST(InlineHookFaultProof, InstructionStraddlingTwoValidPagesIsHooked)
+{
+    AdjacentExecutablePages region;
+    ASSERT_TRUE(region.ok());
+    region.retire(); // hooked below; the address must never be reused (see ScratchPage::leak)
+
+    constexpr std::size_t mov_eax_imm32_length = 5;
+    const std::uintptr_t entry = region.boundary() - 3;
+    region.put(entry, {0xB8, static_cast<std::uint8_t>(LEADING_CALL_CALLEE_VALUE & 0xFF),
+                       static_cast<std::uint8_t>((LEADING_CALL_CALLEE_VALUE >> 8) & 0xFF),
+                       static_cast<std::uint8_t>((LEADING_CALL_CALLEE_VALUE >> 16) & 0xFF),
+                       static_cast<std::uint8_t>((LEADING_CALL_CALLEE_VALUE >> 24) & 0xFF), 0xC3});
+    FlushInstructionCache(GetCurrentProcess(), reinterpret_cast<void *>(entry), 16);
+
+    // Assert the straddle rather than assume it: the instruction must begin on the first page and end on the second,
+    // or this proves nothing about page-crossing code.
+    ASSERT_LT(entry, region.boundary());
+    ASSERT_GT(entry + mov_eax_imm32_length, region.boundary());
+
+    auto target = reinterpret_cast<int (*)()>(entry);
+    ASSERT_EQ(target(), LEADING_CALL_CALLEE_VALUE) << "control: the straddling function runs before any hook";
+
+    Result<Hook> r = inline_at(InlineRequest{.name = "StraddlingInstruction", .target = Address{entry}},
+                               reinterpret_cast<void (*)()>(&leading_call_detour));
+    ASSERT_TRUE(r.has_value()) << "an instruction spanning two valid pages must not be refused: "
+                               << r.error().message();
     Hook h = std::move(*r);
-    EXPECT_TRUE(static_cast<bool>(h));
-    h.release(); // the synthetic buffer is not relocatable code; leak the clone rather than restore it
+
+    EXPECT_EQ(target(), LEADING_CALL_DETOUR_VALUE);
+
+    // The stolen instruction crossed the boundary intact: the trampoline still yields the original value.
+    auto original = h.original<int (*)()>();
+    ASSERT_NE(original, nullptr);
+    EXPECT_EQ(original(), LEADING_CALL_CALLEE_VALUE);
+}
+
+// The window bound is a mirrored backend constant, so it is pinned by a test: a target with the full window of
+// executable committed bytes behind it is NOT refused by the gate, while one four bytes short of it is. Asserts the
+// gate's verdict rather than overall install success, because a fully-readable target may still legitimately fail
+// inside the backend (for example when its trampoline cannot be allocated).
+TEST(InlineHookFaultProof, WindowBoundaryMatchesBackendSteal)
+{
+    SplitExecutableRegion region;
+    ASSERT_TRUE(region.ok());
+    const std::uintptr_t committed_end = region.committed_end();
+
+    constexpr std::size_t window = DetourModKit::detail::BACKEND_MAX_STEAL_WINDOW;
+
+    // Exactly the window fits: whatever happens next is the backend's decision, not a window refusal.
+    Result<Hook> fits = try_install_at(committed_end - window, "WindowFits");
+    if (fits.has_value())
+    {
+        region.retire();
+    }
+    if (!fits.has_value())
+    {
+        EXPECT_NE(fits.error().code, ErrorCode::TargetPrologueUnsafe)
+            << "a target with a full steal window of committed executable bytes must not be refused by the gate";
+    }
+
+    // One byte short of the window: the gate must refuse.
+    Result<Hook> shy = try_install_at(committed_end - window + 1, "WindowShort");
+    ASSERT_FALSE(shy.has_value()) << "a target whose window runs past committed memory must be refused";
+    EXPECT_EQ(shy.error().code, ErrorCode::TargetPrologueUnsafe);
+}
+
+// A directly registered function bound is authoritative: even executable bytes cannot be patched past its end.
+TEST(InlineHookFaultProof, ReliableFunctionBoundOverrunReturnsTypedFailure)
+{
+    dmk_test::ScratchPage page;
+    ASSERT_TRUE(page.ok());
+    page.put(0, {0x90, 0x90, 0x90, 0x90, 0xC3});
+
+    constexpr DWORD declared_size = static_cast<DWORD>(DetourModKit::detail::BACKEND_MIN_PATCH - 1);
+    RuntimeFunctionRegistration registration{page.addr(), 0, declared_size};
+    ASSERT_TRUE(registration.ok());
+
+    const DetourModKit::detail::TargetWindowResult verdict =
+        DetourModKit::detail::validate_backend_steal_window(page.addr());
+    ASSERT_EQ(verdict.verdict, DetourModKit::detail::TargetWindowVerdict::BoundOverrun);
+    EXPECT_EQ(verdict.detail, page.addr(declared_size));
+
+    Result<Hook> r = try_install_at(page.addr(), "FunctionBoundOverrun");
+    ASSERT_FALSE(r.has_value());
+    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+}
+
+// Code with no unwind metadata (a JIT buffer, or a leaf function) must NOT be rejected: absence of .pdata is not
+// evidence of an unsafe target. This is the load-bearing non-rejection control for the unwind-bound check.
+TEST(InlineHookFaultProof, LeafCodeWithoutPdataIsNotRejected)
+{
+    dmk_test::ScratchPage page;
+    ASSERT_TRUE(page.ok());
+    page.leak(); // inline-hooked below; the address must never be reused (see ScratchPage::leak)
+    // mov eax, 1; ret -- a complete leaf function, registered with no exception table.
+    page.put(0, {0xB8, 0x01, 0x00, 0x00, 0x00, 0xC3});
+    FlushInstructionCache(GetCurrentProcess(), page.base(), dmk_test::ScratchPage::PAGE_SIZE);
+
+    Result<Hook> r = try_install_at(page.addr(0), "LeafNoPdata");
+    ASSERT_TRUE(r.has_value()) << "code without unwind metadata must not be refused: " << r.error().message();
+    EXPECT_TRUE(static_cast<bool>(*r));
+}
+
+// The range-aware filter must not swallow a DMK fault outside the declared span. A guarded read of an unrelated
+// no-access page still reports its own failure while hook installs continue to work, proving the hook gate's guard did
+// not install a process-wide catch-all.
+TEST(InlineHookFaultProof, UnrelatedFaultIsNotSwallowedByTheHookGate)
+{
+    void *unrelated = VirtualAlloc(nullptr, 0x1000, MEM_COMMIT | MEM_RESERVE, PAGE_NOACCESS);
+    ASSERT_NE(unrelated, nullptr);
+
+    const Address probe{reinterpret_cast<std::uintptr_t>(unrelated)};
+    const Result<std::uint64_t> read = memory::read<std::uint64_t>(probe);
+    ASSERT_FALSE(read.has_value());
+    EXPECT_EQ(read.error().code, ErrorCode::ReadFaulted);
+
+    // A normal install still succeeds afterwards: the guard is scoped, not sticky.
+    Result<Hook> r = inline_at(InlineRequest{.name = "AfterUnrelatedFault", .target = addr_of(&echo)}, &echo_detour);
+    EXPECT_TRUE(r.has_value()) << "an unrelated contained fault must not disturb later hook installs";
+    VirtualFree(unrelated, 0, MEM_RELEASE);
 }
 
 // INLINE duplicate detection (Options::fail_if_already_hooked + is_target_hooked)
@@ -341,17 +765,18 @@ TEST(HookInline, FailIfAlreadyHookedDetectsAbsJumpTrampoline)
     const auto foreign_destination = reinterpret_cast<std::uintptr_t>(GetProcAddress(kernel32, "Sleep"));
     ASSERT_NE(foreign_destination, 0u);
 
-    // Plant 48 B8 <foreign_destination> FF E0 into a readable buffer and hook its address. The create fails at the
-    // foreign-JMP pre-flight, before any backend touches the buffer, so a plain stack buffer is a valid target here.
-    alignas(16) std::array<std::uint8_t, 16> abs_jump{};
-    abs_jump[0] = 0x48; // REX.W
-    abs_jump[1] = 0xB8; // mov rax, imm64
-    std::memcpy(abs_jump.data() + 2, &foreign_destination, sizeof(foreign_destination));
-    abs_jump[10] = 0xFF; // jmp
-    abs_jump[11] = 0xE0; // rax
+    // Plant 48 B8 <foreign_destination> FF E0 on an executable page. It must be real executable memory: the pre-flight
+    // proves the target is code the backend could decode before it asks whether something else has already hooked it,
+    // and a real foreign-hooked function is always executable. Nothing installs here (the heuristic refuses first), so
+    // the page carries no backend trap and is safe to free.
+    dmk_test::ScratchPage page;
+    ASSERT_TRUE(page.ok());
+    page.put(0, {0x48, 0xB8}); // mov rax, imm64
+    std::memcpy(reinterpret_cast<void *>(page.addr(2)), &foreign_destination, sizeof(foreign_destination));
+    page.put(10, {0xFF, 0xE0}); // jmp rax
 
     Result<Hook> r = inline_at(InlineRequest{.name = "AbsJumpForeign",
-                                             .target = Address{reinterpret_cast<std::uintptr_t>(abs_jump.data())},
+                                             .target = Address{page.addr(0)},
                                              .options = Options{.fail_if_already_hooked = true}},
                                &echo_detour);
     ASSERT_FALSE(r.has_value());
@@ -466,7 +891,7 @@ TEST(HookCall, GuardedCallReachesOriginalThroughTrampoline)
 
     // The detour is active so a direct echo(7) is 107; the guarded call routes through the trampoline to the
     // original 7.
-    EXPECT_EQ(echo(7), 107);
+    EXPECT_EQ(call_unfolded(&echo, 7), 107);
     EXPECT_EQ(h.call<int>(7), 7);
 }
 
@@ -502,7 +927,7 @@ TEST(HookCall, MoveAssignTransfersGuardedCallAndTearsDownOld)
     Result<Hook> first = inline_at(InlineRequest{.name = "MoveAssignOld", .target = addr_of(&echo)}, &echo_detour);
     ASSERT_TRUE(first.has_value()) << first.error().message();
     Hook dest = std::move(*first);
-    EXPECT_EQ(echo(7), 107); // echo hooked by dest
+    EXPECT_EQ(call_unfolded(&echo, 7), 107); // echo hooked by dest
 
     Result<Hook> second = inline_at(InlineRequest{.name = "MoveAssignNew", .target = addr_of(&real_hook_target_add)},
                                     &real_hook_detour_add);
@@ -511,13 +936,14 @@ TEST(HookCall, MoveAssignTransfersGuardedCallAndTearsDownOld)
 
     // Move-assign src over dest: dest's old echo hook is torn down (echo restored) and dest adopts src's hook + gate.
     dest = std::move(src);
-    EXPECT_EQ(echo(7), 7);                // dest's overwritten echo hook was restored by the discard teardown
+    // dest's overwritten echo hook was restored by the discard teardown
+    EXPECT_EQ(call_unfolded(&echo, 7), 7);
     EXPECT_FALSE(static_cast<bool>(src)); // src is moved-from / inert
     EXPECT_EQ(src.call<int>(3), int{});   // a guarded call on the moved-from handle is a defined no-op (empty gate)
 
     ASSERT_TRUE(static_cast<bool>(dest));
-    EXPECT_EQ(real_hook_target_add(2, 3), 2 + 3 + 1000); // dest's adopted detour is active
-    EXPECT_EQ(dest.call<int>(2, 3), 5);                  // guarded call reaches the original through the trampoline
+    EXPECT_EQ(call_unfolded(&real_hook_target_add, 2, 3), 2 + 3 + 1000); // dest's adopted detour is active
+    EXPECT_EQ(dest.call<int>(2, 3), 5); // guarded call reaches the original through the trampoline
 }
 
 // try_call is the fail-closed-distinguishing sibling of call: it returns Result<Ret> so a suppressed call surfaces as
@@ -583,7 +1009,7 @@ TEST(HookRelease, ReleaseLeavesHookInstalledAndFiring)
 {
     // Dedicated leak target: this detour stays installed for the process lifetime, so no other test may share it.
     const Address target = addr_of(&leak_target_inline);
-    EXPECT_EQ(leak_target_inline(7), 7); // sanity: clean before the hook
+    EXPECT_EQ(call_unfolded(&leak_target_inline, 7), 7); // sanity: clean before the hook
     Result<Hook> r = inline_at(InlineRequest{.name = "Released", .target = target}, &echo_detour);
     ASSERT_TRUE(r.has_value()) << r.error().message();
     Hook h = std::move(*r);
@@ -591,7 +1017,7 @@ TEST(HookRelease, ReleaseLeavesHookInstalledAndFiring)
     h.release();
     EXPECT_FALSE(static_cast<bool>(h));    // handle disengaged
     EXPECT_TRUE(is_target_hooked(target)); // still installed (leaked intentionally; that is the contract)
-    EXPECT_EQ(leak_target_inline(7), 107); // the detour still fires
+    EXPECT_EQ(call_unfolded(&leak_target_inline, 7), 107); // the detour still fires
     // No restore: leak_target_inline stays hooked for the process lifetime. Intentional leak.
 }
 
@@ -599,19 +1025,19 @@ TEST(HookRelease, ReleaseLeavesHookInstalledAndFiring)
 
 TEST(HookTeardown, DestructorRestoresPrologue)
 {
-    EXPECT_EQ(echo(7), 7); // sanity: unhooked
+    EXPECT_EQ(call_unfolded(&echo, 7), 7); // sanity: unhooked
     {
         Result<Hook> r = inline_at(InlineRequest{.name = "TeardownRestore", .target = addr_of(&echo)}, &echo_detour);
         ASSERT_TRUE(r.has_value()) << r.error().message();
         Hook h = std::move(*r);
-        EXPECT_EQ(echo(7), 107); // hooked
+        EXPECT_EQ(call_unfolded(&echo, 7), 107); // hooked
     }
-    EXPECT_EQ(echo(7), 7); // prologue restored on scope exit
+    EXPECT_EQ(call_unfolded(&echo, 7), 7); // prologue restored on scope exit
 }
 
 TEST(HookTeardown, MovedFromHandleIsInert)
 {
-    EXPECT_EQ(echo(7), 7);
+    EXPECT_EQ(call_unfolded(&echo, 7), 7);
     {
         Result<Hook> r = inline_at(InlineRequest{.name = "MovedFrom", .target = addr_of(&echo)}, &echo_detour);
         ASSERT_TRUE(r.has_value()) << r.error().message();
@@ -623,9 +1049,9 @@ TEST(HookTeardown, MovedFromHandleIsInert)
         // call() through a disengaged handle must be a defined no-op returning the inactive default, not a null
         // dereference of the moved-out Impl (the guarded twin of original<Fn>(), which is already inert here).
         EXPECT_EQ(a.call<int>(7), int{});
-        EXPECT_EQ(echo(7), 107);
+        EXPECT_EQ(call_unfolded(&echo, 7), 107);
     } // only b unhooks; a's destructor is a no-op
-    EXPECT_EQ(echo(7), 7);
+    EXPECT_EQ(call_unfolded(&echo, 7), 7);
 }
 
 // MID create / lifecycle (the MidContext-accessor semantics live in test_mid_hook_context.cpp)
@@ -722,18 +1148,26 @@ TEST(HookMid, FailIfAlreadyHookedRefusesOverInline)
     EXPECT_EQ(mid.error().code, ErrorCode::TargetAlreadyHookedInProcess);
 }
 
-TEST(HookMid, DefaultFailsOnLeadingCallPrologue)
+// A mid hook patches the same prologue through the same pre-flight, so the breakpoint refusal must hold there too.
+// Planted on an executable page so the refusal comes from the breakpoint classifier, not the steal-window gate.
+TEST(HookMid, DefaultFailsOnInt3Prologue)
 {
+    dmk_test::ScratchPage page;
+    ASSERT_TRUE(page.ok());
+    page.put(0, {0xCC, 0xC3, 0x90, 0x90});
     auto detour = [](MidContext &) {};
-    Result<Hook> r = mid_at(MidRequest{.name = "MidCallPrologue", .target = addr_of(CALL_PROLOGUE_BYTES)}, detour);
+    Result<Hook> r = mid_at(MidRequest{.name = "MidInt3Prologue", .target = Address{page.addr(0)}}, detour);
     ASSERT_FALSE(r.has_value());
     EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
 }
 
-TEST(HookMid, DefaultFailsOnInt3Prologue)
+// The mid pre-flight shares the inline steal-window gate: a target that is not executable committed memory is refused
+// before the backend can decode it.
+TEST(HookMid, DefaultRefusesNonExecutableTarget)
 {
+    alignas(16) static std::uint8_t mid_data_prologue[32] = {0x90, 0x90, 0x90, 0x90, 0x90, 0xC3};
     auto detour = [](MidContext &) {};
-    Result<Hook> r = mid_at(MidRequest{.name = "MidInt3Prologue", .target = addr_of(INT3_PROLOGUE_BYTES)}, detour);
+    Result<Hook> r = mid_at(MidRequest{.name = "MidDataTarget", .target = addr_of(mid_data_prologue)}, detour);
     ASSERT_FALSE(r.has_value());
     EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
 }
@@ -750,7 +1184,7 @@ TEST(HookMid, RealCreateModifiesArgViaRcx)
     Hook h = std::move(*r);
 
     // unhooked add(2, 3) == 5; with rcx := 1000 the resumed body computes 1000 + 3.
-    EXPECT_EQ(real_hook_target_add(2, 3), 1000 + 3);
+    EXPECT_EQ(call_unfolded(&real_hook_target_add, 2, 3), 1000 + 3);
 }
 
 TEST(HookMid, RealCreateDisabledRestoresOriginal)
@@ -763,9 +1197,9 @@ TEST(HookMid, RealCreateDisabledRestoresOriginal)
     ASSERT_TRUE(r.has_value()) << r.error().message();
     Hook h = std::move(*r);
 
-    EXPECT_EQ(real_hook_target_add(2, 3), 1000 + 3);
+    EXPECT_EQ(call_unfolded(&real_hook_target_add, 2, 3), 1000 + 3);
     ASSERT_TRUE(h.disable().has_value());
-    EXPECT_EQ(real_hook_target_add(2, 3), 5); // original body again
+    EXPECT_EQ(call_unfolded(&real_hook_target_add, 2, 3), 5); // original body again
 }
 
 TEST(HookMid, TeardownRestoresOriginal)
@@ -773,15 +1207,15 @@ TEST(HookMid, TeardownRestoresOriginal)
 #if !defined(__x86_64__) && !defined(_M_X64)
     GTEST_SKIP() << "requires x86-64 (Win64) calling convention";
 #endif
-    EXPECT_EQ(real_hook_target_mul(4, 5), 20);
+    EXPECT_EQ(call_unfolded(&real_hook_target_mul, 4, 5), 20);
     {
         auto detour = [](MidContext &ctx) { gpr(ctx, Gpr::Rcx) = 10; };
         Result<Hook> r = mid_at(MidRequest{.name = "MidTeardown", .target = addr_of(&real_hook_target_mul)}, detour);
         ASSERT_TRUE(r.has_value()) << r.error().message();
         Hook h = std::move(*r);
-        EXPECT_EQ(real_hook_target_mul(4, 5), 10 * 5);
+        EXPECT_EQ(call_unfolded(&real_hook_target_mul, 4, 5), 10 * 5);
     }
-    EXPECT_EQ(real_hook_target_mul(4, 5), 20); // prologue restored
+    EXPECT_EQ(call_unfolded(&real_hook_target_mul, 4, 5), 20); // prologue restored
 }
 
 TEST(HookMid, ReleaseLeavesMidInstalled)
@@ -806,7 +1240,7 @@ TEST(HookMid, MovedFromMidHandleIsInert)
 #if !defined(__x86_64__) && !defined(_M_X64)
     GTEST_SKIP() << "requires x86-64 (Win64) calling convention";
 #endif
-    EXPECT_EQ(real_hook_target_mul(4, 5), 20);
+    EXPECT_EQ(call_unfolded(&real_hook_target_mul, 4, 5), 20);
     {
         auto detour = [](MidContext &ctx) { gpr(ctx, Gpr::Rcx) = 10; };
         Result<Hook> r = mid_at(MidRequest{.name = "MidMovedFrom", .target = addr_of(&real_hook_target_mul)}, detour);
@@ -815,9 +1249,9 @@ TEST(HookMid, MovedFromMidHandleIsInert)
         Hook b = std::move(a);
         EXPECT_FALSE(static_cast<bool>(a));
         EXPECT_TRUE(static_cast<bool>(b));
-        EXPECT_EQ(real_hook_target_mul(4, 5), 10 * 5);
+        EXPECT_EQ(call_unfolded(&real_hook_target_mul, 4, 5), 10 * 5);
     }
-    EXPECT_EQ(real_hook_target_mul(4, 5), 20);
+    EXPECT_EQ(call_unfolded(&real_hook_target_mul, 4, 5), 20);
 }
 
 // install_all: declarative table with severity + ordering + rollback
@@ -2242,8 +2676,8 @@ TEST(HookStackTest, PushReturnsUsableHandleAndReportsSize)
     // The returned reference reaches the live trampoline (the capture-now pattern) and the detour is armed.
     auto *orig = stored.original<EchoFn>();
     ASSERT_NE(orig, nullptr);
-    EXPECT_EQ(orig(7), 7);   // trampoline yields the original body
-    EXPECT_EQ(echo(7), 107); // detour active while the stack owns the hook
+    EXPECT_EQ(orig(7), 7);                   // trampoline yields the original body
+    EXPECT_EQ(call_unfolded(&echo, 7), 107); // detour active while the stack owns the hook
     // Scope exit restores echo cleanly (single hook, so order is moot but the stack still owns the teardown).
 }
 
@@ -2264,8 +2698,10 @@ namespace
         {
             return 0;
         }
-        // The recursive call resolves to reentrant_target's patched entry, so each level re-enters the detour.
-        return reentrant_target(n - 1) + 1;
+        // The recursive call must resolve to reentrant_target's patched ENTRY so each level re-enters the detour.
+        // Routed through the unfoldable indirection because an optimizer turns direct self-recursion into a loop,
+        // which would re-enter nothing and leave this proving only that the outermost call was hooked.
+        return call_unfolded(&reentrant_target, n - 1) + 1;
     }
 
     int reentrant_detour(int n)
@@ -2336,10 +2772,10 @@ TEST(HookConcurrency, ConcurrentEnableDisableIsRaceSafe)
 
     // The hook survived the storm: brought to a known state, both dispatch paths still work end to end.
     ASSERT_TRUE(h.enable().has_value());
-    EXPECT_EQ(echo(7), 107);      // enabled: the detour adds 100
-    EXPECT_EQ(h.call<int>(7), 7); // original body through the trampoline
+    EXPECT_EQ(call_unfolded(&echo, 7), 107); // enabled: the detour adds 100
+    EXPECT_EQ(h.call<int>(7), 7);            // original body through the trampoline
     ASSERT_TRUE(h.disable().has_value());
-    EXPECT_EQ(echo(7), 7); // disabled: original prologue restored
+    EXPECT_EQ(call_unfolded(&echo, 7), 7); // disabled: original prologue restored
 }
 
 TEST(HookConcurrency, ReentrantCallFromDetourRequiresRecursiveGuard)
@@ -2354,7 +2790,7 @@ TEST(HookConcurrency, ReentrantCallFromDetourRequiresRecursiveGuard)
     // Invoking the hooked entry fires the detour, which forwards through the guarded call(); the original recurses into
     // the hooked entry, re-entering the detour on the same thread. call() holds a per-hook recursive_mutex across the
     // whole invocation, so the nested call() re-locks instead of self-deadlocking. A plain mutex would hang this line.
-    const int result = reentrant_target(4);
+    const int result = call_unfolded(&reentrant_target, 4);
     EXPECT_EQ(result, 4);                                                   // recursion adds 1 four times down to 0
     EXPECT_EQ(s_reentrant_detour_calls.load(std::memory_order_relaxed), 5); // detour fired at depths 4,3,2,1,0
 

--- a/tests/test_hook.cpp
+++ b/tests/test_hook.cpp
@@ -174,6 +174,35 @@ TEST(HookInline, CreateEmptyName)
     EXPECT_EQ(r.error().code, ErrorCode::InvalidArg);
 }
 
+// Every hookable target above must occupy its own address. Several have identical bodies by nature (a leak target is a
+// deliberate copy of the target it stands in for), and a linker that folds identical machine code would collapse them
+// onto one address: the tests that deliberately leak a hook on their own dedicated target would then leave a target
+// another test expects clean permanently hooked, and that test would observe the leaked detour instead of the original.
+// The failure is silent, appears only in optimized builds, and looks like a trampoline defect rather than a test-setup
+// defect, so it is pinned here rather than left to be rediscovered. tests/CMakeLists.txt disables the folding.
+TEST(HookTargetIsolation, DistinctTargetsDoNotShareAnAddress)
+{
+    const std::array<std::pair<const char *, std::uintptr_t>, 8> targets{{
+        {"echo", reinterpret_cast<std::uintptr_t>(&echo)},
+        {"real_hook_target_add", reinterpret_cast<std::uintptr_t>(&real_hook_target_add)},
+        {"real_hook_target_mul", reinterpret_cast<std::uintptr_t>(&real_hook_target_mul)},
+        {"leak_target_inline", reinterpret_cast<std::uintptr_t>(&leak_target_inline)},
+        {"leak_target_disengaged", reinterpret_cast<std::uintptr_t>(&leak_target_disengaged)},
+        {"leak_target_mid", reinterpret_cast<std::uintptr_t>(&leak_target_mid)},
+        {"leak_target_lifecycle", reinterpret_cast<std::uintptr_t>(&leak_target_lifecycle)},
+        {"leak_target_layered", reinterpret_cast<std::uintptr_t>(&leak_target_layered)},
+    }};
+
+    for (std::size_t i = 0; i < targets.size(); ++i)
+    {
+        for (std::size_t j = i + 1; j < targets.size(); ++j)
+        {
+            EXPECT_NE(targets[i].second, targets[j].second) << targets[i].first << " and " << targets[j].first
+                                                            << " share an address, so a hook on either lands on both";
+        }
+    }
+}
+
 // INLINE typed trampoline + enable/disable
 
 TEST(HookInline, TypedTrampolineCallsOriginal)
@@ -666,25 +695,44 @@ TEST(InlineHookFaultProof, WindowBoundaryMatchesBackendSteal)
     EXPECT_EQ(shy.error().code, ErrorCode::TargetPrologueUnsafe);
 }
 
-// A directly registered function bound is authoritative: even executable bytes cannot be patched past its end.
+// A directly registered function bound is authoritative: even executable bytes cannot be patched past its end. The
+// bound must accommodate the LARGER of the backend's two patch forms, because which form runs is decided inside the
+// backend after this validation. A function only the near jump could hook is refused rather than risk the indirect
+// fallback writing past its end, so the boundary is pinned on both sides here.
 TEST(InlineHookFaultProof, ReliableFunctionBoundOverrunReturnsTypedFailure)
 {
     dmk_test::ScratchPage page;
     ASSERT_TRUE(page.ok());
     page.put(0, {0x90, 0x90, 0x90, 0x90, 0xC3});
 
-    constexpr DWORD declared_size = static_cast<DWORD>(DetourModKit::detail::BACKEND_MIN_PATCH - 1);
-    RuntimeFunctionRegistration registration{page.addr(), 0, declared_size};
-    ASSERT_TRUE(registration.ok());
+    // One byte short of the fallback form's patch: refused, even though the near jump alone would have fitted.
+    constexpr DWORD too_short = static_cast<DWORD>(DetourModKit::detail::BACKEND_FALLBACK_MIN_PATCH - 1);
+    {
+        RuntimeFunctionRegistration registration{page.addr(), 0, too_short};
+        ASSERT_TRUE(registration.ok());
 
-    const DetourModKit::detail::TargetWindowResult verdict =
-        DetourModKit::detail::validate_backend_steal_window(page.addr());
-    ASSERT_EQ(verdict.verdict, DetourModKit::detail::TargetWindowVerdict::BoundOverrun);
-    EXPECT_EQ(verdict.detail, page.addr(declared_size));
+        const DetourModKit::detail::TargetWindowResult verdict =
+            DetourModKit::detail::validate_backend_steal_window(page.addr());
+        ASSERT_EQ(verdict.verdict, DetourModKit::detail::TargetWindowVerdict::BoundOverrun)
+            << "a function too short for the fallback patch must be refused, not left to the form the backend picks";
+        EXPECT_EQ(verdict.detail, page.addr(too_short));
 
-    Result<Hook> r = try_install_at(page.addr(), "FunctionBoundOverrun");
-    ASSERT_FALSE(r.has_value());
-    EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+        Result<Hook> r = try_install_at(page.addr(), "FunctionBoundOverrun");
+        ASSERT_FALSE(r.has_value());
+        EXPECT_EQ(r.error().code, ErrorCode::TargetPrologueUnsafe);
+    }
+
+    // Exactly the fallback form's patch: long enough for either form, so the bound must not refuse it.
+    {
+        RuntimeFunctionRegistration registration{page.addr(), 0,
+                                                 static_cast<DWORD>(DetourModKit::detail::BACKEND_FALLBACK_MIN_PATCH)};
+        ASSERT_TRUE(registration.ok());
+
+        const DetourModKit::detail::TargetWindowResult verdict =
+            DetourModKit::detail::validate_backend_steal_window(page.addr());
+        EXPECT_NE(verdict.verdict, DetourModKit::detail::TargetWindowVerdict::BoundOverrun)
+            << "a function long enough for either patch form must not be refused on its bound";
+    }
 }
 
 // Code with no unwind metadata (a JIT buffer, or a leaf function) must NOT be rejected: absence of .pdata is not

--- a/tests/test_memory.cpp
+++ b/tests/test_memory.cpp
@@ -3441,6 +3441,30 @@ TEST_F(MemoryTest, GuardedRead_GuardPageRearmedFailsClosedOnRetry)
     VirtualFree(mem, 0, MEM_RELEASE);
 }
 
+// A cross-page read reports the first inaccessible source address, not merely the span's starting address.
+TEST_F(MemoryTest, GuardedReadReportsFaultingAddress)
+{
+    SYSTEM_INFO system_info{};
+    GetSystemInfo(&system_info);
+    const std::size_t page_size = system_info.dwPageSize;
+
+    auto *memory_base =
+        static_cast<std::byte *>(VirtualAlloc(nullptr, page_size * 2, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
+    ASSERT_NE(memory_base, nullptr);
+    std::memset(memory_base, 0x5A, page_size);
+
+    DWORD old_protection = 0;
+    ASSERT_TRUE(VirtualProtect(memory_base + page_size, page_size, PAGE_NOACCESS, &old_protection));
+
+    std::array<std::byte, 8> output{};
+    volatile std::uintptr_t fault_address = 0;
+    EXPECT_FALSE(detail::guarded_read_bytes(reinterpret_cast<std::uintptr_t>(memory_base + page_size - 4),
+                                            output.data(), output.size(), &fault_address));
+    EXPECT_EQ(fault_address, reinterpret_cast<std::uintptr_t>(memory_base + page_size));
+
+    (void)VirtualFree(memory_base, 0, MEM_RELEASE);
+}
+
 // Several threads racing shutdown_cache must not both join the same cleanup std::thread (a std::system_error out of a
 // noexcept function -> std::terminate). The join mutex lets exactly one caller join; the rest skip.
 TEST_F(MemoryTest, ShutdownCache_ConcurrentCallersJoinExactlyOnceNoTerminate)


### PR DESCRIPTION
## Summary

Inline and mid hook installs validated at most the target's first byte, while the backend decodes up to 28 bytes past it with no readability or protection check of its own. An invalid or concurrently unmapped target therefore faulted inside backend code and killed the host. Installs now validate the backend's full steal window (executable, committed, readable) before the backend is called, and again immediately before patching, returning a typed error instead.

DMK also refused any prologue beginning with `E8` under the default policy. That rejection was based on a false premise: the backend recovers the call's absolute destination and rewrites the displacement against the trampoline, so a relocated leading call reaches the same callee. Capability is now decided by the backend's own typed failure rather than by a first-byte ban.

## Why it matters

- A target the backend cannot safely decode is refused rather than crashing the game.
- Real functions that begin with a relative call are now hookable.
- `enable`/`disable` verify the target bytes actually changed, so a backend success that wrote no patch fails typed instead of leaving a caller believing an unarmed hook is live.
- Guarded reads report the address that faulted, so a refusal names the byte that failed.

## Notes

- The fault boundary validates *before* the backend call and never around it. DMK's guards recover without running destructors, so wrapping a backend call would abandon its mutexes locked and strand the target page writable-executable.
- No new public API and no ABI change. Behaviour changes: leading-call targets now install; targets that are not readable executable committed memory are refused under every prologue policy.
- Preflight narrows the unmap race and attributes the failure; it does not close it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hook installation now validates that target code is executable, committed, readable, and fully within its function boundary.
  * Unsafe or unsupported targets are rejected with clearer typed errors and diagnostics.
  * Hook enable/disable operations now verify that code was actually patched or restored before updating status.

* **Documentation**
  * Clarified prologue safety rules, relative-call relocation behavior, target memory requirements, and override options.

* **Tests**
  * Expanded coverage for boundary validation, fault reporting, prologue handling, and hook lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->