### PR TITLE
fix(hook): fault-contain VMT publication and make stacked teardown exact

### DIFF
--- a/docs/guides/hooking/vmt-hook-config.md
+++ b/docs/guides/hooking/vmt-hook-config.md
@@ -34,11 +34,13 @@ struct VmtOptions
 };
 ```
 
-Both fields default to `false` to keep the permissive baseline: no pre-flight checks, while pre-existing failures (null or unreadable object, empty name, backend errors) still apply. Opt in to the safety net on mods that exclusively target well-formed C++ vtables. `vmt_for(name, object)` with the options argument omitted uses a default-constructed `VmtOptions{}` (both knobs off).
+Both fields default to `false` to keep the permissive baseline for the *policy* checks. They do not switch off object-word validation: `vmt_for` and `apply_to` always refuse, with `InvalidObject`, an object whose vptr word is unreadable or not currently writable. `vmt_for` additionally refuses an unreadable vtable or RTTI header prefix and a table with no callable slot, because creating a hook clones that memory. `apply_to` installs an existing clone and therefore does not require the displaced vtable to be cloneable; only `fail_on_non_function_pointer` inspects its first slot. The backend reads and rewrites the object word with no check of its own, so object-word validation is not optional. What the two knobs add is refusal of objects that are *valid* but suspicious. `vmt_for(name, object)` with the options argument omitted uses a default-constructed `VmtOptions{}` (both knobs off).
+
+A non-writable object word is reported, never acquired: DetourModKit will not `VirtualProtect` an object writable to force a clone onto it. The protection belongs to the object's owner, and widening it would outlive the hook.
 
 ## 3. `fail_if_already_hooked` semantics
 
-When `true`, `vmt_for` (and `VmtHook::apply_to`) checks the object's current vptr against the cloned vtables tracked by this kit. A match means "this object's vptr already points at a clone installed by us"; a second `vmt_for` would silently layer another clone on top of the first. The guard returns `ErrorCode::HookAlreadyExists` for `vmt_for`; for `apply_to` it is a no-op success when the clone belongs to the named hook (the desired post-state already holds) and a failure when the clone belongs to a different VMT hook of this kit.
+When `true`, `vmt_for` (and `VmtHook::apply_to`) checks the object's current vptr against the cloned vtables tracked by this kit. A match means "this object's vptr already points at a clone installed by us"; a second `vmt_for` would silently layer another clone on top of the first. The guard returns `ErrorCode::HookAlreadyExists` for `vmt_for`; for `apply_to` it is a no-op success only when this hook applied the object and it is still on the clone (the desired post-state already holds), and a failure when the clone belongs to a different VMT hook of this kit. An object carrying this hook's clone that this hook never applied is refused too, under every option value: see section 6.
 
 The detection is local to this statically-linked DMK kit. A VMT hook installed by another DMK consumer in the same process is not visible to this check, exactly the same scoping rule as the inline hook's `is_target_hooked`.
 
@@ -84,14 +86,24 @@ The pre-flight is intentionally conservative: a real function whose first byte i
 
 `vh.release()` detaches the handle: the clone stays installed for the process lifetime and the destructor no longer restores it. Use it only when you intend the VMT hook to outlive its owner.
 
+### Destroy stacked VMT hooks newest-first
+
+When two hooks are layered on one object, the second clones the first's clone and records it as the table it will put back. Destroying them newest-first unwinds that cleanly and the object ends on its real vtable.
+
+Destroying them oldest-first cannot: the older hook's table is still the newer hook's recorded original, so freeing it would leave the newer hook restoring released memory, and the object would dispatch through it. DetourModKit detects this at teardown, restores other objects that still point directly at the older clone, leaks the outranked clone rather than free it, counts the leak on `diagnostics::LeakSubsystem::HookManager`, and logs a warning naming the hook. The stacked object then stays on the leaked clone -- still dispatching correctly, but never returning to its original table. That is the deliberate trade: a permanent leak of one vtable-sized allocation instead of a use-after-free. Order your teardown to avoid it; the same rule and the same reasoning apply to stacked inline hooks on one target.
+
+`remove_from` on an outranked object follows the same rule: it reports success but leaves the object on the newer hook's clone and keeps the restoration dependency, so the object is restored later if the newer hook unwinds first, and the clone is leaked if it does not.
+
 ## 6. Interaction with `apply_to`
 
 `vh.apply_to(object, opts)` installs the existing clone on an additional object and re-runs both checks against the vptr currently on that object:
 
-- `fail_if_already_hooked` short-circuits to a no-op success when the object is already on this hook's clone (the desired post-state already holds), and fails when the object is on a clone owned by a different VMT hook of this kit.
+- `fail_if_already_hooked` short-circuits to a no-op success when this hook applied the object and it is still on the clone (the desired post-state already holds), and fails when the object is on a clone owned by a different VMT hook of this kit.
 - `fail_on_non_function_pointer` decodes the first slot of the vtable currently on the object (the one about to be replaced) and refuses to install the cloned vptr when the slot is not a real function pointer.
 
 `apply_to`'s "no-op when already applied" is a deliberate difference from `vmt_for`'s "refuse with HookAlreadyExists". `vmt_for` is the path that establishes a clone; re-creating on the same vptr is always wrong. `apply_to` is the path that installs an existing clone on additional objects; calling it twice on the same object is a no-op the caller may legitimately want to express.
+
+Independently of the policy knobs, `apply_to` returns `HookAlreadyExists` whenever the hook cannot name the vptr it would displace: the object already carries this clone but was never applied through this handle, or the object has since moved off the vptr this hook recorded for it (usually a newer VMT hook layered on it, but the check is on the recorded vptr, not on who moved it, so a foreign hooking library or the host itself trips it too). Both are refused under every `VmtOptions` value, because the hook restores from what it recorded: admitting either would leave it holding a vptr the object never had, and writing that back at teardown is the use-after-free the newest-first rule above exists to avoid. Where the mover was a newer VMT hook, re-installing the older clone over it would also silently discard that hook's slots, since the older clone was copied before it existed.
 
 ## 7. Per-method typed hooking
 

--- a/include/DetourModKit/hook.hpp
+++ b/include/DetourModKit/hook.hpp
@@ -870,6 +870,13 @@ namespace DetourModKit
          * @param object The seed object whose vtable is cloned and whose vptr is swapped to the clone.
          * @param options Create-time policy (fail-if-already-hooked, pre-flight slot decode).
          * @return The RAII @ref VmtHook on success, or an Error (InvalidObject, HookAlreadyExists, BackendFailed).
+         *         InvalidObject covers an unreadable or non-writable object word, an unreadable vtable or RTTI header
+         *         prefix, and a table with no callable slot; those are refused under every @p options value, since the
+         *         alternative is a fault this Result could not report.
+         * @warning Swapping the vptr is a bare pointer write with no thread protection, exactly as in
+         *          @ref VmtHook::apply_to: clone during setup or a host-quiesced window, not against an object a game
+         *          thread is actively calling into. Validation refuses an object it can prove unsafe; it does not make
+         *          a concurrently-used object safe.
          */
         [[nodiscard]] Result<VmtHook> vmt_for(std::string name, void *object, VmtOptions options = {});
 
@@ -878,15 +885,12 @@ namespace DetourModKit
          * @brief Move-only RAII handle for a cloned (hooked) vtable applied to one or more live objects.
          * @details VMT hooking is many-to-many (one cloned vtable, applied to M live objects) and has NO
          *          enable/disable (a backend VmtHook limitation), so it is a dedicated owning type rather than a flat
-         *          @ref Hook. @ref vmt_for clones the seed object's vtable; @ref apply_to swaps the clone onto another
-         *          object of the same class; the destructor restores every patched vptr (newest-first across applied
-         *          objects). Individual virtual methods are redirected with @ref hook_method (by vtable index), the
-         *          pre-hook slot is recovered typed with @ref original, and a single method hook is lifted with
-         *          @ref remove_method. Because the redirect lives in the one cloned vtable, a @ref hook_method takes
-         *          effect on every object the clone is currently applied to, and a later @ref apply_to inherits it.
-         * @warning Restoring a vptr is a bare pointer write with no thread protection: the caller must guarantee no
-         *          thread is dispatching through a cloned slot across create/apply/remove, that each applied object
-         *          outlives the hook, and that the object's vptr was not re-layered since the clone went on.
+         *          @ref Hook. Because the redirect lives in the one cloned vtable, a @ref hook_method takes effect on
+         *          every object the clone is currently applied to, and a later @ref apply_to inherits it.
+         * @warning Swapping or restoring a vptr is a bare pointer write with no thread protection: the caller must
+         *          guarantee no thread is dispatching through a cloned slot across create/apply/remove, and that each
+         *          applied object outlives the hook. Fault containment is not an ownership protocol -- an object word
+         *          proven valid at the pre-flight can still be freed by its owner a moment later.
          * @note Concurrency: object-vptr transitions in @ref vmt_for / @ref apply_to / @ref remove_from / teardown are
          *       serialized by a setup-time object gate so duplicate create/apply checks and swaps are one ordered
          *       operation. @ref original copies the pre-hook slot pointer out under a shared-read lock and returns it,
@@ -904,7 +908,15 @@ namespace DetourModKit
             VmtHook &operator=(const VmtHook &) = delete;
 
             /**
-             * @brief Restores the original vptr on every applied object (newest-first), unless released or moved-from.
+             * @brief Restores the original vptr on every applied object, unless released, moved-from, or outranked.
+             * @details Restoration requires proving every applied object still points at this clone. An object that
+             *          does not has usually had a newer @ref VmtHook layered on top, and that successor holds this
+             *          clone's table as the original it will restore, so freeing this clone would leave it restoring
+             *          released memory. Objects still pointing at this clone are restored, then the clone is leaked
+             *          for the unsafe objects. The same branch covers an unreadable or otherwise unexpected object
+             *          word because its dependency state cannot be established safely. The leak is counted on
+             *          @ref diagnostics::LeakSubsystem::HookManager and logged with the hook's name. Destroy VMT hooks
+             *          newest-first to get the original table back.
              * @note Explicitly noexcept (a destructor is implicitly noexcept already): like @ref Hook::~Hook it runs
              *       from loader-lock teardown, so the no-throw contract is pinned at the declaration.
              */
@@ -920,7 +932,12 @@ namespace DetourModKit
              * @brief Applies the cloned vtable to an additional live object, swapping its vptr.
              * @param object The object to put on the clone.
              * @param options Apply-time policy (fail-if-already-hooked, pre-flight slot decode).
-             * @return Success, or an Error (InvalidObject, HookAlreadyExists, BackendFailed).
+             * @return Success, or an Error (InvalidObject, HookAlreadyExists, BackendFailed). An unreadable or
+             *         non-writable object word is InvalidObject under every @p options value. HookAlreadyExists is
+             *         likewise returned under every @p options value when this handle cannot name what it would
+             *         displace: @p object already carries this clone but was never applied here, or @p object has
+             *         since moved off the vptr this handle recorded for it (usually a newer @ref VmtHook layered on
+             *         it). Re-applying either would leave teardown restoring a vptr @p object never had.
              * @warning Swapping @p object's vptr is a bare pointer write with no dispatch-time synchronization (the
              *          class @warning covers the full contract): it is safe only while no thread is dispatching a
              *          virtual call through @p object. Apply during setup or a host-quiesced window, not against an
@@ -932,8 +949,13 @@ namespace DetourModKit
              * @brief Restores the original vptr on one applied object.
              * @param object The object to restore.
              * @return Success, or InvalidObject for a null @p object / InvalidHookState for a disengaged handle.
-             * @details Best-effort restore: removing an object that is not on this clone is a harmless no-op, so a
-             *          successful return does not assert that @p object was previously applied.
+             * @details Restoring requires @p object to be provably on this clone, and Success does not assert that it
+             *          was. @p object may never have been applied here (a harmless no-op), or its word may not read
+             *          back as this clone (usually a newer @ref VmtHook layered on it), or the word may not be
+             *          provably writable. In every case but the first, @p object is left where it is and this handle
+             *          keeps the restoration dependency: teardown restores @p object if its word reads back as this
+             *          clone by then, and otherwise leaks this clone rather than free a table a successor records as
+             *          its original.
              * @warning Restoring @p object's vptr is a bare pointer write with no protection against an in-flight
              *          dispatch through the slot (see the class @warning): quiesce the object, or restore only at a
              *          safe host-shutdown point, before removing it.

--- a/include/DetourModKit/hook.hpp
+++ b/include/DetourModKit/hook.hpp
@@ -909,14 +909,13 @@ namespace DetourModKit
 
             /**
              * @brief Restores the original vptr on every applied object, unless released, moved-from, or outranked.
-             * @details Restoration requires proving every applied object still points at this clone. An object that
-             *          does not has usually had a newer @ref VmtHook layered on top, and that successor holds this
-             *          clone's table as the original it will restore, so freeing this clone would leave it restoring
-             *          released memory. Objects still pointing at this clone are restored, then the clone is leaked
-             *          for the unsafe objects. The same branch covers an unreadable or otherwise unexpected object
-             *          word because its dependency state cannot be established safely. The leak is counted on
-             *          @ref diagnostics::LeakSubsystem::HookManager and logged with the hook's name. Destroy VMT hooks
-             *          newest-first to get the original table back.
+             * @details A writable object still on this clone is restored to its binding's original vptr.
+             *          An object already at that original needs no write and releases the binding safely even when its
+             *          word is not writable. Any other or unreadable value retains the dependency because a successor
+             *          may still record this clone as the table it will restore. Safely restorable peers are restored,
+             *          then an unresolved dependency leaks the clone rather than free a table still in use. The leak
+             *          is counted on @ref diagnostics::LeakSubsystem::HookManager and logged with the hook's name.
+             *          Destroy VMT hooks newest-first to get the original table back.
              * @note Explicitly noexcept (a destructor is implicitly noexcept already): like @ref Hook::~Hook it runs
              *       from loader-lock teardown, so the no-throw contract is pinned at the declaration.
              */
@@ -949,13 +948,12 @@ namespace DetourModKit
              * @brief Restores the original vptr on one applied object.
              * @param object The object to restore.
              * @return Success, or InvalidObject for a null @p object / InvalidHookState for a disengaged handle.
-             * @details Restoring requires @p object to be provably on this clone, and Success does not assert that it
-             *          was. @p object may never have been applied here (a harmless no-op), or its word may not read
-             *          back as this clone (usually a newer @ref VmtHook layered on it), or the word may not be
-             *          provably writable. In every case but the first, @p object is left where it is and this handle
-             *          keeps the restoration dependency: teardown restores @p object if its word reads back as this
-             *          clone by then, and otherwise leaks this clone rather than free a table a successor records as
-             *          its original.
+             * @details Success does not assert that @p object was applied here; an untracked object is a harmless
+             *          no-op. For a tracked binding, a writable object on this clone is restored to the recorded
+             *          original vptr. An object already at that original needs no write and releases the binding even
+             *          when its word is not writable. Any other or unreadable value is left unchanged and retains the
+             *          dependency, so teardown can restore it if it returns to this clone or leak the clone rather than
+             *          free a table a successor may still restore.
              * @warning Restoring @p object's vptr is a bare pointer write with no protection against an in-flight
              *          dispatch through the slot (see the class @warning): quiesce the object, or restore only at a
              *          safe host-shutdown point, before removing it.

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -1540,6 +1540,40 @@ namespace DetourModKit
                     (void)m_impl.release();
                     return;
                 }
+                // Restore every object whose state is known. A different vptr may belong to a successor that recorded
+                // this clone as its original; an unreadable or non-writable word is equally unsafe to overwrite.
+                std::size_t unrestorable = 0;
+                for (const auto &binding : m_impl->object_bindings)
+                {
+                    const DetourModKit::detail::ObjectWordResult word = DetourModKit::detail::validate_vmt_object_word(
+                        reinterpret_cast<std::uintptr_t>(binding.object));
+                    if (word.verdict != DetourModKit::detail::ObjectWordVerdict::Unreadable &&
+                        word.vptr == binding.original_vptr)
+                    {
+                        m_impl->backend.remove(binding.object);
+                        continue;
+                    }
+                    if (word.verdict == DetourModKit::detail::ObjectWordVerdict::Ok &&
+                        word.vptr == m_impl->cloned_vptr_base)
+                    {
+                        *reinterpret_cast<std::uintptr_t *>(binding.object) = binding.original_vptr;
+                        m_impl->backend.remove(binding.object);
+                        continue;
+                    }
+                    ++unrestorable;
+                }
+                if (unrestorable > 0)
+                {
+                    (void)log().try_log(LogLevel::Warning,
+                                        "hook::~VmtHook: VMT hook '{}' destroyed while {} of its {} object(s) could "
+                                        "not be provably restored to their original vtable; leaked this clone to "
+                                        "avoid a vtable use-after-free. Destroy VMT hooks newest-first to restore "
+                                        "the original table.",
+                                        std::string_view{name}, unrestorable, m_impl->object_bindings.size());
+                    diagnostics::record_intentional_leak(diagnostics::LeakSubsystem::HookManager);
+                    (void)m_impl.release();
+                    return;
+                }
                 self_ref = static_cast<HMODULE>(m_impl->self_ref);
                 m_impl.reset();
             }
@@ -1581,40 +1615,62 @@ namespace DetourModKit
             // observes the object either fully on the clone or not yet. The process-wide object gate serializes this
             // vptr transition against vmt_for/apply/remove on other handles targeting the same object.
             std::unique_lock<DetourModKit::detail::SrwSharedMutex> gate(m_impl->method_mutex);
-            // Read the object's current vptr once, up front, under the fault guard. Both the opt-in strict checks
-            // (fail_if_already_hooked / fail_on_non_function_pointer) and the always-on clone-of-clone detection in the
-            // permissive branch below consume it. A read fault is only actionable on the strict path (it fails closed);
-            // on the permissive default a malformed object is caught downstream by the backend apply, so a failed read
-            // there just skips the best-effort warning rather than changing the permissive contract.
-            const std::optional<std::uintptr_t> current_vptr =
-                DetourModKit::detail::guarded_read<std::uintptr_t>(reinterpret_cast<std::uintptr_t>(object));
+            // The backend's apply reads the object word and stores a new vptr into it with no check of either, so this
+            // gate is not a policy: it runs under every option set, because the alternative is a host fault the handle
+            // cannot report. It is taken before any backend call, never around one.
+            const DetourModKit::detail::ObjectWordResult word =
+                DetourModKit::detail::validate_vmt_object_word(reinterpret_cast<std::uintptr_t>(object));
+            if (word.verdict != DetourModKit::detail::ObjectWordVerdict::Ok)
+            {
+                return std::unexpected(Error{ErrorCode::InvalidObject, "hook::vmt_apply", word.detail});
+            }
+            const std::uintptr_t current_vptr = word.vptr;
+            // Locate this object's restoration binding before any policy branch: both policies need it to tell a
+            // truthful re-apply from one whose recorded original no longer describes the object. Teardown restores
+            // from the binding, so a binding that names a vptr the object never had is a use-after-free waiting to
+            // happen, and refusing is the only outcome that keeps every recorded original true.
+            const auto binding = std::find_if(m_impl->object_bindings.begin(), m_impl->object_bindings.end(),
+                                              [object](const auto &entry) -> bool { return entry.object == object; });
+            const bool already_tracked = binding != m_impl->object_bindings.end();
+            if (current_vptr == m_impl->cloned_vptr_base)
+            {
+                if (!already_tracked)
+                {
+                    // This handle did not publish the observed clone and holds no original vptr for this object.
+                    // Binding it now would record the clone base as its own original, and teardown would then read
+                    // the object as restored and free the clone out from under it.
+                    return std::unexpected(Error{ErrorCode::HookAlreadyExists, "hook::vmt_apply", current_vptr});
+                }
+            }
+            else if (already_tracked && current_vptr != binding->original_vptr)
+            {
+                // Something moved the object off the vptr this handle recorded, usually a newer layer, so the binding
+                // no longer names what an apply here would displace. Where it was a newer layer, republishing would
+                // also discard that layer's slots, since this clone was copied before it existed.
+                return std::unexpected(Error{ErrorCode::HookAlreadyExists, "hook::vmt_apply", current_vptr});
+            }
             if (options.fail_if_already_hooked || options.fail_on_non_function_pointer)
             {
-                if (!current_vptr)
-                {
-                    return std::unexpected(
-                        Error{ErrorCode::InvalidObject, "hook::vmt_apply", reinterpret_cast<std::uintptr_t>(object)});
-                }
                 if (options.fail_if_already_hooked)
                 {
-                    if (*current_vptr == m_impl->cloned_vptr_base)
+                    if (current_vptr == m_impl->cloned_vptr_base)
                     {
                         // Already on this hook's own clone -- a clean no-op rather than a silent re-apply.
                         return {};
                     }
-                    if (DetourModKit::detail::HookLedger::instance().is_vmt_clone_base(*current_vptr))
+                    if (DetourModKit::detail::HookLedger::instance().is_vmt_clone_base(current_vptr))
                     {
                         // On a clone owned by a different VmtHook of this kit: refuse rather than chain on top.
-                        return std::unexpected(Error{ErrorCode::HookAlreadyExists, "hook::vmt_apply", *current_vptr});
+                        return std::unexpected(Error{ErrorCode::HookAlreadyExists, "hook::vmt_apply", current_vptr});
                     }
                 }
                 if (options.fail_on_non_function_pointer)
                 {
                     const std::optional<std::uintptr_t> slot0 =
-                        DetourModKit::detail::guarded_read<std::uintptr_t>(*current_vptr);
+                        DetourModKit::detail::guarded_read<std::uintptr_t>(current_vptr);
                     if (!slot0)
                     {
-                        return std::unexpected(Error{ErrorCode::InvalidObject, "hook::vmt_apply", *current_vptr});
+                        return std::unexpected(Error{ErrorCode::InvalidObject, "hook::vmt_apply", current_vptr});
                     }
                     if (!looks_like_function_vmt_slot(*slot0))
                     {
@@ -1622,8 +1678,8 @@ namespace DetourModKit
                     }
                 }
             }
-            else if (current_vptr && *current_vptr != m_impl->cloned_vptr_base &&
-                     DetourModKit::detail::HookLedger::instance().is_vmt_clone_base(*current_vptr))
+            else if (current_vptr != m_impl->cloned_vptr_base &&
+                     DetourModKit::detail::HookLedger::instance().is_vmt_clone_base(current_vptr))
             {
                 // Permissive default (no opt-in): the object's vptr is already a clone base owned by another VmtHook of
                 // this kit. Chaining on top reads that first clone as the pristine vtable, so the first mod's hooked
@@ -1638,7 +1694,20 @@ namespace DetourModKit
                     "another DMK VMT hook; that clone's hooked slots will be captured as this hook's original. Set "
                     "VmtOptions::fail_if_already_hooked to refuse instead.",
                     std::string_view{m_impl->name}, format::format_address(reinterpret_cast<std::uintptr_t>(object)),
-                    format::format_address(*current_vptr));
+                    format::format_address(current_vptr));
+            }
+            // Reserve the restoration binding before backend publication. Growing afterward could throw with the
+            // object already on the clone but absent from the state teardown needs. A benign re-apply needs no slot.
+            if (!already_tracked)
+            {
+                try
+                {
+                    m_impl->object_bindings.reserve(m_impl->object_bindings.size() + 1);
+                }
+                catch (const std::bad_alloc &)
+                {
+                    return std::unexpected(Error{ErrorCode::OutOfMemory, "hook::vmt_apply"});
+                }
             }
             // The backend tracks the applied object in an internal container, so apply can throw bad_alloc; contain it
             // so a failed apply returns an Error instead of unwinding out of the handle method.
@@ -1654,6 +1723,11 @@ namespace DetourModKit
             {
                 return std::unexpected(
                     Error{ErrorCode::BackendFailed, "hook::vmt_apply", reinterpret_cast<std::uintptr_t>(object)});
+            }
+            if (!already_tracked)
+            {
+                // Cannot throw: the reserve above guaranteed the capacity.
+                m_impl->object_bindings.push_back({object, current_vptr});
             }
             return {};
         }
@@ -1677,9 +1751,30 @@ namespace DetourModKit
             // the reader sees the clone either fully applied to @p object or fully removed, never a torn transition.
             // The object gate serializes the actual vptr restore against other handle-level vptr transitions.
             std::unique_lock<DetourModKit::detail::SrwSharedMutex> gate(m_impl->method_mutex);
-            // Best-effort restore: the backend restores the original vptr on @p object, and removing an object that is
-            // not on this clone is a harmless no-op.
+            const auto binding = std::find_if(m_impl->object_bindings.begin(), m_impl->object_bindings.end(),
+                                              [object](const auto &entry) -> bool { return entry.object == object; });
+            if (binding == m_impl->object_bindings.end())
+            {
+                m_impl->backend.remove(object);
+                return {};
+            }
+
+            // SafetyHook discards its original-vptr entry even when a successor prevents restoration. Keep the full
+            // binding here and restore from it if that successor has already unwound back onto this clone.
+            const DetourModKit::detail::ObjectWordResult word =
+                DetourModKit::detail::validate_vmt_object_word(reinterpret_cast<std::uintptr_t>(object));
+            if (word.verdict == DetourModKit::detail::ObjectWordVerdict::Ok && word.vptr == m_impl->cloned_vptr_base)
+            {
+                *reinterpret_cast<std::uintptr_t *>(object) = binding->original_vptr;
+            }
             m_impl->backend.remove(object);
+
+            const std::optional<std::uintptr_t> after =
+                DetourModKit::detail::guarded_read<std::uintptr_t>(reinterpret_cast<std::uintptr_t>(object));
+            if (after && *after == binding->original_vptr)
+            {
+                m_impl->object_bindings.erase(binding);
+            }
             return {};
         }
 
@@ -1838,31 +1933,30 @@ namespace DetourModKit
             {
                 return std::unexpected(Error{ErrorCode::UnknownError, "hook::vmt_for"});
             }
-            // Read the object's current vptr once, up front, under the fault guard: the opt-in strict checks and the
-            // always-on clone-of-clone detection in the permissive branch both consume it. A read fault is only
-            // actionable on the strict path (it fails closed); on the permissive default the malformed object is caught
-            // by the slot walk / header-prefix guard below, so a failed read there only skips the best-effort warning.
-            const std::optional<std::uintptr_t> current_vptr =
-                DetourModKit::detail::guarded_read<std::uintptr_t>(reinterpret_cast<std::uintptr_t>(object));
+            // The backend's create reads the object word and stores the clone's vptr into it with no check of either,
+            // so this gate is not a policy: it runs under every option set, because the alternative is a host fault
+            // the Result cannot report. It is taken before any backend call, never around one.
+            const DetourModKit::detail::ObjectWordResult word =
+                DetourModKit::detail::validate_vmt_object_word(reinterpret_cast<std::uintptr_t>(object));
+            if (word.verdict != DetourModKit::detail::ObjectWordVerdict::Ok)
+            {
+                return std::unexpected(Error{ErrorCode::InvalidObject, "hook::vmt_for", word.detail});
+            }
+            const std::uintptr_t current_vptr = word.vptr;
             if (options.fail_if_already_hooked || options.fail_on_non_function_pointer)
             {
-                if (!current_vptr)
-                {
-                    return std::unexpected(
-                        Error{ErrorCode::InvalidObject, "hook::vmt_for", reinterpret_cast<std::uintptr_t>(object)});
-                }
                 if (options.fail_if_already_hooked &&
-                    DetourModKit::detail::HookLedger::instance().is_vmt_clone_base(*current_vptr))
+                    DetourModKit::detail::HookLedger::instance().is_vmt_clone_base(current_vptr))
                 {
-                    return std::unexpected(Error{ErrorCode::HookAlreadyExists, "hook::vmt_for", *current_vptr});
+                    return std::unexpected(Error{ErrorCode::HookAlreadyExists, "hook::vmt_for", current_vptr});
                 }
                 if (options.fail_on_non_function_pointer)
                 {
                     const std::optional<std::uintptr_t> slot0 =
-                        DetourModKit::detail::guarded_read<std::uintptr_t>(*current_vptr);
+                        DetourModKit::detail::guarded_read<std::uintptr_t>(current_vptr);
                     if (!slot0)
                     {
-                        return std::unexpected(Error{ErrorCode::InvalidObject, "hook::vmt_for", *current_vptr});
+                        return std::unexpected(Error{ErrorCode::InvalidObject, "hook::vmt_for", current_vptr});
                     }
                     if (!looks_like_function_vmt_slot(*slot0))
                     {
@@ -1870,7 +1964,7 @@ namespace DetourModKit
                     }
                 }
             }
-            else if (current_vptr && DetourModKit::detail::HookLedger::instance().is_vmt_clone_base(*current_vptr))
+            else if (DetourModKit::detail::HookLedger::instance().is_vmt_clone_base(current_vptr))
             {
                 // Permissive default: cloning an object already on another kit VMT clone reads that clone as the
                 // pristine vtable, baking the first mod's hooked slots into this hook's original snapshot -- the silent
@@ -1883,13 +1977,23 @@ namespace DetourModKit
                     "another DMK VMT hook; that clone's hooked slots will be captured as this hook's original. Set "
                     "VmtOptions::fail_if_already_hooked to refuse instead.",
                     format::format_address(reinterpret_cast<std::uintptr_t>(object)), std::string_view{name},
-                    format::format_address(*current_vptr));
+                    format::format_address(current_vptr));
             }
             const std::optional<std::size_t> method_count = count_vmt_method_slots(object);
             if (!method_count)
             {
                 return std::unexpected(
                     Error{ErrorCode::InvalidObject, "hook::vmt_for", reinterpret_cast<std::uintptr_t>(object)});
+            }
+            // An engaged zero is a successful walk that found no callable slot, which is a different failure from an
+            // unreadable one and must be rejected on its own. The backend has no such check: it would size the clone to
+            // the RTTI prefix alone and publish &clone[VMT_HEADER] -- one past the end of what it copied -- as the live
+            // vptr, so every virtual dispatch would read uninitialised allocator memory and jump through it. Refusing
+            // here also costs no capability: method_count == 0 makes hook_method reject every index anyway, so the
+            // clone this would publish is unusable by construction.
+            if (*method_count == 0)
+            {
+                return std::unexpected(Error{ErrorCode::InvalidObject, "hook::vmt_for", current_vptr});
             }
             // The slot walk above proved the forward vtable is mapped, but the backend clone also memcpys the RTTI
             // header prefix that sits immediately below the vptr (original_vmt - VMT_HEADER). Guard that prefix here so
@@ -1924,6 +2028,9 @@ namespace DetourModKit
                 // unwinds `impl` (restoring the object's vptr) without leaving a phantom ledger entry.
                 auto impl =
                     std::make_unique<VmtHook::Impl>(std::move(backend_hook), std::move(name), *base, *method_count, 0);
+                // Track the seed exactly as apply_to tracks every later object, so teardown can test it for a newer
+                // layer. Like make_unique above, a throw here unwinds `impl` and restores the vptr before publication.
+                impl->object_bindings.push_back({object, current_vptr});
                 const std::string_view created_name = impl->name;
                 // Record the clone as the final committed step. try_record_vmt is noexcept: on an out-of-memory
                 // bookkeeping failure it returns nullopt, and failing the create here unwinds `impl` (restoring the

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -54,6 +54,8 @@ namespace DetourModKit::detail
 
 #if defined(DMK_ENABLE_TEST_SEAMS)
     bool (*g_hook_create_witness_override)(bool) noexcept = nullptr;
+    // Fired after the VMT object gate is released and immediately before the leak warning reaches the logger.
+    void (*g_vmt_teardown_warning_probe)() noexcept = nullptr;
 #endif
 } // namespace DetourModKit::detail
 
@@ -1564,14 +1566,22 @@ namespace DetourModKit
                 }
                 if (unrestorable > 0)
                 {
+                    const std::size_t object_count = m_impl->object_bindings.size();
+                    diagnostics::record_intentional_leak(diagnostics::LeakSubsystem::HookManager);
+                    (void)m_impl.release();
+                    object_gate.unlock();
+#if defined(DMK_ENABLE_TEST_SEAMS)
+                    if (auto *probe = DetourModKit::detail::g_vmt_teardown_warning_probe)
+                    {
+                        probe();
+                    }
+#endif
                     (void)log().try_log(LogLevel::Warning,
                                         "hook::~VmtHook: VMT hook '{}' destroyed while {} of its {} object(s) could "
                                         "not be provably restored to their original vtable; leaked this clone to "
                                         "avoid a vtable use-after-free. Destroy VMT hooks newest-first to restore "
                                         "the original table.",
-                                        std::string_view{name}, unrestorable, m_impl->object_bindings.size());
-                    diagnostics::record_intentional_leak(diagnostics::LeakSubsystem::HookManager);
-                    (void)m_impl.release();
+                                        std::string_view{name}, unrestorable, object_count);
                     return;
                 }
                 self_ref = static_cast<HMODULE>(m_impl->self_ref);

--- a/src/internal/hook_backend.hpp
+++ b/src/internal/hook_backend.hpp
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace DetourModKit
 {
@@ -125,11 +126,9 @@ namespace DetourModKit
          *
          *          Per-method hooks are backend VmHooks keyed by vtable index. Each VmHook, on destruction, rewrites
          *          its cloned-vtable slot back to the original function pointer, so erasing an entry (@ref
-         *          VmtHook::remove_method) or destroying the map (handle teardown) restores that method. The map is
-         *          declared last so it is destroyed first: method slots in the clone are restored before `backend`
-         *          restores each applied object's vptr off the clone entirely -- the intuitive unhook-methods-then-
-         *          unapply-objects order (either order is memory-safe because the clone allocation is a shared_ptr
-         *          kept alive by both the VmtHook and every VmHook).
+         *          VmtHook::remove_method) or destroying the map (handle teardown) restores that method. VmtHook
+         *          restores object bindings before destroying Impl; the map then dies before `backend`, keeping the
+         *          clone allocation alive until every VmHook has released it.
          *
          *          method_mutex is the reader/writer guard for per-method state: @ref VmtHook::original snapshots a
          *          slot's original pointer under a shared read, while @ref VmtHook::hook_method,
@@ -141,6 +140,12 @@ namespace DetourModKit
          */
         struct VmtHook::Impl
         {
+            struct ObjectBinding
+            {
+                void *object{nullptr};
+                std::uintptr_t original_vptr{0};
+            };
+
             safetyhook::VmtHook backend;
             std::string name;
             std::uintptr_t cloned_vptr_base{0};
@@ -150,6 +155,10 @@ namespace DetourModKit
             // released on clean teardown, left outstanding with the leaked Impl on a leak branch. Holds an HMODULE;
             // acquire/release live in hook.cpp.
             void *self_ref{nullptr};
+            // Complete restoration state for objects whose dependency on this clone has not been safely released. The
+            // backend exposes no reader and drops its own original-vptr entry when removal is outranked. Guarded by the
+            // process-wide VMT object gate.
+            std::vector<ObjectBinding> object_bindings;
             mutable DetourModKit::detail::SrwSharedMutex method_mutex;
             std::unordered_map<std::size_t, safetyhook::VmHook> method_hooks;
 

--- a/src/internal/hook_fault_boundary.cpp
+++ b/src/internal/hook_fault_boundary.cpp
@@ -110,4 +110,54 @@ namespace DetourModKit
         }
         return "the target is hookable";
     }
+
+    detail::ObjectWordResult detail::validate_vmt_object_word(std::uintptr_t object) noexcept
+    {
+        // Readability first, and by touching rather than querying: VirtualQuery cannot report that a guard page will
+        // trap the first access. This is the read the backend performs unchecked to capture the original vtable.
+        volatile std::uintptr_t fault_address = object;
+        std::uintptr_t vptr = 0;
+        if (!guarded_read_bytes(object, &vptr, sizeof(vptr), &fault_address))
+        {
+            return ObjectWordResult{ObjectWordVerdict::Unreadable, fault_address, 0};
+        }
+
+        // Readable does not imply writable, and the store is what the backend does next. There is no guarded probe for
+        // writability that does not itself write, and a trial write would corrupt the very word under test, so this
+        // asks the OS. A stale answer can only arise from a concurrent protection change, which the @warning owns.
+        MEMORY_BASIC_INFORMATION info{};
+        if (VirtualQuery(reinterpret_cast<LPCVOID>(object), &info, sizeof(info)) != sizeof(info))
+        {
+            return ObjectWordResult{ObjectWordVerdict::NotWritable, object, vptr};
+        }
+        if (info.State != MEM_COMMIT)
+        {
+            return ObjectWordResult{ObjectWordVerdict::NotWritable, object, vptr};
+        }
+        // A guard armed before the read already failed it closed above. This catches one armed since: PAGE_GUARD traps
+        // the first access to a page whose protection otherwise reads as writable, so the backend's store would take
+        // the fault this whole gate exists to prevent.
+        if ((info.Protect & PAGE_GUARD) != 0)
+        {
+            return ObjectWordResult{ObjectWordVerdict::NotWritable, object, vptr};
+        }
+        constexpr DWORD WRITABLE_PROTECTIONS =
+            PAGE_READWRITE | PAGE_WRITECOPY | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+        if ((info.Protect & WRITABLE_PROTECTIONS) == 0)
+        {
+            return ObjectWordResult{ObjectWordVerdict::NotWritable, object, vptr};
+        }
+
+        // The word must not straddle two regions with different protections: VirtualQuery reports the region containing
+        // the first byte, so a pointer-sized word ending in a read-only neighbour would pass on its first byte alone.
+        // VirtualQuery places @p object inside the region it reports, so measuring the remainder as an offset from the
+        // region base keeps this arithmetic wrap-free without trusting the reported bounds not to overflow.
+        const std::uintptr_t offset_in_region = object - reinterpret_cast<std::uintptr_t>(info.BaseAddress);
+        if (static_cast<std::uintptr_t>(info.RegionSize) - offset_in_region < sizeof(std::uintptr_t))
+        {
+            return ObjectWordResult{ObjectWordVerdict::NotWritable, object, vptr};
+        }
+
+        return ObjectWordResult{ObjectWordVerdict::Ok, object, vptr};
+    }
 } // namespace DetourModKit

--- a/src/internal/hook_fault_boundary.hpp
+++ b/src/internal/hook_fault_boundary.hpp
@@ -3,19 +3,21 @@
 
 /**
  * @file hook_fault_boundary.hpp
- * @brief Range-confined validation of a hook target's backend steal window.
+ * @brief Range-confined validation of the foreign memory the hooking backend touches unchecked.
  *
- * The hooking backend decodes a target's prologue with no readability or protection check of its own, so an invalid or
- * concurrently unmapped target faults inside backend code and kills the host. This boundary proves the window the
- * backend may touch is executable, committed and readable before the backend is ever called, and reports which byte
- * failed. These declarations are internal to the build and are never installed.
+ * The backend validates neither the code it decodes nor the object words it writes, so an invalid or concurrently
+ * changing target faults inside backend code and kills the host. This boundary proves the memory the backend may touch
+ * is safe before the backend is ever called, and reports which byte failed. It covers two surfaces: an inline/mid
+ * target's steal window, and a VMT object's vptr word. These declarations are internal and are never installed.
  *
  * @warning No function here may span a call into the hooking backend (safetyhook::InlineHook::create / enable /
- *          disable, safetyhook::MidHook::create). DMK's guarded primitives recover from a fault by abandoning the
- *          faulting frame -- __builtin_longjmp on MinGW, an asynchronous unwind under /EHsc on MSVC -- and neither
- *          runs destructors. InlineHook::enable holds its own mutex and the backend's virtual_protect_mutex across the
- *          patch, so a claimed fault would abandon both locked for the life of the process and strand the target page
- *          writable-executable. Validate before the backend call; never around it.
+ *          disable, safetyhook::MidHook::create, safetyhook::VmtHook::create / apply). DMK's guarded primitives recover
+ *          from a fault by abandoning the faulting frame -- __builtin_longjmp on MinGW, an asynchronous unwind under
+ *          /EHsc on MSVC -- and neither runs destructors. InlineHook::enable holds its own mutex and the backend's
+ *          virtual_protect_mutex across the patch, so a claimed fault would abandon both locked for the life of the
+ *          process and strand the target page writable-executable; the VMT paths hold the process-wide object gate
+ *          across their backend call, so a claimed fault there deadlocks every later VMT operation and leaks the
+ *          clone's executable allocation. Validate before the backend call; never around it.
  */
 
 #include <cstddef>
@@ -91,6 +93,41 @@ namespace DetourModKit
 
         /// Human-readable fragment naming a window refusal, for diagnostic log lines.
         [[nodiscard]] std::string_view target_window_description(TargetWindowVerdict verdict) noexcept;
+
+        /// Why @ref validate_vmt_object_word refused an object, or @ref ObjectWordVerdict::Ok if it did not.
+        enum class ObjectWordVerdict : std::uint8_t
+        {
+            Ok,
+            Unreadable,
+            NotWritable
+        };
+
+        /**
+         * @brief An object-word verdict, the address that explains it, and the captured vptr.
+         * @details @p detail is the faulting address for @ref ObjectWordVerdict::Unreadable and the object word itself
+         *          otherwise. @p vptr is the value read from the object, or zero when the read failed.
+         */
+        struct ObjectWordResult
+        {
+            ObjectWordVerdict verdict{ObjectWordVerdict::Ok};
+            std::uintptr_t detail{0};
+            std::uintptr_t vptr{0};
+        };
+
+        /**
+         * @brief Decides whether the backend may read and rewrite @p object's vptr word without faulting the host.
+         * @details The backend's VmtHook::create and VmtHook::apply both dereference the object word and then store a
+         *          new vptr into it with no readability or protection check of their own -- unlike its own remove and
+         *          destroy, which do probe writability. A read-only object word therefore survives every read-based
+         *          pre-flight and faults on the store. This requires the word to be readable AND currently writable.
+         * @return @ref ObjectWordVerdict::Ok when the backend may proceed, else the refusal and its address.
+         * @note Reports writability rather than acquiring it. A caller must not make a read-only object word writable
+         *       to force a clone through: the protection is the owner's, and silently widening it outlives the hook.
+         * @warning A verdict describes the moment it was taken. A concurrent unmap or protection change can invalidate
+         *          it before the caller acts on it; this narrows the window and attributes failures, and does not
+         *          eliminate the race.
+         */
+        [[nodiscard]] ObjectWordResult validate_vmt_object_word(std::uintptr_t object) noexcept;
     } // namespace detail
 } // namespace DetourModKit
 

--- a/tests/test_hook.cpp
+++ b/tests/test_hook.cpp
@@ -1737,6 +1737,7 @@ namespace DetourModKit::detail
     extern HMODULE (*g_hook_module_ref_override)() noexcept;
 #if defined(DMK_ENABLE_TEST_SEAMS)
     extern bool (*g_hook_create_witness_override)(bool) noexcept;
+    extern void (*g_vmt_teardown_warning_probe)() noexcept;
 #endif
 } // namespace DetourModKit::detail
 
@@ -1778,6 +1779,40 @@ namespace
         HookCreateWitnessFailureScope(const HookCreateWitnessFailureScope &) = delete;
         HookCreateWitnessFailureScope &operator=(const HookCreateWitnessFailureScope &) = delete;
     };
+
+#if defined(DMK_ENABLE_TEST_SEAMS)
+    std::atomic<bool> s_vmt_warning_probe_entered{false};
+    std::atomic<bool> s_vmt_warning_inner_done{false};
+    std::atomic<bool> s_vmt_warning_inner_done_in_window{false};
+
+    void wait_for_vmt_warning_inner_operation() noexcept
+    {
+        s_vmt_warning_probe_entered.store(true, std::memory_order_release);
+        for (int i = 0; i < 500 && !s_vmt_warning_inner_done.load(std::memory_order_acquire); ++i)
+        {
+            Sleep(1);
+        }
+        s_vmt_warning_inner_done_in_window.store(s_vmt_warning_inner_done.load(std::memory_order_acquire),
+                                                 std::memory_order_release);
+    }
+
+    class VmtTeardownWarningProbeScope
+    {
+    public:
+        VmtTeardownWarningProbeScope() noexcept
+        {
+            s_vmt_warning_probe_entered.store(false, std::memory_order_relaxed);
+            s_vmt_warning_inner_done.store(false, std::memory_order_relaxed);
+            s_vmt_warning_inner_done_in_window.store(false, std::memory_order_relaxed);
+            DetourModKit::detail::g_vmt_teardown_warning_probe = &wait_for_vmt_warning_inner_operation;
+        }
+
+        ~VmtTeardownWarningProbeScope() noexcept { DetourModKit::detail::g_vmt_teardown_warning_probe = nullptr; }
+
+        VmtTeardownWarningProbeScope(const VmtTeardownWarningProbeScope &) = delete;
+        VmtTeardownWarningProbeScope &operator=(const VmtTeardownWarningProbeScope &) = delete;
+    };
+#endif
 } // namespace
 
 TEST(HookCreateWitness, InlineFailureReturnsTypedErrorAndRollsBack)
@@ -3559,6 +3594,78 @@ TEST(HookVmtLayered, OldestFirstTeardownLeaksOutrankedClone)
     // freed memory.
     EXPECT_EQ(dispatch_compute(object.get(), 2, 3), 5);
 }
+
+TEST(HookVmt, TeardownReleasesAlreadyOriginalReadOnlyBinding)
+{
+    auto donor = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t original_vptr = *reinterpret_cast<std::uintptr_t *>(donor.get());
+    dmk_test::ScratchPage object_page;
+    ASSERT_TRUE(object_page.ok());
+    auto *const object_word = static_cast<std::uintptr_t *>(object_page.base());
+    *object_word = original_vptr;
+    const std::size_t before = diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager);
+
+    Result<VmtHook> created = vmt_for("AlreadyOriginalReadOnly", object_word);
+    ASSERT_TRUE(created.has_value()) << created.error().message();
+    std::optional<VmtHook> hook(std::move(*created));
+    ASSERT_NE(*object_word, original_vptr);
+
+    *object_word = original_vptr;
+    DWORD previous_protection = 0;
+    ASSERT_NE(::VirtualProtect(object_word, sizeof(*object_word), PAGE_READONLY, &previous_protection), 0);
+    EXPECT_EQ(previous_protection, PAGE_EXECUTE_READWRITE);
+
+    hook.reset();
+    EXPECT_EQ(*object_word, original_vptr);
+    EXPECT_EQ(diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager), before)
+        << "an already-original binding needs no write and must not force a clone leak";
+}
+
+#if defined(DMK_ENABLE_TEST_SEAMS)
+// The warning probe pauses teardown at the logging boundary while another thread enters vmt_for. A bounded wait fails
+// without hanging if teardown still owns the object gate there.
+TEST(HookVmtLayered, TeardownWarningRunsAfterObjectGateRelease)
+{
+    auto object = std::make_unique<VmtTestTarget>();
+    auto inner_object = std::make_unique<VmtTestTarget>();
+    ScopedLogCapture capture;
+
+    Result<VmtHook> older_result = vmt_for("WarningGateOlder", object.get());
+    ASSERT_TRUE(older_result.has_value()) << older_result.error().message();
+    std::optional<VmtHook> older(std::move(*older_result));
+
+    Result<VmtHook> newer_result = vmt_for("WarningGateNewer", object.get());
+    ASSERT_TRUE(newer_result.has_value()) << newer_result.error().message();
+    std::optional<VmtHook> newer(std::move(*newer_result));
+
+    const VmtTeardownWarningProbeScope probe_scope;
+    std::atomic<bool> inner_ok{false};
+    std::thread inner_thread(
+        [&]
+        {
+            for (int i = 0; i < 500 && !s_vmt_warning_probe_entered.load(std::memory_order_acquire); ++i)
+            {
+                Sleep(1);
+            }
+            if (!s_vmt_warning_probe_entered.load(std::memory_order_acquire))
+            {
+                return;
+            }
+            Result<VmtHook> inner = vmt_for("WarningGateInner", inner_object.get());
+            inner_ok.store(inner.has_value(), std::memory_order_release);
+            s_vmt_warning_inner_done.store(true, std::memory_order_release);
+        });
+
+    older.reset();
+    inner_thread.join();
+
+    EXPECT_TRUE(s_vmt_warning_probe_entered.load(std::memory_order_acquire));
+    EXPECT_TRUE(s_vmt_warning_inner_done_in_window.load(std::memory_order_acquire))
+        << "the teardown warning path held the process-wide VMT object gate while logging";
+    EXPECT_TRUE(inner_ok.load(std::memory_order_acquire));
+    newer.reset();
+}
+#endif
 
 TEST(HookVmtLayered, OutrankedRemoveRetainsOriginalForLaterRestore)
 {

--- a/tests/test_hook.cpp
+++ b/tests/test_hook.cpp
@@ -2159,54 +2159,112 @@ TEST(HookVmt, MovedFromVmtHandleIsInert)
 
 // VMT slot pre-flight: refuse to clone an object whose vtable's first slot is an int3 padding/breakpoint byte, or a
 // same-module jump stub; accept a real function prologue. The pre-flight is opt-in (fail_on_non_function_pointer).
+//
+// The slot bodies live on an executable page rather than in static data. A slot is only counted as callable when its
+// value is an executable address, and only a counted slot reaches the byte classifier, so bodies planted in .rdata
+// make every case here refused as a zero-slot table before its first byte is ever read: the refusal cases would pass
+// without exercising the classifier and the acceptance cases would fail outright.
 namespace
 {
-    // Aligned to a 16-byte boundary so the byte at offset 0 is the absolute function-pointer target the pre-flight
-    // decoder reads. The page the buffer lives in is committed and readable.
-    alignas(16) const std::uint8_t INT3_SLOT_BYTES[] = {0xCC, 0xCC, 0xC3, 0x90};
-    alignas(16) const std::uint8_t RET_SLOT_BYTES[] = {0xC3, 0x90, 0x90, 0x90};
+    // Offsets are spaced well past the longest body so no case can decode into its neighbour. The page is prefilled
+    // 0xCC, which also terminates the slot walk at the first unwritten offset.
+    struct SlotBodyPage
+    {
+        dmk_test::ScratchPage page;
 
-    // First byte E9 (jmp rel32) with a displacement landing a few bytes ahead inside this same buffer. The buffer lives
-    // in the test image, so the slot and the resolved jump target map to the same module: a same-module jump stub.
-    alignas(16) const std::uint8_t JMP_STUB_SLOT_BYTES[] = {0xE9, 0x03, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90,
-                                                            0xC3, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
+        static constexpr std::size_t INT3 = 0x000;
+        static constexpr std::size_t RET = 0x040;
+        static constexpr std::size_t PROLOGUE = 0x080;
 
-    // First byte 0x48 (REX.W prefix opening a standard x64 prologue, here sub rsp, 0x28): the decoder must classify the
-    // slot as a function body.
-    alignas(16) const std::uint8_t PROLOGUE_SLOT_BYTES[] = {0x48, 0x83, 0xEC, 0x28, 0xC3, 0x90, 0x90, 0x90};
+        SlotBodyPage() noexcept
+        {
+            if (!page.ok())
+            {
+                return;
+            }
+            page.put(INT3, {0xCC, 0xCC, 0xC3, 0x90});
+            page.put(RET, {0xC3, 0x90, 0x90, 0x90});
+            // First byte 0x48 (REX.W prefix opening a standard x64 prologue, here sub rsp, 0x28): the decoder must
+            // classify the slot as a function body.
+            page.put(PROLOGUE, {0x48, 0x83, 0xEC, 0x28, 0xC3, 0x90, 0x90, 0x90});
+        }
+
+        [[nodiscard]] void *at(std::size_t offset) const noexcept
+        {
+            return reinterpret_cast<void *>(page.addr(offset));
+        }
+    };
+
+    // One page for every case below: the bodies are immutable once written and none of them is ever hooked.
+    const SlotBodyPage &slot_bodies()
+    {
+        static const SlotBodyPage bodies;
+        return bodies;
+    }
+
 } // namespace
+
+// A jump stub has to sit in this image's own code section, not on the scratch page. The classifier resolves the module
+// of the slot address FIRST and refuses outright when there is none, so a stub on privately allocated memory is
+// rejected before the same-module comparison it exists to pin is ever reached. Planted in .text, both the stub and the
+// address its rel32 resolves to map to this module, which is the shape of an incremental-link thunk or a patched slot.
+// E9 jmp +3, landing on the ret three bytes past the instruction's end; the trailing int3s stop a decode running on.
+#if defined(_MSC_VER)
+#pragma section(".text$dmk", read, execute)
+__declspec(allocate(".text$dmk")) extern const std::uint8_t SAME_MODULE_JMP_STUB[16] = {
+    0xE9, 0x03, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90, 0xC3, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+#else
+__attribute__((section(".text$dmk"), used)) extern const std::uint8_t SAME_MODULE_JMP_STUB[16] = {
+    0xE9, 0x03, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90, 0xC3, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC};
+#endif
 
 TEST(HookVmt, PreFlightRefusesInt3FirstSlot)
 {
+    // The backend copies the RTTI header below the vptr plus every counted slot. That header is one word on the MSVC
+    // ABI and two on the Itanium ABI (MinGW), so the prefix is sized for the wider of the two: a single word would put
+    // the copy's start 8 bytes before this struct on MinGW. The leading words and the non-executable terminator keep
+    // that copy inside this fixture.
     struct Int3VTable
     {
-        void *methods[2];
+        void *rtti[2];
+        void *methods[3];
     };
     Int3VTable vtable{};
-    vtable.methods[0] = const_cast<void *>(static_cast<const void *>(INT3_SLOT_BYTES));
-    vtable.methods[1] = const_cast<void *>(static_cast<const void *>(RET_SLOT_BYTES));
-    void *vptr = &vtable;
+    vtable.methods[0] = slot_bodies().at(SlotBodyPage::INT3);
+    vtable.methods[1] = slot_bodies().at(SlotBodyPage::RET);
+    vtable.methods[2] = nullptr; // terminates the slot walk in bounds
+    void *vptr = &vtable.methods[0];
+
+    // The default policy admits this object, which is what makes the refusal below attributable to the classifier
+    // rather than to a slot that was never counted. The handle is dropped so the vptr is back on the local table
+    // before the strict attempt.
+    {
+        Result<VmtHook> permissive = vmt_for("Int3VmtPermissive", &vptr);
+        ASSERT_TRUE(permissive.has_value()) << permissive.error().message();
+        VmtHook dropped = std::move(*permissive);
+    }
+    ASSERT_EQ(vptr, static_cast<void *>(&vtable.methods[0]));
 
     Result<VmtHook> r = vmt_for("Int3Vmt", &vptr, VmtOptions{.fail_on_non_function_pointer = true});
     ASSERT_FALSE(r.has_value());
     EXPECT_EQ(r.error().code, ErrorCode::InvalidObject);
 
     // The refused create did not touch the vptr: it still points at our local vtable.
-    EXPECT_EQ(vptr, static_cast<void *>(&vtable));
+    EXPECT_EQ(vptr, static_cast<void *>(&vtable.methods[0]));
 }
 
 TEST(HookVmt, PreFlightAcceptsFunctionPrologue)
 {
     // Slot 0 carries a normal x64 prologue first byte (0x48), so pre-flight with fail_on_non_function_pointer=true must
-    // accept the vtable and the create must succeed. The rtti member sits at vptr[-1]: the clone copies the RTTI slot
-    // ahead of the vtable, so the vptr must point past an in-bounds leading member.
+    // accept the vtable and the create must succeed. The rtti members sit below the vptr, sized for the wider of the
+    // two RTTI headers (see PreFlightRefusesInt3FirstSlot), so the clone's copy starts inside this fixture.
     struct PrologueVTable
     {
-        void *rtti;
+        void *rtti[2];
         void *methods[2];
     };
     PrologueVTable vtable{};
-    vtable.methods[0] = const_cast<void *>(static_cast<const void *>(PROLOGUE_SLOT_BYTES));
+    vtable.methods[0] = slot_bodies().at(SlotBodyPage::PROLOGUE);
     void *vptr = &vtable.methods[0];
 
     Result<VmtHook> r = vmt_for("PrologueVmt", &vptr, VmtOptions{.fail_on_non_function_pointer = true});
@@ -2221,38 +2279,58 @@ TEST(HookVmt, PreFlightAcceptsFunctionPrologue)
 
 TEST(HookVmt, PreFlightOffByDefault)
 {
-    // The default options (fail_on_non_function_pointer = false) do not run the pre-flight, so a synthetic vtable with
-    // a null first slot still creates successfully -- the new check is opt-in, not on-by-default. The rtti member sits
-    // at vptr[-1].
-    struct NullVTable
+    // The pre-flight is opt-in: an object the classifier would reject still creates under the default options. The
+    // contrast has to be drawn on ONE object that both policies agree is structurally valid, so the only difference is
+    // the classifier. Slot 0 is a bare `ret` -- executable, so it counts as a callable slot and the table is not
+    // zero-slot, but its first byte is one the classifier refuses. The rtti members sit below the vptr.
+    struct RetVTable
     {
-        void *rtti;
+        void *rtti[2];
         void *methods[2];
     };
-    NullVTable vtable{};
+    RetVTable vtable{};
+    vtable.methods[0] = slot_bodies().at(SlotBodyPage::RET);
     void *vptr = &vtable.methods[0];
 
-    Result<VmtHook> r = vmt_for("NullSlotVmt", &vptr);
-    ASSERT_TRUE(r.has_value()) << r.error().message();
-    VmtHook vh = std::move(*r); // dropped at scope end, restoring the vptr
-    (void)vh;
+    {
+        Result<VmtHook> r = vmt_for("RetSlotVmt", &vptr);
+        ASSERT_TRUE(r.has_value()) << r.error().message();
+        VmtHook dropped = std::move(*r);
+    }
+    ASSERT_EQ(vptr, static_cast<void *>(&vtable.methods[0]));
+
+    Result<VmtHook> strict = vmt_for("RetSlotVmtStrict", &vptr, VmtOptions{.fail_on_non_function_pointer = true});
+    ASSERT_FALSE(strict.has_value());
+    EXPECT_EQ(strict.error().code, ErrorCode::InvalidObject);
 }
 
 TEST(HookVmt, PreFlightRefusesSameModuleJumpStub)
 {
+    // As in the int3 case: the leading rtti words and the terminator keep the backend's clone copy in bounds.
     struct StubVTable
     {
-        void *methods[2];
+        void *rtti[2];
+        void *methods[3];
     };
     StubVTable vtable{};
-    vtable.methods[0] = const_cast<void *>(static_cast<const void *>(JMP_STUB_SLOT_BYTES));
-    vtable.methods[1] = const_cast<void *>(static_cast<const void *>(RET_SLOT_BYTES));
-    void *vptr = &vtable;
+    vtable.methods[0] = const_cast<std::uint8_t *>(&SAME_MODULE_JMP_STUB[0]);
+    vtable.methods[1] = slot_bodies().at(SlotBodyPage::RET);
+    vtable.methods[2] = nullptr;
+    void *vptr = &vtable.methods[0];
+
+    // As above: prove the default admits it, so the strict refusal is the classifier's verdict and not a slot walk
+    // that counted nothing.
+    {
+        Result<VmtHook> permissive = vmt_for("JmpStubVmtPermissive", &vptr);
+        ASSERT_TRUE(permissive.has_value()) << permissive.error().message();
+        VmtHook dropped = std::move(*permissive);
+    }
+    ASSERT_EQ(vptr, static_cast<void *>(&vtable.methods[0]));
 
     Result<VmtHook> r = vmt_for("JmpStubVmt", &vptr, VmtOptions{.fail_on_non_function_pointer = true});
     ASSERT_FALSE(r.has_value());
     EXPECT_EQ(r.error().code, ErrorCode::InvalidObject);
-    EXPECT_EQ(vptr, static_cast<void *>(&vtable));
+    EXPECT_EQ(vptr, static_cast<void *>(&vtable.methods[0]));
 }
 
 TEST(HookVmt, ApplyPreFlightRefusesInt3FirstSlot)
@@ -2269,13 +2347,34 @@ TEST(HookVmt, ApplyPreFlightRefusesInt3FirstSlot)
         void *methods[2];
     };
     Int3VTable vtable{};
-    vtable.methods[0] = const_cast<void *>(static_cast<const void *>(INT3_SLOT_BYTES));
-    vtable.methods[1] = const_cast<void *>(static_cast<const void *>(RET_SLOT_BYTES));
+    vtable.methods[0] = slot_bodies().at(SlotBodyPage::INT3);
+    vtable.methods[1] = slot_bodies().at(SlotBodyPage::RET);
     void *vptr = &vtable;
 
     Result<void> applied = vh.apply_to(&vptr, VmtOptions{.fail_on_non_function_pointer = true});
     ASSERT_FALSE(applied.has_value());
+    EXPECT_EQ(applied.error().code, ErrorCode::InvalidObject);
     EXPECT_EQ(vptr, static_cast<void *>(&vtable));
+}
+
+// apply_to installs an existing clone, so its default path needs a readable, writable object word but does not clone or
+// inspect the displaced vtable. The opt-in slot policy owns that additional classification.
+TEST(HookVmt, ApplyDefaultNeedsOnlyWritableObjectWord)
+{
+    auto seed = std::make_unique<VmtTestTarget>();
+    Result<VmtHook> r = vmt_for("ApplyWritableWordSeed", seed.get());
+    ASSERT_TRUE(r.has_value()) << r.error().message();
+    VmtHook vh = std::move(*r);
+
+    struct FakeObject
+    {
+        std::uintptr_t vptr{0};
+    } object;
+
+    ASSERT_TRUE(vh.apply_to(&object).has_value());
+    EXPECT_NE(object.vptr, 0u);
+    ASSERT_TRUE(vh.remove_from(&object).has_value());
+    EXPECT_EQ(object.vptr, 0u);
 }
 
 TEST(HookVmt, ReleaseLeavesCloneInstalled)
@@ -3130,4 +3229,510 @@ TEST(HookInlineLayered, OldestFirstTeardownLeaksOlderBackend)
     ASSERT_FALSE(blocked.has_value());
     EXPECT_EQ(blocked.error().code, ErrorCode::TargetAlreadyHookedInProcess)
         << "a leaked backend remains physically installed and must stay represented in the ledger";
+}
+
+// VMT object-word fault boundary. The backend's create and apply both dereference the object's vptr word and then
+// store a new vptr into it with no readability or protection check of their own, so an object word the kit has not
+// proven readable AND writable is a host fault that no Result can report.
+namespace
+{
+    /// The x86-64 base page size; every hostile object word below gets a page of its own.
+    constexpr std::size_t OBJECT_WORD_PAGE_BYTES = 0x1000;
+
+    // The states an object's vptr word can be in that the backend cannot survive. NoAccess, Reserved and Guarded all
+    // fault the backend's READ, so the kit's guarded read is what refuses them. ReadOnly is the odd one out: it reads
+    // cleanly and faults the STORE, so only proving the word writable can refuse it.
+    enum class ObjectWordState
+    {
+        NoAccess,
+        ReadOnly,
+        Reserved,
+        Guarded
+    };
+
+    [[nodiscard]] std::string_view object_word_state_name(ObjectWordState state) noexcept
+    {
+        switch (state)
+        {
+        case ObjectWordState::NoAccess:
+            return "PAGE_NOACCESS object word";
+        case ObjectWordState::ReadOnly:
+            return "PAGE_READONLY object word";
+        case ObjectWordState::Reserved:
+            return "MEM_RESERVE uncommitted object word";
+        case ObjectWordState::Guarded:
+            return "PAGE_GUARD object word";
+        }
+        return "unknown object word";
+    }
+
+    /**
+     * @brief Builds a one-page object whose vptr word sits in @p state, or nullptr if the page could not be pinned.
+     * @param state The hostile state to pin the word's page to.
+     * @param planted_vptr A genuine vtable pointer, stored into the word while the page is still writable.
+     * @details @p planted_vptr is what makes the readable states meaningful: the word names a real, cloneable vtable,
+     *          so the page's protection is the only thing left that can refuse the object. A word holding garbage
+     *          would be refused by the slot walk instead and would prove nothing about the object-word gate.
+     * @note Every page is leaked ON PURPOSE, the discipline NoAccessPage in fixtures/fault_injection.hpp documents: a
+     *       released VA can be recycled by a later allocation, and a subsequent case's word would then land on live
+     *       writable memory and be accepted, passing for the wrong reason. One page per call is negligible in a test
+     *       process that exits immediately.
+     */
+    [[nodiscard]] void *make_hostile_object_word(ObjectWordState state, std::uintptr_t planted_vptr) noexcept
+    {
+        if (state == ObjectWordState::Reserved)
+        {
+            // Reserved but never committed: no page frame backs the word, so any access to it faults.
+            return ::VirtualAlloc(nullptr, OBJECT_WORD_PAGE_BYTES, MEM_RESERVE, PAGE_READWRITE);
+        }
+        if (state == ObjectWordState::NoAccess)
+        {
+            return ::VirtualAlloc(nullptr, OBJECT_WORD_PAGE_BYTES, MEM_RESERVE | MEM_COMMIT, PAGE_NOACCESS);
+        }
+        void *page = ::VirtualAlloc(nullptr, OBJECT_WORD_PAGE_BYTES, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        if (page == nullptr)
+        {
+            return nullptr;
+        }
+        *static_cast<std::uintptr_t *>(page) = planted_vptr;
+        const DWORD protection =
+            (state == ObjectWordState::ReadOnly) ? PAGE_READONLY : static_cast<DWORD>(PAGE_READWRITE | PAGE_GUARD);
+        DWORD previous = 0;
+        if (::VirtualProtect(page, OBJECT_WORD_PAGE_BYTES, protection, &previous) == FALSE)
+        {
+            return nullptr;
+        }
+        return page;
+    }
+
+    // Names the policy and state in assertion failures.
+    [[nodiscard]] std::string describe_word_case(ObjectWordState state, const VmtOptions &options)
+    {
+        return std::string(object_word_state_name(state)) +
+               ", fail_if_already_hooked=" + (options.fail_if_already_hooked ? "true" : "false") +
+               ", fail_on_non_function_pointer=" + (options.fail_on_non_function_pointer ? "true" : "false");
+    }
+} // namespace
+
+// The object-word gate is not a policy. vmt_for and apply_to must refuse an object whose vptr word the backend cannot
+// safely read and rewrite under EVERY VmtOptions set, the permissive default included, because the alternative to
+// refusing is not a laxer contract but a host fault neither entry point can report. Drive both entry points across
+// every policy and every hostile word state, and assert the typed code rather than mere failure.
+TEST(VmtHookFaultProof, ApplyInvalidObjectAlwaysReturnsTypedFailure)
+{
+    auto donor = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t genuine_vptr = *reinterpret_cast<std::uintptr_t *>(donor.get());
+
+    // apply_to needs a live handle, so seed one on an ordinary writable object. Declared after the object it clones so
+    // reverse-order destruction restores the vptr while the object is still alive.
+    auto seed_object = std::make_unique<VmtTestTarget>();
+    Result<VmtHook> seeded = vmt_for("FaultProofSeed", seed_object.get());
+    ASSERT_TRUE(seeded.has_value()) << seeded.error().message();
+    VmtHook vh = std::move(*seeded);
+
+    const std::array<VmtOptions, 4> policies{
+        VmtOptions{},
+        VmtOptions{.fail_if_already_hooked = true},
+        VmtOptions{.fail_on_non_function_pointer = true},
+        VmtOptions{.fail_if_already_hooked = true, .fail_on_non_function_pointer = true},
+    };
+    const std::array<ObjectWordState, 4> states{ObjectWordState::NoAccess, ObjectWordState::ReadOnly,
+                                                ObjectWordState::Reserved, ObjectWordState::Guarded};
+
+    for (const ObjectWordState state : states)
+    {
+        for (const VmtOptions &options : policies)
+        {
+            const std::string context = describe_word_case(state, options);
+
+            // A fresh page per call keeps each case independent of what the last one did to its word. The guard state
+            // in particular survives being tripped: swallowing a guard-page fault re-arms the fence before reporting
+            // the read as failed, so a fired guard is not a way for a later case to pass on a disarmed word.
+            void *const create_object = make_hostile_object_word(state, genuine_vptr);
+            ASSERT_NE(create_object, nullptr) << context;
+            const Result<VmtHook> created = vmt_for("FaultProofCreate", create_object, options);
+            ASSERT_FALSE(created.has_value()) << context;
+            EXPECT_EQ(created.error().code, ErrorCode::InvalidObject) << context;
+
+            void *const apply_object = make_hostile_object_word(state, genuine_vptr);
+            ASSERT_NE(apply_object, nullptr) << context;
+            const Result<void> applied = vh.apply_to(apply_object, options);
+            ASSERT_FALSE(applied.has_value()) << context;
+            EXPECT_EQ(applied.error().code, ErrorCode::InvalidObject) << context;
+        }
+    }
+
+    // Every refusal left the handle intact. A refused apply must also leave no backend record of the hostile object:
+    // one would fault this handle's teardown, which no assertion could survive to report.
+    EXPECT_TRUE(static_cast<bool>(vh));
+    EXPECT_TRUE(vh.remove_from(seed_object.get()).has_value());
+}
+
+// The PAGE_READONLY word per entry point, in isolation. This is the state no read-based pre-flight can catch: the word
+// is readable and names a genuine vtable, so the slot walk and the header-prefix guard both pass, and the refusal can
+// only come from proving the word WRITABLE before the backend's store.
+TEST(VmtHookFaultProof, CreateRefusesReadOnlyObjectWord)
+{
+    auto donor = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t genuine_vptr = *reinterpret_cast<std::uintptr_t *>(donor.get());
+
+    void *const object = make_hostile_object_word(ObjectWordState::ReadOnly, genuine_vptr);
+    ASSERT_NE(object, nullptr);
+
+    const Result<VmtHook> created = vmt_for("ReadOnlyWordCreate", object);
+    ASSERT_FALSE(created.has_value());
+    EXPECT_EQ(created.error().code, ErrorCode::InvalidObject);
+    EXPECT_EQ(*static_cast<std::uintptr_t *>(object), genuine_vptr) << "a refused create must publish nothing";
+}
+
+TEST(VmtHookFaultProof, ApplyRefusesReadOnlyObjectWord)
+{
+    auto donor = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t genuine_vptr = *reinterpret_cast<std::uintptr_t *>(donor.get());
+
+    auto seed_object = std::make_unique<VmtTestTarget>();
+    Result<VmtHook> seeded = vmt_for("ReadOnlyWordApplySeed", seed_object.get());
+    ASSERT_TRUE(seeded.has_value()) << seeded.error().message();
+    VmtHook vh = std::move(*seeded);
+
+    void *const object = make_hostile_object_word(ObjectWordState::ReadOnly, genuine_vptr);
+    ASSERT_NE(object, nullptr);
+
+    const Result<void> applied = vh.apply_to(object);
+    ASSERT_FALSE(applied.has_value());
+    EXPECT_EQ(applied.error().code, ErrorCode::InvalidObject);
+    EXPECT_EQ(*static_cast<std::uintptr_t *>(object), genuine_vptr) << "a refused apply must publish nothing";
+}
+
+// The gate's other half: it must refuse hostile object words without refusing ordinary ones, and a refusal must be
+// inert. An ordinary writable object applies and restores, a hooked seed keeps dispatching through its clone across a
+// refused apply, and the refused object leaves no backend record behind.
+TEST(VmtHookFaultProof, WritableObjectAppliesAndRefusalLeavesSeedUsable)
+{
+    auto donor = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t genuine_vptr = *reinterpret_cast<std::uintptr_t *>(donor.get());
+
+    auto seed_object = std::make_unique<VmtTestTarget>();
+    auto peer_object = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t peer_vptr_original = *reinterpret_cast<std::uintptr_t *>(peer_object.get());
+
+    Result<VmtHook> seeded = vmt_for("GateControlSeed", seed_object.get());
+    ASSERT_TRUE(seeded.has_value()) << seeded.error().message();
+    VmtHook vh = std::move(*seeded);
+    MethodVmtScope scope(vh);
+    ASSERT_TRUE(vh.hook_method<VmtComputeFn>(VMT_COMPUTE_INDEX, &vmt_detour_compute).has_value());
+
+    // The detour firing is what proves the ABI-dependent slot index above is the right one: a wrong pick would leave
+    // compute unhooked and yield the plain 5.
+    EXPECT_EQ(dispatch_compute(seed_object.get(), 2, 3), 1005);
+
+    // Control: a plain writable object applies, dispatches through the clone, and restores.
+    ASSERT_TRUE(vh.apply_to(peer_object.get()).has_value());
+    EXPECT_EQ(dispatch_compute(peer_object.get(), 4, 5), 1009);
+
+    void *const hostile = make_hostile_object_word(ObjectWordState::ReadOnly, genuine_vptr);
+    ASSERT_NE(hostile, nullptr);
+    const Result<void> refused = vh.apply_to(hostile);
+    ASSERT_FALSE(refused.has_value());
+    EXPECT_EQ(refused.error().code, ErrorCode::InvalidObject);
+
+    // The refusal changed nothing: both live objects still dispatch through the clone's hooked slot.
+    EXPECT_EQ(dispatch_compute(seed_object.get(), 2, 3), 1005);
+    EXPECT_EQ(dispatch_compute(peer_object.get(), 4, 5), 1009);
+
+    ASSERT_TRUE(vh.remove_from(peer_object.get()).has_value());
+    EXPECT_EQ(*reinterpret_cast<std::uintptr_t *>(peer_object.get()), peer_vptr_original);
+    EXPECT_EQ(dispatch_compute(peer_object.get(), 4, 5), 9);
+}
+
+// A vtable whose FIRST slot is not a callable address: the slot walk succeeds and returns an engaged count of ZERO.
+// That is a different failure from an unreadable table (the walk worked), and the backend has no check for it -- it
+// sizes the clone to the RTTI prefix alone and publishes &clone[VMT_HEADER], one past the end of what it copied, as
+// the object's live vptr. vmt_for must reject the engaged zero on its own.
+TEST(HookVmt, PreFlightRefusesVtableWithNoCallableSlots)
+{
+    // Mapped and readable but not executable, so the walk reads slot 0 fine and terminates on it, yielding zero.
+    static std::uintptr_t data_sink = 0;
+    // The fake vptr points into the MIDDLE of the table so the RTTI header prefix below it (vptr - VMT_HEADER) is
+    // mapped and readable. That keeps the engaged-zero check the only thing that can refuse this object, rather than
+    // the header-prefix guard refusing it first for an unrelated reason.
+    static std::uintptr_t data_vtable[8];
+    for (std::uintptr_t &slot : data_vtable)
+    {
+        slot = reinterpret_cast<std::uintptr_t>(&data_sink);
+    }
+
+    struct FakeObject
+    {
+        std::uintptr_t vptr;
+    } object{reinterpret_cast<std::uintptr_t>(&data_vtable[4])};
+    const std::uintptr_t vptr_before = object.vptr;
+
+    const Result<VmtHook> created = vmt_for("ZeroSlotVmt", &object);
+    ASSERT_FALSE(created.has_value());
+    EXPECT_EQ(created.error().code, ErrorCode::InvalidObject);
+    // Publishing the clone wrote a one-past-the-end vptr into this word, so an unchanged vptr is what proves the
+    // refusal published nothing.
+    EXPECT_EQ(object.vptr, vptr_before) << "a refused create must leave the object's vptr untouched";
+}
+
+// Two VMT clones stacked on ONE object, torn down newest-first: B unwinds onto A's clone base, then A unwinds onto the
+// pristine table. No layer is ever outranked at its own teardown, so nothing may be leaked and the object must land
+// back on its original vtable.
+TEST(HookVmtLayered, NewestFirstTeardownRestoresPristineTable)
+{
+    auto object = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t pristine_vptr = *reinterpret_cast<std::uintptr_t *>(object.get());
+    // Measure a delta rather than resetting the process-wide counters, so this test does not perturb any other
+    // leak-count assertion in the suite.
+    const std::size_t before = diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager);
+
+    {
+        // Stacking is the permissive clone-of-clone, which warns by contract; keep that off the default sink.
+        ScopedLogCapture capture;
+
+        Result<VmtHook> ra = vmt_for("LayerVmtOrderA", object.get());
+        ASSERT_TRUE(ra.has_value()) << ra.error().message();
+        std::optional<VmtHook> a(std::move(*ra));
+
+        Result<VmtHook> rb = vmt_for("LayerVmtOrderB", object.get());
+        ASSERT_TRUE(rb.has_value()) << rb.error().message();
+        std::optional<VmtHook> b(std::move(*rb));
+
+        b.reset();
+        a.reset();
+    }
+
+    EXPECT_EQ(*reinterpret_cast<std::uintptr_t *>(object.get()), pristine_vptr)
+        << "newest-first VMT teardown must land the object back on its pristine table";
+    EXPECT_EQ(diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager), before)
+        << "no layer is outranked in newest-first order, so nothing may be leaked";
+    EXPECT_EQ(dispatch_compute(object.get(), 2, 3), 5);
+}
+
+// The same two clones torn down OLDEST-first, the order a bare std::vector<VmtHook> produces. A's clone base is the
+// original B recorded and will write back at ~B, so ~A must leak its clone rather than let the backend free a table a
+// live successor still points at. The accepted, documented trade is that the object ends on A's LEAKED clone rather
+// than its pristine table: not a restore, but not a use-after-free either.
+TEST(HookVmtLayered, OldestFirstTeardownLeaksOutrankedClone)
+{
+    auto object = std::make_unique<VmtTestTarget>();
+    auto peer = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t pristine_vptr = *reinterpret_cast<std::uintptr_t *>(object.get());
+    const std::uintptr_t peer_pristine_vptr = *reinterpret_cast<std::uintptr_t *>(peer.get());
+    const std::size_t before = diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager);
+    std::uintptr_t a_clone_base = 0;
+
+    {
+        ScopedLogCapture capture;
+
+        Result<VmtHook> ra = vmt_for("LayerVmtLeakA", object.get());
+        ASSERT_TRUE(ra.has_value()) << ra.error().message();
+        std::optional<VmtHook> a(std::move(*ra));
+        a_clone_base = *reinterpret_cast<std::uintptr_t *>(object.get());
+        ASSERT_TRUE(a->apply_to(peer.get()).has_value());
+        ASSERT_NE(*reinterpret_cast<std::uintptr_t *>(peer.get()), peer_pristine_vptr);
+
+        Result<VmtHook> rb = vmt_for("LayerVmtLeakB", object.get());
+        ASSERT_TRUE(rb.has_value()) << rb.error().message();
+        std::optional<VmtHook> b(std::move(*rb));
+
+        // Inverted order: destroy the OLDER clone while B still records A's clone base as the original it will write
+        // back into the live object.
+        a.reset();
+        EXPECT_EQ(diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager), before + 1)
+            << "an outranked VMT clone must be leaked, not freed under its successor's recorded original";
+        EXPECT_EQ(*reinterpret_cast<std::uintptr_t *>(peer.get()), peer_pristine_vptr)
+            << "an outranked object must not prevent independent objects from being restored";
+        EXPECT_NE(capture.drain().find("leaked this clone to avoid a vtable use-after-free"), std::string::npos)
+            << "the leak-on-inversion branch must warn so the condition is diagnosable";
+
+        // B unwinds onto A's leaked clone base. Leaked, so still mapped: the store is not a dangling pointer.
+        b.reset();
+        EXPECT_EQ(*reinterpret_cast<std::uintptr_t *>(object.get()), a_clone_base);
+    }
+
+    EXPECT_NE(*reinterpret_cast<std::uintptr_t *>(object.get()), pristine_vptr)
+        << "the documented trade: an inverted teardown leaves the object on the leaked clone, not the original table";
+    EXPECT_EQ(diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager), before + 1);
+    // The leaked clone is a faithful copy of the original table, so dispatch still works rather than jumping through
+    // freed memory.
+    EXPECT_EQ(dispatch_compute(object.get(), 2, 3), 5);
+}
+
+TEST(HookVmtLayered, OutrankedRemoveRetainsOriginalForLaterRestore)
+{
+    auto object = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t pristine_vptr = *reinterpret_cast<std::uintptr_t *>(object.get());
+    const std::size_t before = diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager);
+
+    ScopedLogCapture capture;
+    Result<VmtHook> ra = vmt_for("RemoveRestoreA", object.get());
+    ASSERT_TRUE(ra.has_value()) << ra.error().message();
+    std::optional<VmtHook> a(std::move(*ra));
+    const std::uintptr_t a_clone_base = *reinterpret_cast<std::uintptr_t *>(object.get());
+
+    Result<VmtHook> rb = vmt_for("RemoveRestoreB", object.get());
+    ASSERT_TRUE(rb.has_value()) << rb.error().message();
+    std::optional<VmtHook> b(std::move(*rb));
+
+    // SafetyHook drops A's private original-vptr entry here because B is still on the object.
+    ASSERT_TRUE(a->remove_from(object.get()).has_value());
+
+    b.reset();
+    ASSERT_EQ(*reinterpret_cast<std::uintptr_t *>(object.get()), a_clone_base);
+
+    // A's retained binding restores the pristine table even though its backend no longer knows this object.
+    a.reset();
+    EXPECT_EQ(*reinterpret_cast<std::uintptr_t *>(object.get()), pristine_vptr);
+    EXPECT_EQ(diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager), before);
+    EXPECT_EQ(dispatch_compute(object.get(), 2, 3), 5);
+}
+
+// remove_from called while a NEWER clone is layered on the object. The backend erases its own bookkeeping on every
+// path, including the one where it sees the object is no longer on this clone and therefore declines to restore, so
+// after this call the backend can no longer restore the predecessor. The kit must keep its complete binding: dropping
+// it would let ~A free a clone that B still records as the original it will write back at ~B.
+TEST(HookVmtLayered, RemoveFromOutrankedObjectKeepsCloneReachable)
+{
+    auto object = std::make_unique<VmtTestTarget>();
+    const std::size_t before = diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager);
+    std::uintptr_t a_clone_base = 0;
+
+    {
+        ScopedLogCapture capture;
+
+        Result<VmtHook> ra = vmt_for("RemoveOutrankedA", object.get());
+        ASSERT_TRUE(ra.has_value()) << ra.error().message();
+        std::optional<VmtHook> a(std::move(*ra));
+        a_clone_base = *reinterpret_cast<std::uintptr_t *>(object.get());
+
+        std::optional<VmtHook> b;
+        {
+            MethodVmtScope scope(*a);
+            ASSERT_TRUE(a->hook_method<VmtTransformFn>(VMT_TRANSFORM_INDEX, &vmt_detour_transform).has_value());
+            EXPECT_EQ(dispatch_transform(object.get(), 7), 514);
+
+            Result<VmtHook> rb = vmt_for("RemoveOutrankedB", object.get());
+            ASSERT_TRUE(rb.has_value()) << rb.error().message();
+            b.emplace(std::move(*rb));
+
+            // B cloned A's clone, so A's detour came along and still fires through B's table.
+            EXPECT_EQ(dispatch_transform(object.get(), 7), 514);
+
+            // A releases its object while B outranks it. The backend declines to restore yet drops its record, so only
+            // the kit's binding can keep A's clone reachable.
+            ASSERT_TRUE(a->remove_from(object.get()).has_value());
+        }
+
+        // The leaked clone retains the detour, so clear its handle publication before destroying the handle.
+        a.reset();
+        EXPECT_EQ(diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager), before + 1)
+            << "remove_from must not drop the binding of an object it could not release: ~A then frees a "
+               "clone B still records as its original";
+
+        b.reset();
+        EXPECT_EQ(*reinterpret_cast<std::uintptr_t *>(object.get()), a_clone_base);
+    }
+
+    // Churn the backend's own clone allocator: a FREED clone's bytes would be handed to one of these and overwritten,
+    // turning the dispatch below into a jump through scribbled memory. A leaked clone is untouched by this. The CRT
+    // heap is the wrong pool to churn -- the backend allocates clones from its own VirtualAlloc-backed allocator.
+    for (int i = 0; i < 16; ++i)
+    {
+        auto churn_object = std::make_unique<VmtTestTarget>();
+        Result<VmtHook> churn = vmt_for("RemoveOutrankedChurn", churn_object.get());
+        ASSERT_TRUE(churn.has_value()) << churn.error().message();
+        VmtHook churn_hook = std::move(*churn);
+        ASSERT_TRUE(churn_hook.hook_method<VmtComputeFn>(VMT_COMPUTE_INDEX, &vmt_detour_compute).has_value());
+    }
+
+    // The object still dispatches through A's leaked clone, whose transform slot still holds A's detour. s_method_vmt
+    // is null now, so that detour returns its unhooked marker: a defined value only reachable if the slot survived.
+    EXPECT_EQ(dispatch_transform(object.get(), 7), -1)
+        << "the object must still dispatch through A's leaked clone rather than freed or recycled memory";
+    EXPECT_EQ(diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager), before + 1);
+}
+
+// Re-applying an object this handle already tracks, after a newer layer moved it off the vptr the handle recorded.
+// Teardown restores from the binding, so admitting this would leave the binding naming a vptr the object never had:
+// A would read its own object as restored, free its clone, and ~B would then write that freed clone into the live
+// object. Republishing is also wrong on its own terms, since A's clone was copied before B existed and putting it back
+// would discard B's slots. Refusing is what keeps every recorded original true.
+TEST(HookVmtLayered, ReapplyAcrossNewerLayerIsRefused)
+{
+    auto object = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t pristine_vptr = *reinterpret_cast<std::uintptr_t *>(object.get());
+    const std::size_t before = diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager);
+
+    {
+        ScopedLogCapture capture;
+
+        Result<VmtHook> ra = vmt_for("ReapplyLayerA", object.get());
+        ASSERT_TRUE(ra.has_value()) << ra.error().message();
+        std::optional<VmtHook> a(std::move(*ra));
+        const std::uintptr_t a_clone_base = *reinterpret_cast<std::uintptr_t *>(object.get());
+
+        Result<VmtHook> rb = vmt_for("ReapplyLayerB", object.get());
+        ASSERT_TRUE(rb.has_value()) << rb.error().message();
+        std::optional<VmtHook> b(std::move(*rb));
+        const std::uintptr_t b_clone_base = *reinterpret_cast<std::uintptr_t *>(object.get());
+        ASSERT_NE(a_clone_base, b_clone_base);
+
+        const Result<void> reapplied = a->apply_to(object.get());
+        ASSERT_FALSE(reapplied.has_value()) << "a re-apply across a newer layer must not silently republish";
+        EXPECT_EQ(reapplied.error().code, ErrorCode::HookAlreadyExists);
+        EXPECT_EQ(*reinterpret_cast<std::uintptr_t *>(object.get()), b_clone_base)
+            << "a refused apply must leave the object where the newer layer put it";
+
+        // A's binding is still truthful, so the inverted teardown can still see that B outranks it and leaks rather
+        // than freeing a clone B records as the original it will write back.
+        a.reset();
+        EXPECT_EQ(diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::HookManager), before + 1)
+            << "the refused re-apply must leave A's binding able to detect that it is outranked";
+
+        b.reset();
+        EXPECT_EQ(*reinterpret_cast<std::uintptr_t *>(object.get()), a_clone_base);
+    }
+
+    EXPECT_NE(*reinterpret_cast<std::uintptr_t *>(object.get()), pristine_vptr);
+    EXPECT_EQ(dispatch_compute(object.get(), 2, 3), 5);
+}
+
+// An object sitting on this handle's own clone base that the handle never applied: the kit holds no original vptr for
+// it, so recording one now would name the clone base as the object's own original, and teardown would read it as
+// already restored and free the clone out from under it. Both policies must refuse, or the strict opt-in would be the
+// laxer of the two.
+TEST(HookVmt, ApplyToUntrackedObjectOnOwnCloneIsRefusedUnderEveryPolicy)
+{
+    auto seed = std::make_unique<VmtTestTarget>();
+    auto stowaway = std::make_unique<VmtTestTarget>();
+    const std::uintptr_t stowaway_pristine = *reinterpret_cast<std::uintptr_t *>(stowaway.get());
+
+    Result<VmtHook> r = vmt_for("StowawaySeed", seed.get());
+    ASSERT_TRUE(r.has_value()) << r.error().message();
+    VmtHook vh = std::move(*r);
+    const std::uintptr_t clone_base = *reinterpret_cast<std::uintptr_t *>(seed.get());
+
+    // The shape a host produces by byte-copying, pooling or recycling an instance whose vptr word was captured while
+    // it was on the clone. No kit call put this object here, so no binding exists for it.
+    *reinterpret_cast<std::uintptr_t *>(stowaway.get()) = clone_base;
+
+    // The stowaway must come off the clone even when an assertion below returns early. Declared after vh, this guard
+    // restores before vh frees the clone and before ~VmtTestTarget dispatches its virtual destructor.
+    struct RestoreStowaway
+    {
+        void *object;
+        std::uintptr_t vptr;
+        ~RestoreStowaway() noexcept { *reinterpret_cast<std::uintptr_t *>(object) = vptr; }
+    } const restore{stowaway.get(), stowaway_pristine};
+
+    const std::array<VmtOptions, 2> policies{VmtOptions{}, VmtOptions{.fail_if_already_hooked = true}};
+    for (const VmtOptions &options : policies)
+    {
+        const Result<void> applied = vh.apply_to(stowaway.get(), options);
+        ASSERT_FALSE(applied.has_value()) << "fail_if_already_hooked=" << options.fail_if_already_hooked;
+        EXPECT_EQ(applied.error().code, ErrorCode::HookAlreadyExists)
+            << "fail_if_already_hooked=" << options.fail_if_already_hooked;
+    }
 }


### PR DESCRIPTION
## Summary

`vmt_for` and `apply_to` now validate that an object's vptr word is readable and currently writable before any backend call, under every `VmtOptions` value. SafetyHook reads and rewrites that word unchecked, so a reserved, no-access, read-only or guarded object faulted the host instead of returning an error. Validation happens before the backend call, never around it: the VMT paths hold the process-wide object gate across that call, and DMK's guards abandon the faulting frame without unwinding.

A vtable with no callable slot is refused instead of published as a one-past-the-end vptr.

`VmtHook` now retains a complete object/original-vptr binding rather than a bare object pointer. The backend discards its own restoration record whenever removal is outranked by a newer clone, which left use-after-free schedules around `remove_from` and around oldest-first teardown. Teardown restores every object it can prove is still on this clone, then leaks the clone only if a binding remains unrestorable, so one outranked object no longer strands its peers.

## Behavior changes

- Invalid object storage returns `InvalidObject` where it previously crashed the host. Fail-closed on a crashing path.
- A zero-slot table is refused at create. It was already unusable: `hook_method` rejected every index against a count of zero.
- Stacked clones torn down newest-first return the object to its pristine table. Torn down oldest-first, the outranked clone is leaked, counted on `diagnostics::LeakSubsystem::HookManager`, and logged. That is deliberate: a one-off leak instead of a use-after-free.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VMT hook safety when objects or virtual tables cannot be safely read or restored.
  * Prevented unsafe teardown scenarios by preserving hooks when restoration cannot be verified.
  * Clarified behavior for layered hooks, invalid objects, duplicate applications, and removal failures.
  * Added safeguards against host faults when object memory is unreadable, unwritable, reserved, or guarded.

* **Documentation**
  * Expanded guidance on validation options, hook stacking, teardown order, and failure behavior.

* **Tests**
  * Added coverage for hostile memory states, layered hook restoration, and strict versus default validation policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->