### PR TITLE
feat(logger): single-owner shutdown and loader-lock abandon

### DIFF
--- a/src/internal/async_logger.cpp
+++ b/src/internal/async_logger.cpp
@@ -801,6 +801,11 @@ namespace DetourModKit
     void AsyncLogger::Impl::finish_producer() noexcept
     {
         const size_t previous = m_active_producers.fetch_sub(1, std::memory_order_seq_cst);
+        // Signal flush waiters only while stopping, where the last admitted producer draining out is the transition
+        // that lets a shutdown-time flush observe m_active_producers == 0 and complete. During Async this path stays
+        // off the flush condition variable so a producer never contends the control-plane mutex on a hot enqueue; an
+        // Async flush waiter is instead released by the writer's post-drain notify or, failing that, by its own wait
+        // timeout, so its return value stays a genuine drain acknowledgement in every case.
         if (previous == 1 && m_state.load(std::memory_order_seq_cst) != State::Async)
         {
             m_flush_cv.notify_all();

--- a/src/internal/async_logger.cpp
+++ b/src/internal/async_logger.cpp
@@ -44,6 +44,14 @@ namespace DetourModKit
             return is_loader_lock_held();
         }
 
+#if defined(DMK_ENABLE_TEST_SEAMS)
+        // Test-only gates for deterministic shutdown interleavings.
+        std::atomic<std::atomic<bool> *> g_async_logger_writer_gate{nullptr};
+        std::atomic<std::atomic<bool> *> g_async_logger_producer_gate{nullptr};
+        std::atomic<bool> g_async_logger_producer_waiting{false};
+        std::atomic<bool> g_async_logger_flush_waiting{false};
+#endif
+
         StringPool::StringPool() noexcept
         {
             std::lock_guard<std::mutex> lock(m_pool_mutex);
@@ -506,9 +514,7 @@ namespace DetourModKit
         [[nodiscard]] bool writer_was_detached() const noexcept;
 
         void writer_thread_func() noexcept;
-        // Drains any messages remaining in the queue after the writer thread exits (called during shutdown to flush
-        // late-enqueued messages that arrived between m_running=false and the writer observing an empty queue).
-        void drain_remaining() noexcept;
+        void finish_producer() noexcept;
         void write_batch(std::span<detail::LogMessage> messages) noexcept;
         bool handle_overflow(detail::LogMessage &&message) noexcept;
         // Wakes the writer thread if it is parked on m_flush_cv after a successful push. The producer increments
@@ -531,8 +537,21 @@ namespace DetourModKit
         // stays mapped. void* keeps the pimpl header-light; it holds an HMODULE in the implementation. See
         // detail::acquire_module_ref.
         void *m_writer_self_ref{nullptr};
-        std::atomic<bool> m_running{false};
-        std::atomic<bool> m_shutdown_requested{false};
+        // Single-owner shutdown state. Async: producers enqueue and the writer drains. Stopping: a stop was
+        // requested, so the retained writer finishes the drain while new callback-safe producers drop and count.
+        // Stopped: the writer has drained, flushed the sink, and acknowledged the drain. The writer owns the
+        // Stopping->Stopped transition at its own tail (the loader-lock abandon path returns and leaves everything to
+        // it); shutdown() only requests the stop.
+        enum class State : std::uint8_t
+        {
+            Async,
+            Stopping,
+            Stopped
+        };
+        std::atomic<State> m_state{State::Stopped};
+        // Producers register before observing m_state. This prevents the writer from exiting while an admitted
+        // producer has not published its queue slot yet.
+        std::atomic<size_t> m_active_producers{0};
         // Latched by shutdown() when it detaches the writer on the loader-lock path. Read by ~AsyncLogger to keep the
         // Impl alive past the detached writer. A latched flag (rather than re-querying is_loader_lock_held() in the
         // destructor) avoids a TOCTOU where the loader-lock state differs between the detach decision and the free.
@@ -580,14 +599,14 @@ namespace DetourModKit
                                     "AsyncLogger: acquire_module_ref failed");
         }
 
-        m_running.store(true, std::memory_order_release);
+        m_state.store(State::Async, std::memory_order_release);
         try
         {
             m_writer_thread = std::jthread(&AsyncLogger::Impl::writer_thread_func, this);
         }
         catch (...)
         {
-            m_running.store(false, std::memory_order_release);
+            m_state.store(State::Stopped, std::memory_order_release);
             release_module_ref(writer_self_ref);
             throw;
         }
@@ -601,35 +620,28 @@ namespace DetourModKit
 
     bool AsyncLogger::Impl::enqueue(LogLevel level, std::string_view message) noexcept
     {
-        if (m_shutdown_requested.load(std::memory_order_acquire))
+        // The seq_cst registration and state check form an admission handshake with shutdown's state transition. A
+        // producer that observes Async remains visible until it publishes or drops; one that arrives after Stopping
+        // cannot publish.
+        m_active_producers.fetch_add(1, std::memory_order_seq_cst);
+        if (m_state.load(std::memory_order_seq_cst) != State::Async)
         {
-            std::lock_guard<std::mutex> lock(*m_log_mutex);
-            if (!m_file_stream->is_open() || !m_file_stream->good())
-            {
-                // Stream already closed or failed during teardown: the message cannot be delivered, so report the drop
-                // rather than a false success.
-                return false;
-            }
-
-            const auto now = std::chrono::system_clock::now();
-            const auto time_t = std::chrono::system_clock::to_time_t(now);
-            std::tm tm_buf{};
-
-#if defined(_WIN32) || defined(_MSC_VER)
-            localtime_s(&tm_buf, &time_t);
-#else
-            localtime_r(&time_t, &tm_buf);
-#endif
-
-            const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
-            *m_file_stream << "[" << std::put_time(&tm_buf, m_config.timestamp_format.c_str()) << "."
-                           << std::setfill('0') << std::setw(3) << ms.count() << std::setfill(' ') << "] "
-                           << "[" << std::setw(7) << std::left << to_string(level) << "] :: " << message << '\n';
-            m_file_stream->flush();
-
-            // Surface a write/flush failure through the no-throw delivery bool.
-            return m_file_stream->good();
+            m_dropped_messages.fetch_add(1, std::memory_order_relaxed);
+            finish_producer();
+            return false;
         }
+
+#if defined(DMK_ENABLE_TEST_SEAMS)
+        if (auto *gate = detail::g_async_logger_producer_gate.load(std::memory_order_acquire))
+        {
+            detail::g_async_logger_producer_waiting.store(true, std::memory_order_release);
+            while (gate->load(std::memory_order_acquire))
+            {
+                std::this_thread::yield();
+            }
+            detail::g_async_logger_producer_waiting.store(false, std::memory_order_release);
+        }
+#endif
 
         LogMessage msg(level, message);
 
@@ -639,25 +651,34 @@ namespace DetourModKit
         if (m_queue.try_push(msg))
         {
             notify_writer();
+            finish_producer();
             return true;
         }
         // Push failed -- undo the pre-increment before entering overflow handling
         m_pending_messages.fetch_sub(1, std::memory_order_seq_cst);
-        return handle_overflow(std::move(msg));
+        const bool handled = handle_overflow(std::move(msg));
+        finish_producer();
+        return handled;
     }
 
     bool AsyncLogger::Impl::flush_with_timeout(std::chrono::milliseconds timeout) noexcept
     {
-        if (!m_running.load(std::memory_order_acquire))
-        {
-            return true;
-        }
-
+        // Succeeds only on a genuine drain acknowledgement -- the pending count reaching zero -- never merely because
+        // the writer stopped. A stopped writer with an undrained queue must report a failed flush, not a false
+        // success. The predicate is checked before the wait, so an already-drained logger returns at once.
         std::unique_lock<std::mutex> lock(m_flush_mutex);
-
-        const bool flushed = m_flush_cv.wait_for(lock, timeout, [this]() noexcept
-                                                 { return m_pending_messages.load(std::memory_order_acquire) == 0; });
-
+#if defined(DMK_ENABLE_TEST_SEAMS)
+        detail::g_async_logger_flush_waiting.store(true, std::memory_order_release);
+#endif
+        const bool flushed = m_flush_cv.wait_for(lock, timeout,
+                                                 [this]() noexcept
+                                                 {
+                                                     return m_pending_messages.load(std::memory_order_acquire) == 0 &&
+                                                            m_active_producers.load(std::memory_order_seq_cst) == 0;
+                                                 });
+#if defined(DMK_ENABLE_TEST_SEAMS)
+        detail::g_async_logger_flush_waiting.store(false, std::memory_order_release);
+#endif
         return flushed;
     }
 
@@ -668,66 +689,78 @@ namespace DetourModKit
 
     void AsyncLogger::Impl::shutdown() noexcept
     {
-        bool expected = false;
-        if (!m_shutdown_requested.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+        State expected = State::Async;
+        if (!m_state.compare_exchange_strong(expected, State::Stopping, std::memory_order_seq_cst))
         {
+            // Already Stopping or Stopped: shutdown ran once and owns the teardown.
             return;
         }
 
-        m_running.store(false, std::memory_order_release);
-
-        // Wake the writer if it is parked. Taking m_flush_mutex serializes this notify with the writer's
-        // atomic unlock-and-block inside wait_for, so a parked writer observes m_running == false promptly
-        // instead of waiting out the flush interval before it can exit and be joined below.
-        {
-            std::lock_guard<std::mutex> lock(m_flush_mutex);
-            m_flush_cv.notify_all();
-        }
+        // The changed wait predicate makes a lock unnecessary here. Avoiding m_flush_mutex is required on the
+        // loader-lock abandon path, where waiting for a writer-owned mutex can deadlock process teardown.
+        m_flush_cv.notify_all();
 
         if (m_writer_thread.joinable())
         {
             if (detail::async_logger_loader_lock_held())
             {
-                // Under the loader lock we cannot join. Detach the writer and leak its module reference (taken before
-                // thread creation), keeping the writer's code mapped for the rest of the process while it drains and
-                // exits. Latch that the writer is detached so ~AsyncLogger leaks this Impl in place instead of
-                // destroying the queue / cv / file stream out from under that still-running writer.
-                m_writer_thread.detach();
+                // Loader-lock abandon: publish the stop and return immediately. The retained writer alone finishes
+                // the drain, owns final sink access, resets the pending counter, and performs the Stopping->Stopped
+                // transition at its tail. Draining or zeroing the counter here would make this thread a second
+                // consumer of the same queue and sink and could underflow the counter against the writer's own
+                // decrement. Detach the writer and leak its module reference (taken before thread creation) so its
+                // code stays mapped, and latch the detach so ~AsyncLogger leaks this Impl in place instead of freeing
+                // the queue / cv / file stream the writer still reads.
+                try
+                {
+                    m_writer_thread.detach();
+                }
+                catch (...)
+                {
+                    // The Impl is abandoned below, so a still-joinable jthread remains live storage rather than
+                    // reaching its joining destructor under the loader lock.
+                }
                 m_writer_detached.store(true, std::memory_order_release);
                 DetourModKit::diagnostics::record_intentional_leak(
                     DetourModKit::diagnostics::LeakSubsystem::AsyncLogger);
+                return;
             }
-            else
+
+            try
             {
                 m_writer_thread.join();
-                // Joined off the loader lock: the writer's code is done, so drop the reference taken before thread
-                // creation. Another reference on the module still exists (the caller running this teardown), so this is
-                // never terminal.
-                release_module_ref(static_cast<HMODULE>(m_writer_self_ref));
-                m_writer_self_ref = nullptr;
             }
+            catch (...)
+            {
+                try
+                {
+                    if (m_writer_thread.joinable())
+                    {
+                        m_writer_thread.detach();
+                    }
+                }
+                catch (...)
+                {
+                    // The leaked Impl keeps a still-joinable thread object alive.
+                }
+                m_writer_detached.store(true, std::memory_order_release);
+                DetourModKit::diagnostics::record_intentional_leak(
+                    DetourModKit::diagnostics::LeakSubsystem::AsyncLogger);
+                return;
+            }
+            // Joined off the loader lock: the writer's code is done, so drop the reference taken before thread
+            // creation. Another reference on the module still exists (the caller running this teardown), so this is
+            // never terminal.
+            release_module_ref(static_cast<HMODULE>(m_writer_self_ref));
+            m_writer_self_ref = nullptr;
         }
 
-        // Drain any messages enqueued between m_running=false and the writer thread exiting. Without this,
-        // late-arriving messages would be silently lost and the force-zero below would mask the discrepancy.
-        //
-        // A narrow race remains: a producer that already passed the m_shutdown_requested check in enqueue() but has not
-        // yet called try_push() can enqueue one message after this drain completes. This is an accepted trade-off --
-        // closing it would require a producers_in_flight atomic counter on every enqueue() call, adding two atomic RMW
-        // operations to the hot path. At most one message per producer thread can be lost, and only during the
-        // nanosecond window between the drain and the force-zero below.
-        drain_remaining();
-
-        {
-            std::lock_guard<std::mutex> lock(m_flush_mutex);
-            m_pending_messages.store(0, std::memory_order_release);
-            m_flush_cv.notify_all();
-        }
+        // The writer waits for every admitted producer and owns the complete drain before join returns.
     }
 
     bool AsyncLogger::Impl::is_running() const noexcept
     {
-        return m_running.load(std::memory_order_acquire);
+        return m_state.load(std::memory_order_acquire) == State::Async;
     }
 
     bool AsyncLogger::Impl::is_writer_waiting() const noexcept
@@ -765,6 +798,15 @@ namespace DetourModKit
         return m_writer_detached.load(std::memory_order_acquire);
     }
 
+    void AsyncLogger::Impl::finish_producer() noexcept
+    {
+        const size_t previous = m_active_producers.fetch_sub(1, std::memory_order_seq_cst);
+        if (previous == 1 && m_state.load(std::memory_order_seq_cst) != State::Async)
+        {
+            m_flush_cv.notify_all();
+        }
+    }
+
     void AsyncLogger::Impl::notify_writer() noexcept
     {
         // The caller has already incremented m_pending_messages and published the queue slot. In the
@@ -795,8 +837,18 @@ namespace DetourModKit
 
         auto last_flush = std::chrono::steady_clock::now();
 
-        while (m_running.load(std::memory_order_acquire) || !m_queue.empty())
+        while (m_state.load(std::memory_order_seq_cst) == State::Async ||
+               m_active_producers.load(std::memory_order_seq_cst) != 0 || !m_queue.empty())
         {
+#if defined(DMK_ENABLE_TEST_SEAMS)
+            // Test-only pause point: hold the writer off the queue while a fixture inspects the pre-drain state.
+            for (auto *gate = detail::g_async_logger_writer_gate.load(std::memory_order_acquire);
+                 gate && gate->load(std::memory_order_acquire);
+                 gate = detail::g_async_logger_writer_gate.load(std::memory_order_acquire))
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+#endif
             batch.clear();
             // The popped count is not needed here; the batch.empty() check below decides between the write path and the
             // idle-flush path.
@@ -824,8 +876,9 @@ namespace DetourModKit
                 // returns without blocking and the next cycle spins again -- bounded each pass rather than a
                 // tight hot loop. The writer only truly blocks once pending reaches zero (the genuinely idle
                 // case), where notify_writer() or the flush-interval timeout wakes it.
-                for (size_t spin = 0; spin < INFLIGHT_SPIN_LIMIT && m_running.load(std::memory_order_acquire) &&
-                                      m_pending_messages.load(std::memory_order_seq_cst) != 0 && m_queue.empty();
+                for (size_t spin = 0;
+                     spin < INFLIGHT_SPIN_LIMIT && m_state.load(std::memory_order_acquire) == State::Async &&
+                     m_pending_messages.load(std::memory_order_seq_cst) != 0 && m_queue.empty();
                      ++spin)
                 {
                     std::this_thread::yield();
@@ -853,7 +906,8 @@ namespace DetourModKit
                                     [this]() noexcept
                                     {
                                         return m_pending_messages.load(std::memory_order_seq_cst) != 0 ||
-                                               !m_running.load(std::memory_order_acquire);
+                                               (m_state.load(std::memory_order_seq_cst) != State::Async &&
+                                                m_active_producers.load(std::memory_order_seq_cst) == 0);
                                     });
                 m_writer_waiting.store(false, std::memory_order_seq_cst);
             }
@@ -872,19 +926,11 @@ namespace DetourModKit
             m_pending_messages.store(0, std::memory_order_release);
             m_flush_cv.notify_all();
         }
-    }
 
-    void AsyncLogger::Impl::drain_remaining() noexcept
-    {
-        // No pre-reserve: this frame is noexcept and try_pop_batch owns the fail-closed reservation (see
-        // writer_thread_func). Under OOM a drain iteration may pop fewer items or none; the loop then exits with
-        // some messages still queued, which is the correct fail-closed shutdown behaviour (never a terminate).
-        std::vector<LogMessage> remaining;
-        while (m_queue.try_pop_batch(remaining, m_config.batch_size) > 0)
-        {
-            write_batch(remaining);
-            remaining.clear();
-        }
+        // The writer is the single owner of the Stopping->Stopped transition: it publishes Stopped only after the
+        // queue is fully drained, the sink flushed, and the pending counter zeroed above. On the loader-lock abandon
+        // path shutdown() returned early and left this final acknowledgement to the retained writer.
+        m_state.store(State::Stopped, std::memory_order_release);
     }
 
     void AsyncLogger::Impl::write_batch(std::span<LogMessage> messages) noexcept
@@ -1066,7 +1112,7 @@ namespace DetourModKit
         }
 
         // Off the loader lock the writer was joined by shutdown(), so the unique_ptr destroys the Impl normally. ~Impl
-        // calls shutdown() again, but the m_shutdown_requested CAS makes that an idempotent no-op before the members
+        // calls shutdown() again, but the Async->Stopping state CAS makes that an idempotent no-op before the members
         // are freed.
     }
 
@@ -1118,6 +1164,11 @@ namespace DetourModKit
     void AsyncLogger::reset_dropped_count() noexcept
     {
         m_impl->reset_dropped_count();
+    }
+
+    bool AsyncLogger::writer_was_detached() const noexcept
+    {
+        return m_impl->writer_was_detached();
     }
 
 } // namespace DetourModKit

--- a/src/internal/async_logger.hpp
+++ b/src/internal/async_logger.hpp
@@ -19,26 +19,16 @@ namespace DetourModKit
     /**
      * @class AsyncLogger
      * @brief Asynchronous logger that decouples log production from file I/O.
-     * @details Uses a lock-free queue to accept log messages from multiple threads and a dedicated writer thread to
-     *          perform batched file writes. This significantly reduces latency on the producer side. The configuration
-     *          type (AsyncLoggerConfig) lives in the public async_logger_config.hpp. All implementation state -- the
-     *          MPMC queue, the overflow string pool, the per-message record, the writer thread, and the flush
-     *          synchronization -- lives behind a pimpl (Impl, defined in src/async_logger.cpp over
-     *          src/internal/async_logger_queue.hpp), so this header names none of it and the one translation unit that
-     *          includes it to drive the writer (src/logger.cpp) compiles with the queue / pool / threading internals
-     *          off its include path.
-     * @note Internal transport, not a consumer-constructible type: its only constructor takes a
-     *       `detail::WinFileStream` (a private, never-installed sink) plus the Logger's file mutex, so only `Logger`
-     *       -- which owns both -- builds one, driven by `Logger::enable_async_mode()`. A consumer logs through the
-     *       `Logger` value facade or the free `log()`, never by constructing an `AsyncLogger` directly. That is why
-     *       this definition lives in src/internal and is never installed: `logger.hpp` needs only a forward
-     *       declaration to hold the writer behind an `atomic<shared_ptr<AsyncLogger>>`, so the full type reaches no
-     *       consumer include path.
-     * @note Uses shared_ptr<detail::WinFileStream> to safely handle Logger reconfiguration during runtime.
-     * @note The destructor is self-safe under the Windows loader lock: if teardown had to detach the writer thread
-     *       (because a join would deadlock under the loader lock), the destructor leaks the pimpl in place so the
-     *       queue / condition variable / file stream the detached writer still reads are never freed under it. An owner
-     *       therefore does not have to leak the handle itself to destroy an AsyncLogger safely from a loader-lock path.
+     * @details A dedicated writer thread drains a lock-free MPMC queue and performs batched writes, so producers pay
+     *          only an enqueue. All transport state (queue, string pool, per-message record, writer, flush
+     *          synchronization) lives behind a pimpl, so this header names none of it.
+     * @note Internal transport, not a consumer-constructible type. Its constructor takes a private, never-installed
+     *       `detail::WinFileStream` sink plus the Logger's file mutex, so only `Logger` builds one (through
+     *       `Logger::enable_async_mode()`); a consumer logs through the `Logger` facade or the free `log()`.
+     * @note The sink is held by shared_ptr so a runtime Logger reconfigure can swap it safely.
+     * @note The destructor is self-safe under the Windows loader lock: if shutdown() had to detach the writer (a join
+     *       would deadlock under the loader lock), it leaks the pimpl in place so the queue / condition variable / file
+     *       stream the detached writer still reads are never freed under it.
      */
     class AsyncLogger
     {
@@ -54,11 +44,10 @@ namespace DetourModKit
 
         /**
          * @brief Stops the writer and destroys the logger, staying safe under the Windows loader lock.
-         * @details Runs shutdown() first. On a clean off-loader-lock teardown the writer is joined and the pimpl is
-         *          destroyed normally. If shutdown() had to DETACH the writer (loader-lock path), the pimpl is instead
-         *          leaked in place -- the already-heap-allocated implementation is abandoned rather than freed -- so the
-         *          detached writer keeps reading a live queue / condition variable / file stream until it observes the
-         *          stop and exits. The writer's own counted module reference keeps its code pages mapped.
+         * @details Runs shutdown() first. Off the loader lock the writer is joined and the pimpl destroyed normally. If
+         *          shutdown() had to detach the writer (loader-lock path), the pimpl is leaked in place so the detached
+         *          writer keeps reading a live queue / condition variable / file stream until it observes the stop; its
+         *          own counted module reference keeps its code pages mapped.
          */
         ~AsyncLogger() noexcept;
 
@@ -75,7 +64,9 @@ namespace DetourModKit
          * @details Non-blocking under the DropNewest / DropOldest policies. Under OverflowPolicy::Block a full queue
          *          parks the caller up to block_timeout_ms, and under OverflowPolicy::SyncFallback a full queue writes
          *          the message synchronously on the calling thread, so neither of those policies is callback-safe (see
-         *          OverflowPolicy). Otherwise the message is written by the writer thread.
+         *          OverflowPolicy). Otherwise the message is written by the writer thread. Once shutdown has begun the
+         *          message is dropped and counted under every policy; a callback-safe producer never blocks on
+         *          synchronous I/O during teardown.
          * @note Best-effort: never throws and returns false on drop. Callback-safe only under the DropNewest /
          *       DropOldest policies (see @details).
          */
@@ -96,19 +87,23 @@ namespace DetourModKit
         void flush() noexcept;
 
         /**
-         * @brief Stops the writer thread and drains remaining queued messages.
-         * @details Signals shutdown. Off the Windows loader lock, joins the writer thread, then drains any messages
-         * that
-         *          arrived between the stop signal and thread exit. Under the loader lock, detaches the writer instead
-         *          of joining; the destructor observes that detach and leaks the pimpl in place so the detached writer's
-         *          queue, condition variable, and file stream stay alive until the writer exits.
-         * @note A producer that already passed the shutdown check but has not yet completed try_push() can enqueue at
-         *       most one message after the final drain. This is an accepted trade-off to avoid adding atomic overhead
-         *       (producers_in_flight counter) to every enqueue() call.
+         * @brief Requests shutdown and gives the drain and final sink access a single owner.
+         * @details Stops admission, waits for producers already admitted, and lets the writer alone finish the drain
+         *          and sink flush. Off the Windows loader lock it joins the writer. Under the loader lock it abandons
+         *          the writer and pimpl without waiting, draining, or touching the sink.
          */
         void shutdown() noexcept;
 
         [[nodiscard]] bool is_running() const noexcept;
+
+        /**
+         * @brief Reports whether shutdown() detached the writer under the loader lock instead of joining it.
+         * @details The owner reads this after shutdown() to decide sink ownership: a detached writer still owns final
+         *          sink access, so the sink must be abandoned (leaked with the detached Impl), never closed. Tying that
+         *          decision to the actual detach outcome, rather than an independent loader-lock re-query, removes a
+         *          TOCTOU between the two.
+         */
+        [[nodiscard]] bool writer_was_detached() const noexcept;
 
         /**
          * @brief Reports whether the writer thread is currently parked on the flush condition variable.
@@ -142,7 +137,7 @@ namespace DetourModKit
 
         // All implementation state and behaviour live behind this pimpl so the queue, string pool, per-message record,
         // writer thread, and flush synchronization stay off the public include path (their definitions live in the
-        // non-installed src/internal/async_logger_queue.hpp, reached only by src/async_logger.cpp).
+        // non-installed src/internal/async_logger_queue.hpp, reached only by src/internal/async_logger.cpp).
         struct Impl;
         std::unique_ptr<Impl> m_impl;
     };

--- a/src/internal/async_logger_queue.hpp
+++ b/src/internal/async_logger_queue.hpp
@@ -202,7 +202,7 @@ namespace DetourModKit::detail
          * @param max_count Maximum number of items to pop.
          * @return size_t Number of items actually popped.
          * @note noexcept and fail-closed under allocation pressure. It is called from the writer thread's noexcept
-         *       frames (writer_thread_func / drain_remaining), so a throwing reserve would be an unrecoverable
+         *       frame (writer_thread_func), so a throwing reserve would be an unrecoverable
          *       std::terminate. Instead it reserves headroom under a local try/catch and, if that allocation fails,
          *       pops only as many items as the vector's existing spare capacity allows -- the LogMessage move is
          *       noexcept, so push_back within capacity never allocates and never throws. Under OOM a smaller batch

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -282,29 +282,20 @@ namespace DetourModKit
             gap_probe();
         }
 
-        // If the writer thread was detached under loader lock, it may still be accessing AsyncLogger members (m_queue,
-        // m_flush_mutex, etc.). Transfer ownership to permanent heap storage so the object outlives the detached
-        // thread; the writer thread holds its own module reference (taken before thread creation), which keeps the code
-        // pages it executes from mapped.
-        //
-        // The transfer is unconditional when loader lock is held: concurrent log() callers may still own temporary
-        // shared_ptrs obtained from m_async_logger before exchange(), so use_count() is not a reliable proxy for "no
-        // other owners". Dropping local_logger's ref while a temporary outlives us would let the last temporary's
-        // destructor race the detached writer thread.
-        //
-        // The leak is per-call and append-only: each invocation retains its own shared_ptr cell, so a process that
-        // re-attaches after shutdown (e.g. hot-reload) and hits loader lock again cannot drop a prior handle whose
-        // writer thread may still be running. The helper first tries new (std::nothrow), then non-CRT permanent storage
-        // fallbacks, so the noexcept destructor never frees the logger merely because the heap cell could not be
-        // allocated.
-        if (local_logger && detail::is_loader_lock_held())
+        // A detached writer still owns the AsyncLogger state and final sink access. Retain the handle permanently and
+        // return without sink I/O. Keying on the recorded detach outcome avoids a loader-lock re-query race, and an
+        // unconditional per-call leak protects temporary shared_ptr owners and repeated detach cycles. The retention
+        // helper has non-throwing permanent-storage fallbacks.
+        if (local_logger && local_logger->writer_was_detached())
         {
             leak_async_logger_handle(local_logger);
+            return;
         }
 
         {
-            // Acquire both mutexes to prevent configure()/reconfigure() from opening a new stream in the gap after the
-            // async-logger teardown block above releases m_async_mutex.
+            // Normal path: the writer was joined (or async was never enabled), so this thread is the single owner of
+            // final sink access. Acquire both mutexes to prevent configure()/reconfigure() from opening a new stream in
+            // the gap after the async-logger teardown block above releases m_async_mutex.
             std::scoped_lock lock(m_async_mutex, *m_log_mutex_ptr);
             if (m_log_file_stream_ptr && m_log_file_stream_ptr->is_open())
             {
@@ -337,6 +328,11 @@ namespace DetourModKit
 
     bool Logger::log(LogLevel level, std::string_view message)
     {
+        if (m_shutdown_called.load(std::memory_order_acquire))
+        {
+            return false;
+        }
+
         if (level < m_current_log_level.load(std::memory_order_acquire))
         {
             return false;
@@ -358,6 +354,13 @@ namespace DetourModKit
 
         const auto level_str = to_string(level);
         std::lock_guard<std::mutex> lock(*m_log_mutex_ptr);
+
+        // Close the race where shutdown exchanges the async handle after the first check but before this thread reaches
+        // the synchronous sink. An admitted synchronous write finishes before shutdown can acquire this same mutex.
+        if (m_shutdown_called.load(std::memory_order_acquire))
+        {
+            return false;
+        }
 
         if (m_log_file_stream_ptr->is_open() && m_log_file_stream_ptr->good())
         {
@@ -580,17 +583,9 @@ namespace DetourModKit
             should_log = true;
         }
 
-        // If the writer thread was detached under loader lock it may still be touching AsyncLogger members (m_queue,
-        // m_flush_mutex, etc.). Mirror shutdown_internal's discipline: transfer ownership to permanent heap storage so
-        // the object outlives the detached thread; the writer thread's own module reference (taken before thread
-        // creation) keeps the code pages it runs from mapped.
-        // Dropping the last shared_ptr here instead would let the AsyncLogger destructor race the live writer -- a
-        // use-after-free. The transfer is unconditional under loader lock since concurrent log() callers may still own
-        // temporaries fetched before the exchange, so use_count() is an unreliable "no other owners" proxy. The leak is
-        // per-call and append-only, so a hot-reload cycle (disable -> enable -> disable) that hits loader lock again
-        // cannot drop a prior handle whose writer may still be running. The helper first tries new (std::nothrow), then
-        // non-CRT permanent storage fallbacks, so the object is retained even if the heap cell cannot be allocated.
-        const bool leaked_under_loader_lock = local_async && detail::is_loader_lock_held();
+        // Mirror shutdown_internal's ownership rule: a detached writer keeps exclusive access to live AsyncLogger
+        // state, so retain every detached handle through the non-throwing permanent-storage path.
+        const bool leaked_under_loader_lock = local_async && local_async->writer_was_detached();
         if (leaked_under_loader_lock)
         {
             leak_async_logger_handle(local_async);

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -362,7 +362,7 @@ TEST_F(AsyncLoggerTest, IsRunningAfterShutdown)
     EXPECT_FALSE(logger->is_running());
 }
 
-TEST_F(AsyncLoggerTest, EnqueueAfterShutdown_SyncWrite)
+TEST_F(AsyncLoggerTest, EnqueueAfterShutdownDropsAndCounts)
 {
     AsyncLoggerConfig config;
     config.batch_size = 10;
@@ -376,9 +376,13 @@ TEST_F(AsyncLoggerTest, EnqueueAfterShutdown_SyncWrite)
     logger->shutdown();
     EXPECT_FALSE(logger->is_running());
 
-    EXPECT_TRUE(logger->enqueue(LogLevel::Info, "Post-shutdown sync message"));
-    EXPECT_TRUE(logger->enqueue(LogLevel::Error, "Post-shutdown sync error"));
-    EXPECT_TRUE(logger->enqueue(LogLevel::Warning, "Post-shutdown sync warning"));
+    // Once shutdown has begun the retained writer owns final sink access, so a callback-safe producer must drop and
+    // count rather than switch to blocking synchronous I/O.
+    const std::size_t before = logger->dropped_count();
+    EXPECT_FALSE(logger->enqueue(LogLevel::Info, "Post-shutdown message"));
+    EXPECT_FALSE(logger->enqueue(LogLevel::Error, "Post-shutdown error"));
+    EXPECT_FALSE(logger->enqueue(LogLevel::Warning, "Post-shutdown warning"));
+    EXPECT_EQ(logger->dropped_count(), before + 3);
 }
 
 TEST_F(AsyncLoggerTest, Flush_WhenNotRunning)
@@ -661,7 +665,7 @@ TEST(DynamicMPMCQueueTest, FullAndEmptyQueue)
 
 TEST(DynamicMPMCQueueTest, TryPopBatch_ReserveOom_FailsClosed)
 {
-    // try_pop_batch is called from the writer thread's noexcept frames (writer_thread_func / drain_remaining), so a
+    // try_pop_batch is called from the writer thread's noexcept frame, so a
     // throwing reserve would std::terminate the host under memory pressure. It must instead fail closed: catch the
     // allocation failure and pop only within the vector's existing spare capacity. Here the destination vector has zero
     // capacity, so the injected reserve failure leaves no headroom and the call pops nothing -- rather than
@@ -1389,7 +1393,7 @@ TEST_F(AsyncLoggerTest, SyncFallback_WritesWhenQueueFull)
     EXPECT_NE(content.find("sync_fallback_message"), std::string::npos);
 }
 
-TEST_F(AsyncLoggerTest, EnqueueAfterShutdown_WritesSync)
+TEST_F(AsyncLoggerTest, EnqueueAfterShutdownIsNotWrittenToSink)
 {
     AsyncLoggerConfig config;
     config.queue_capacity = 64;
@@ -1401,15 +1405,15 @@ TEST_F(AsyncLoggerTest, EnqueueAfterShutdown_WritesSync)
     AsyncLogger logger(config, file_stream, log_mutex);
     logger.shutdown();
 
-    // After shutdown, enqueue should fall back to synchronous write
-    bool result = logger.enqueue(LogLevel::Info, "post_shutdown_message");
-    EXPECT_TRUE(result);
+    // After shutdown the producer drops and counts; it does not write synchronously to the sink the retained writer
+    // owns, so the message never reaches the file.
+    EXPECT_FALSE(logger.enqueue(LogLevel::Info, "post_shutdown_message"));
 
     file_stream->close();
 
     std::ifstream read_file(m_test_log_file.string());
     std::string content((std::istreambuf_iterator<char>(read_file)), std::istreambuf_iterator<char>());
-    EXPECT_NE(content.find("post_shutdown_message"), std::string::npos);
+    EXPECT_EQ(content.find("post_shutdown_message"), std::string::npos);
 }
 
 TEST_F(AsyncLoggerTest, MultiThread_EnqueueStress)
@@ -1910,6 +1914,10 @@ TEST_F(AsyncLoggerTest, ParkedWriterNeverStallsToFlushInterval)
 namespace DetourModKit::detail
 {
     extern bool (*g_async_logger_loader_lock_override)() noexcept;
+    extern std::atomic<std::atomic<bool> *> g_async_logger_writer_gate;
+    extern std::atomic<std::atomic<bool> *> g_async_logger_producer_gate;
+    extern std::atomic<bool> g_async_logger_producer_waiting;
+    extern std::atomic<bool> g_async_logger_flush_waiting;
 } // namespace DetourModKit::detail
 
 namespace
@@ -1918,6 +1926,35 @@ namespace
     {
         return true;
     }
+
+    class AsyncLoggerSeamReset
+    {
+    public:
+        AsyncLoggerSeamReset(std::atomic<bool> *writer_gate, std::atomic<bool> *producer_gate) noexcept
+            : m_writer_gate(writer_gate), m_producer_gate(producer_gate)
+        {
+        }
+
+        ~AsyncLoggerSeamReset() noexcept
+        {
+            m_producer_gate->store(false, std::memory_order_release);
+            m_writer_gate->store(false, std::memory_order_release);
+            DetourModKit::detail::g_async_logger_producer_gate.store(nullptr, std::memory_order_release);
+            DetourModKit::detail::g_async_logger_writer_gate.store(nullptr, std::memory_order_release);
+            DetourModKit::detail::g_async_logger_producer_waiting.store(false, std::memory_order_release);
+            DetourModKit::detail::g_async_logger_flush_waiting.store(false, std::memory_order_release);
+            DetourModKit::detail::g_async_logger_loader_lock_override = nullptr;
+        }
+
+        AsyncLoggerSeamReset(const AsyncLoggerSeamReset &) = delete;
+        AsyncLoggerSeamReset &operator=(const AsyncLoggerSeamReset &) = delete;
+        AsyncLoggerSeamReset(AsyncLoggerSeamReset &&) = delete;
+        AsyncLoggerSeamReset &operator=(AsyncLoggerSeamReset &&) = delete;
+
+    private:
+        std::atomic<bool> *m_writer_gate;
+        std::atomic<bool> *m_producer_gate;
+    };
 } // namespace
 
 TEST_F(AsyncLoggerTest, DestructorUnderLoaderLockLeaksImplAndDoesNotHang)
@@ -1954,6 +1991,106 @@ TEST_F(AsyncLoggerTest, DestructorUnderLoaderLockLeaksImplAndDoesNotHang)
     // strong ownership, not the writer's raw access.
     EXPECT_GE(file_stream.use_count(), 2L)
         << "~AsyncLogger destroyed the Impl instead of leaking it; the detached writer's file stream was freed";
-    // The Impl (queue, cv, file stream) is intentionally leaked; the detached writer observes m_running == false and
-    // exits on its own. FILE_SHARE_DELETE lets TearDown still remove the log file even with the leaked handle open.
+    // The Impl (queue, cv, file stream) is intentionally leaked; the detached writer observes the stop and exits on
+    // its own. FILE_SHARE_DELETE lets TearDown still remove the log file even with the leaked handle open.
+}
+
+TEST_F(AsyncLoggerTest, LoaderLockAbandonLeavesDrainAndSinkToTheRetainedWriter)
+{
+    namespace diag = DetourModKit::diagnostics;
+    diag::reset_intentional_leaks();
+
+    AsyncLoggerConfig config;
+    config.queue_capacity = 64;
+    config.batch_size = 8;
+    config.flush_interval = std::chrono::milliseconds{20};
+    config.overflow_policy = OverflowPolicy::DropNewest;
+
+    auto file_stream = std::make_shared<WinFileStream>(m_test_log_file.string());
+    auto log_mutex = std::make_shared<std::mutex>();
+
+    static std::atomic<bool> writer_gate{true};
+    static std::atomic<bool> producer_gate{true};
+    writer_gate.store(true, std::memory_order_release);
+    producer_gate.store(true, std::memory_order_release);
+    DetourModKit::detail::g_async_logger_producer_waiting.store(false, std::memory_order_release);
+    DetourModKit::detail::g_async_logger_flush_waiting.store(false, std::memory_order_release);
+    DetourModKit::detail::g_async_logger_writer_gate.store(&writer_gate, std::memory_order_release);
+    DetourModKit::detail::g_async_logger_loader_lock_override = &al_always_true_loader_lock;
+
+    std::jthread producer;
+    std::jthread flusher;
+    AsyncLoggerSeamReset seam_reset{&writer_gate, &producer_gate};
+    auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
+
+    constexpr int MESSAGE_COUNT = 12;
+    for (int i = 0; i < MESSAGE_COUNT; ++i)
+    {
+        ASSERT_TRUE(logger->enqueue(LogLevel::Info, "ABANDON_DRAIN_" + std::to_string(i)));
+    }
+    ASSERT_EQ(logger->queue_size(), static_cast<size_t>(MESSAGE_COUNT));
+
+    DetourModKit::detail::g_async_logger_producer_gate.store(&producer_gate, std::memory_order_release);
+    std::atomic<bool> producer_result{false};
+    producer = std::jthread(
+        [&logger, &producer_result]() noexcept -> void
+        { producer_result.store(logger->enqueue(LogLevel::Info, "ABANDON_CONCURRENT"), std::memory_order_release); });
+
+    const auto producer_deadline = std::chrono::steady_clock::now() + std::chrono::seconds{5};
+    while (!DetourModKit::detail::g_async_logger_producer_waiting.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < producer_deadline)
+    {
+        std::this_thread::yield();
+    }
+    ASSERT_TRUE(DetourModKit::detail::g_async_logger_producer_waiting.load(std::memory_order_acquire));
+
+    std::atomic<bool> flush_result{false};
+    std::atomic<bool> flush_finished{false};
+    flusher = std::jthread(
+        [&logger, &flush_result, &flush_finished]() noexcept -> void
+        {
+            flush_result.store(logger->flush_with_timeout(std::chrono::seconds{5}), std::memory_order_release);
+            flush_finished.store(true, std::memory_order_release);
+        });
+
+    const auto flush_deadline = std::chrono::steady_clock::now() + std::chrono::seconds{5};
+    while (!DetourModKit::detail::g_async_logger_flush_waiting.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < flush_deadline)
+    {
+        std::this_thread::yield();
+    }
+    ASSERT_TRUE(DetourModKit::detail::g_async_logger_flush_waiting.load(std::memory_order_acquire));
+
+    const auto start_time = std::chrono::steady_clock::now();
+    logger->shutdown();
+    const auto shutdown_elapsed = std::chrono::steady_clock::now() - start_time;
+
+    EXPECT_LT(shutdown_elapsed, std::chrono::seconds(2)) << "loader-lock abandon must not join the writer";
+    EXPECT_TRUE(logger->writer_was_detached());
+    EXPECT_EQ(logger->queue_size(), static_cast<size_t>(MESSAGE_COUNT))
+        << "shutdown drained the queue; the retained writer must be the only consumer";
+    EXPECT_EQ(logger->dropped_count(), 0u) << "shutdown dropped queued messages instead of leaving them to the writer";
+    EXPECT_GE(diag::intentional_leak_count(diag::LeakSubsystem::AsyncLogger), 1u);
+
+    EXPECT_FALSE(flush_finished.load(std::memory_order_acquire));
+
+    // Draining the published queue is insufficient while an admitted producer is still paused before publication.
+    writer_gate.store(false, std::memory_order_release);
+    EXPECT_FALSE(flush_finished.load(std::memory_order_acquire));
+
+    producer_gate.store(false, std::memory_order_release);
+    producer.join();
+    EXPECT_TRUE(producer_result.load(std::memory_order_acquire));
+    flusher.join();
+    EXPECT_TRUE(flush_result.load(std::memory_order_acquire))
+        << "the retained writer did not drain, or the pending counter underflowed";
+    EXPECT_EQ(logger->queue_size(), 0u);
+
+    std::ifstream read_file(m_test_log_file.string());
+    std::string content((std::istreambuf_iterator<char>(read_file)), std::istreambuf_iterator<char>());
+    for (int i = 0; i < MESSAGE_COUNT; ++i)
+    {
+        EXPECT_NE(content.find("ABANDON_DRAIN_" + std::to_string(i)), std::string::npos) << "message " << i << " lost";
+    }
+    EXPECT_NE(content.find("ABANDON_CONCURRENT"), std::string::npos);
 }

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -2024,9 +2024,11 @@ TEST_F(AsyncLoggerTest, LoaderLockAbandonLeavesDrainAndSinkToTheRetainedWriter)
     auto logger = std::make_unique<AsyncLogger>(config, file_stream, log_mutex);
 
     constexpr int MESSAGE_COUNT = 12;
+    // Trailing '|' terminates each index so a later readback matches it exactly: without it "ABANDON_DRAIN_1" is a
+    // prefix of "ABANDON_DRAIN_10"/"_11", and a lost message 1 would still be found inside message 10's line.
     for (int i = 0; i < MESSAGE_COUNT; ++i)
     {
-        ASSERT_TRUE(logger->enqueue(LogLevel::Info, "ABANDON_DRAIN_" + std::to_string(i)));
+        ASSERT_TRUE(logger->enqueue(LogLevel::Info, "ABANDON_DRAIN_" + std::to_string(i) + "|"));
     }
     ASSERT_EQ(logger->queue_size(), static_cast<size_t>(MESSAGE_COUNT));
 
@@ -2090,7 +2092,8 @@ TEST_F(AsyncLoggerTest, LoaderLockAbandonLeavesDrainAndSinkToTheRetainedWriter)
     std::string content((std::istreambuf_iterator<char>(read_file)), std::istreambuf_iterator<char>());
     for (int i = 0; i < MESSAGE_COUNT; ++i)
     {
-        EXPECT_NE(content.find("ABANDON_DRAIN_" + std::to_string(i)), std::string::npos) << "message " << i << " lost";
+        EXPECT_NE(content.find("ABANDON_DRAIN_" + std::to_string(i) + "|"), std::string::npos)
+            << "message " << i << " lost";
     }
     EXPECT_NE(content.find("ABANDON_CONCURRENT"), std::string::npos);
 }

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -314,8 +314,7 @@ TEST_F(LoggerTest, LoggingAfterShutdown)
     Logger &logger = log();
 
     EXPECT_NO_THROW(logger.shutdown());
-
-    EXPECT_NO_THROW(logger.info("Message after shutdown"));
+    EXPECT_FALSE(logger.log(LogLevel::Info, "Message after shutdown"));
 }
 
 TEST_F(LoggerTest, AsyncModeInvalidConfig)
@@ -880,7 +879,8 @@ TEST_F(LoggerTest, ShutdownAndDestructor_Idempotent)
     logger.shutdown();
     logger.shutdown();
 
-    logger.info("Message after shutdown - should still work");
+    // Logging after shutdown is safe: the facade drops rather than resurrecting or writing to the closed sink.
+    EXPECT_FALSE(logger.log(LogLevel::Info, "Message after shutdown is dropped"));
 }
 
 TEST_F(LoggerTest, ConcurrentShutdownAndLog)
@@ -1910,4 +1910,180 @@ TEST_F(LoggerTest, ReconfigureFormatReachesLiveAsyncWriter)
         }
     }
     EXPECT_TRUE(bravo_line_seen) << "async line missing from the reconfigured file";
+}
+
+namespace DetourModKit::detail
+{
+    extern bool (*g_async_logger_loader_lock_override)() noexcept;
+    extern std::atomic<std::atomic<bool> *> g_async_logger_writer_gate;
+} // namespace DetourModKit::detail
+
+namespace
+{
+    bool logger_detach_always_true_loader_lock() noexcept
+    {
+        return true;
+    }
+
+    class LoggerSeamReset
+    {
+    public:
+        explicit LoggerSeamReset(std::atomic<bool> *writer_gate) noexcept : m_writer_gate(writer_gate) {}
+
+        ~LoggerSeamReset() noexcept
+        {
+            m_writer_gate->store(false, std::memory_order_release);
+            DetourModKit::detail::g_async_logger_writer_gate.store(nullptr, std::memory_order_release);
+            DetourModKit::detail::g_async_logger_loader_lock_override = nullptr;
+        }
+
+        LoggerSeamReset(const LoggerSeamReset &) = delete;
+        LoggerSeamReset &operator=(const LoggerSeamReset &) = delete;
+        LoggerSeamReset(LoggerSeamReset &&) = delete;
+        LoggerSeamReset &operator=(LoggerSeamReset &&) = delete;
+
+    private:
+        std::atomic<bool> *m_writer_gate;
+    };
+} // namespace
+
+TEST_F(LoggerTest, LoaderLockDetachLeaksHandleAndKeepsSinkForTheRetainedWriter)
+{
+    const auto detach_file = std::filesystem::temp_directory_path() /
+                             ("test_logger_detach_" + std::to_string(GetCurrentProcessId()) + ".log");
+    std::error_code error_code;
+    std::filesystem::remove(detach_file, error_code);
+
+    diagnostics::reset_intentional_leaks();
+    const std::size_t leak_count_before = diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::Logger);
+
+    // A process-lifetime flag so the detached writer never reads a dangling pointer after the test returns.
+    static std::atomic<bool> writer_gate{true};
+    writer_gate.store(true, std::memory_order_release);
+
+    constexpr int MESSAGE_COUNT = 10;
+    {
+        Logger logger("TESTDETACH", detach_file.string(), "%H:%M:%S");
+        AsyncLoggerConfig config;
+        config.queue_capacity = 64;
+        config.batch_size = 8;
+        config.flush_interval = std::chrono::milliseconds{20};
+        logger.enable_async_mode(config);
+        ASSERT_TRUE(logger.is_async_mode_enabled());
+
+        DetourModKit::detail::g_async_logger_writer_gate.store(&writer_gate, std::memory_order_release);
+        DetourModKit::detail::g_async_logger_loader_lock_override = &logger_detach_always_true_loader_lock;
+        LoggerSeamReset seam_reset{&writer_gate};
+
+        for (int i = 0; i < MESSAGE_COUNT; ++i)
+        {
+            (void)logger.log(LogLevel::Info, "DETACH_SINK_" + std::to_string(i));
+        }
+
+        logger.shutdown();
+        EXPECT_GE(diagnostics::intentional_leak_count(diagnostics::LeakSubsystem::Logger), leak_count_before + 1)
+            << "loader-lock shutdown must leak the AsyncLogger handle rather than dropping it";
+
+        writer_gate.store(false, std::memory_order_release);
+
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{5};
+        bool all_present = false;
+        while (std::chrono::steady_clock::now() < deadline && !all_present)
+        {
+            std::ifstream input_stream(detach_file);
+            const std::string content((std::istreambuf_iterator<char>(input_stream)), std::istreambuf_iterator<char>());
+            all_present = true;
+            for (int i = 0; i < MESSAGE_COUNT; ++i)
+            {
+                if (content.find("DETACH_SINK_" + std::to_string(i)) == std::string::npos)
+                {
+                    all_present = false;
+                    break;
+                }
+            }
+            if (!all_present)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds{10});
+            }
+        }
+        EXPECT_TRUE(all_present) << "the retained writer did not deliver every message; the sink was closed on abandon";
+    }
+
+    // Best-effort removal; FILE_SHARE_DELETE allows it even with the leaked writer's handle still open.
+    std::filesystem::remove(detach_file, error_code);
+}
+
+// Once shutdown has begun, the facade must drop a synchronous log rather than write it to the sink the detached
+// writer now owns. On the loader-lock abandon path the sink stays OPEN, so without Logger::log()'s m_shutdown_called
+// guard the facade would sync-write into the writer's file and interleave with its drain. This proves the guard: the
+// post-shutdown marker never reaches the file, while the writer still delivers its own pre-shutdown messages.
+TEST_F(LoggerTest, LoaderLockAbandonDropsFacadeSyncWriteToWriterOwnedSink)
+{
+    const auto detach_file = std::filesystem::temp_directory_path() /
+                             ("test_logger_facade_drop_" + std::to_string(GetCurrentProcessId()) + ".log");
+    std::error_code error_code;
+    std::filesystem::remove(detach_file, error_code);
+
+    // A process-lifetime flag so the detached writer never reads a dangling pointer after the test returns.
+    static std::atomic<bool> writer_gate{true};
+    writer_gate.store(true, std::memory_order_release);
+
+    constexpr int MESSAGE_COUNT = 6;
+    {
+        Logger logger("TESTDROP", detach_file.string(), "%H:%M:%S");
+        AsyncLoggerConfig config;
+        config.queue_capacity = 64;
+        config.batch_size = 8;
+        config.flush_interval = std::chrono::milliseconds{20};
+        logger.enable_async_mode(config);
+        ASSERT_TRUE(logger.is_async_mode_enabled());
+
+        DetourModKit::detail::g_async_logger_writer_gate.store(&writer_gate, std::memory_order_release);
+        DetourModKit::detail::g_async_logger_loader_lock_override = &logger_detach_always_true_loader_lock;
+        LoggerSeamReset seam_reset{&writer_gate};
+
+        for (int i = 0; i < MESSAGE_COUNT; ++i)
+        {
+            (void)logger.log(LogLevel::Info, "FACADE_KEEP_" + std::to_string(i));
+        }
+
+        // Loader-lock abandon: the writer is detached and the sink stays open under its ownership.
+        logger.shutdown();
+
+        // The facade must refuse a synchronous write now, even though the sink is still open.
+        EXPECT_FALSE(logger.log(LogLevel::Error, "FACADE_POST_SHUTDOWN_DROP"));
+
+        // Release the writer; it drains the pre-shutdown messages into the sink it exclusively owns.
+        writer_gate.store(false, std::memory_order_release);
+
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{5};
+        bool all_present = false;
+        while (std::chrono::steady_clock::now() < deadline && !all_present)
+        {
+            std::ifstream input_stream(detach_file);
+            const std::string content((std::istreambuf_iterator<char>(input_stream)), std::istreambuf_iterator<char>());
+            all_present = true;
+            for (int i = 0; i < MESSAGE_COUNT; ++i)
+            {
+                if (content.find("FACADE_KEEP_" + std::to_string(i)) == std::string::npos)
+                {
+                    all_present = false;
+                    break;
+                }
+            }
+            if (!all_present)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds{10});
+            }
+        }
+        ASSERT_TRUE(all_present) << "the retained writer did not deliver the pre-shutdown messages";
+
+        // The dropped facade write must never appear in the writer-owned sink.
+        std::ifstream input_stream(detach_file);
+        const std::string content((std::istreambuf_iterator<char>(input_stream)), std::istreambuf_iterator<char>());
+        EXPECT_EQ(content.find("FACADE_POST_SHUTDOWN_DROP"), std::string::npos)
+            << "facade wrote synchronously to the sink the detached writer owns after shutdown began";
+    }
+
+    std::filesystem::remove(detach_file, error_code);
 }


### PR DESCRIPTION
## Summary

Gives async logger shutdown a single owner for the queue drain, final sink access, and pending-counter reset, in both normal and loader-lock teardown (roadmap P0-08 / PR-14A).

## Changes

- Replace the `m_running` + `m_shutdown_requested` pair with one `std::atomic<State>` {Async, Stopping, Stopped}. `shutdown()` only requests `Async -> Stopping`; the writer publishes `Stopped` at its own tail after the final drain, sink flush, and counter zero.
- Add a seq_cst active-producers handshake so the retained writer waits for every admitted producer and is the sole consumer of the queue and sink. This closes the previously documented "one late message can be lost" race.
- Loader-lock abandon publishes the stop and returns immediately: no drain, no counter zeroing, no sink close, no blocking on a writer-held mutex. Logger keys sink abandonment on the new `AsyncLogger::writer_was_detached()` rather than re-querying the loader-lock state, removing a TOCTOU.
- During Stopping/Stopped, callback-safe producers drop and count under every policy instead of falling back to blocking synchronous I/O.
- `flush_with_timeout` succeeds only on a genuine drain acknowledgement (pending and in-flight producers both zero), never merely because the writer stopped.
- Add a `Logger::log()` shutdown guard so a facade sync-write cannot race the detached writer's sink.
- Remove `drain_remaining` (made dead by the single-owner drain).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `writer_was_detached()` so applications can determine whether asynchronous logging remains responsible for the log sink after shutdown.
- **Bug Fixes**
  - Improved shutdown reliability by ensuring queued messages and in-progress logging operations drain safely.
  - Logging requests made after shutdown now consistently return `false`, are dropped, and are counted.
  - Prevented shutdown races that could write to a closed or concurrently closing sink.
  - Improved behavior when shutdown occurs under the Windows loader lock, preserving queued messages for the retained writer.
- **Tests**
  - Added coverage for shutdown, loader-lock, message-draining, and post-shutdown logging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->