### PR TITLE
feat(rtti): generation-aware RTTI and validity-bearing healed offsets

### DIFF
--- a/docs/guides/rtti/rtti-self-heal.md
+++ b/docs/guides/rtti/rtti-self-heal.md
@@ -24,7 +24,7 @@ After a patch moves the pointer to `O' = O +/- delta`, `heal_landmark` scans a w
 
 The one constraint: `T` must be a type that is **stable across patches** (a base/engine type, not a game-specific most-derived subtype), because matching is byte-exact on the most-derived mangled name. A subtype rename defeats healing and fails closed via `HealNoMatch`.
 
-All addresses on this surface are the value-typed `Address` (from `address.hpp`). The typed resolvers (`identify_pointee_typed`, `heal_landmark`, `solve_fingerprint`) return `Result<T>` over the unified `ErrorCode`; the boolean `identify_pointee_type` and the count-returning `reverse_scan_block` keep their lightweight shapes rather than a `Result`. The former `IdentifyError` / `HealError` enums fold into the `ErrorCategory::Rtti` block: `BadSlotAddress` / `UnreadableSlot` / `NoRtti` / `BadDescriptor` / `HealNoMatch` / `HealAmbiguous`.
+All addresses on this surface are the value-typed `Address` (from `address.hpp`). The typed resolvers (`identify_pointee_typed`, `heal_landmark`, `solve_fingerprint`) return `Result<T>` over the unified `ErrorCode`; the boolean `identify_pointee_type` and the count-returning `reverse_scan_block` keep their lightweight shapes rather than a `Result`. RTTI failures use the `ErrorCategory::Rtti` block: `BadSlotAddress` / `UnreadableSlot` / `NoRtti` / `BadDescriptor` / `HealNoMatch` / `HealAmbiguous`.
 
 ## The layers
 
@@ -164,17 +164,18 @@ L1-L4 answer *where did the field move?* once. `HealScheduler` answers the rende
 
 ```cpp
 // One process-wide cache slot per offset (the render thread reads these every frame; the heal writes them once).
-std::atomic<std::ptrdiff_t> g_health_off{0x2A0};
+rtti::HealedSlot s_health_off;
 
 auto healer = rtti::HealScheduler::start({.interval_frames = 30}); // 0 -> ErrorCode::InvalidArg
 // ... check healer, then:
 rtti::HealScheduler &sched = *healer;
+s_health_off.seed_nominal(0x2A0);
 
 sched.add_group(
     // work: heal from the live base; return true to latch the group.
     [&](rtti::HealRun &run) noexcept
     {
-        return run.heal_into("health", k_health_ptr, resolved_player_base, g_health_off).has_value();
+        return run.heal_into("health", k_health_ptr, resolved_player_base, s_health_off).has_value();
     },
     // gate (optional): a cheap per-frame precondition. false -> skip silently, do NOT spend the interval.
     []() noexcept { return player_is_seated(); });
@@ -186,10 +187,11 @@ sched.tick();
 - **Fixed interval, not backoff.** An un-latched group re-scans every `interval_frames` frames (default 30, ~0.5s at 60 FPS) with **no attempt cap**: however long a load or a menu takes, it keeps retrying, then latches once it resolves. The scan frame itself does not consume a countdown tick, so scans land on frames `0`, `interval + 1`, `2*(interval) + 2`, ... exactly.
 - **Per-group latch.** Each `add_group` is independent. A group that resolves stops being scanned; a sibling that has not keeps retrying. `all_resolved()` reports whether every group has latched.
 - **Silent pre-gate.** A group's optional `gate` runs *before* the interval countdown, so a target that is not constructed yet is polled cheaply every frame and skipped without spending the retry budget -- the moment the gate opens, the group scans immediately.
-- **`heal_into` is fail-closed.** On a hit it stores `healed_offset` to the caller-owned atomic slot and logs the recovery (a moved field at Info; a confirmation at nominal at Debug). On a miss it leaves the slot untouched (it keeps its seeded nominal, never a guess) and logs per the config's `escalate` policy and the call's `required` flag.
+- **`heal_into` is fail-closed.** On a hit it publishes `healed_offset` to the caller-owned slot and logs the recovery (a moved field at Info; a confirmation at nominal at Debug). On a miss it leaves the slot's value untouched (its seeded nominal, never a guess) and logs per the config's `escalate` policy and the call's `required` flag.
+- **Consume through a `HealedSlot`, not a raw atomic, when the offset authorizes a write.** The raw `std::atomic<std::ptrdiff_t>` overload carries only the value: after a required miss it holds the seeded, possibly dangerous nominal with no in-band failure signal. It remains for read-only compatibility use. The `HealedSlot` overload publishes `{value, generation, validity}`: a resolve is `Confirmed` and carries the resolved vtable image's generation; a **required** miss is `Invalid` with generation `0`; an **optional** miss is `Unverified` with generation `0`. `authorized()` checks validity, while `authorized(current_generation)` also rejects a stale or zero generation; obtain the current value from a live vtable in the target image. Seed the slot so reads before the first heal are explicitly `Unverified`.
 - **Warn once.** The first realised drift across all groups whose `|delta|` exceeds `HealConfig::drift_warn_threshold` (default `0` == any nonzero drift) fires a single process-wide Warning (a CAS one-shot). The recovered pointer offsets self-healed, but non-healable scalar/flag offsets in the same structs silently rode the same shift and need a human to re-verify -- that is the actionable headline the one line carries. A corroborated bracket that writes its own slots (via `solve_fingerprint`) reports its moves through `HealRun::note_drift` so the same one-shot fires consistently.
 
-The scheduler is move-only and render-thread only; the atomic offset slots are the cross-thread channel, not the scheduler itself.
+The scheduler is move-only and render-thread only; the offset slots are the cross-thread channel, not the scheduler itself. `tick()` is non-reentrant: a work or gate callback that calls `tick()` again on the same scheduler is rejected as a no-op, so it cannot corrupt the in-flight scan.
 
 ## Drift telemetry -- `heal_report`
 

--- a/docs/guides/rtti/rtti-walker.md
+++ b/docs/guides/rtti/rtti-walker.md
@@ -12,7 +12,7 @@ Names are returned in MSVC mangled form, for example `.?AVMyClass@ns@@`. Compare
 
 ## ABI layout
 
-The walker treats the following layout as a long-term contract. It has been stable across every Visual C++ release since VS 2010 and is what IDA Pro, Ghidra, Binary Ninja, MinHook, SafetyHook, Detours, and EasyHook all rely on:
+The walker treats the supported MSVC x64 layout below as its ABI contract:
 
 ```text
 vtable[0]   --> first virtual method                  (the qword memory::read returns when reading *obj)
@@ -39,11 +39,11 @@ RVAs are 32-bit unsigned offsets relative to the **owning module's** image base,
 | `rtti::type_name_of(vtable, max_len)` | You want the name as a `std::string` for logging or one-shot inspection. One heap allocation per call. |
 | `rtti::type_name_into(vtable, buf, len)` | You want the same answer with zero allocation. Returns bytes written; output is always NUL-terminated when `len > 0`. |
 | `rtti::vtable_is_type(vtable, expected)` | You only need a yes/no identity probe. Reads `expected.size() + 1` bytes and short-circuits. No allocation. |
-| `rtti::find_in_pointer_table(table, n, expected, vtable_cache?, stride?)` | You need the first object in a pointer table whose vtable matches a given mangled name. The optional caller-owned `std::atomic<Address>` cache slot reduces steady-state cost to a single qword compare per slot. |
+| `rtti::find_in_pointer_table(table, n, expected, vtable_cache?, stride?)` | You need the first object in a pointer table whose vtable matches a given mangled name. The optional caller-owned `std::atomic<Address>` cache slot reduces steady-state cost to a single qword compare per slot and cold-falls back when stale. |
 | `rtti::vtable_for_type(mangled, range?)` | You know a stable class name and want its primary (most-derived) vtable address, scoped to one module. The name-keyed inverse of `vtable_is_type`. |
 | `rtti::vtables_for_type(mangled, out, cap, range?)` | The class may be multiply/virtually inherited and you want every sub-object vtable that shares the name, not just the primary. |
 | `rtti::region_has_rtti(range?)` | You need to tell a type-name miss from a module that has no resolvable MSVC RTTI records at all. |
-| `rtti::TypeIdentity(mangled, range?)` | You want a cached, name-keyed identity handle: resolve the primary vtable once, then `matches(vtable)` is a single qword compare. |
+| `rtti::TypeIdentity(mangled, range?)` | You want a cached, name-keyed identity handle with per-call image-generation validation. |
 
 The forward entry points are noexcept and SEH-guarded; an unmapped page, missing COL, or zero RVA produces a failure return rather than a fault. The reverse resolvers (`vtable_for_type`, `vtables_for_type`) and `TypeIdentity` are SEH-guarded as well and return `std::nullopt` / a zero count on any failure.
 
@@ -71,7 +71,7 @@ bool actor_is_ready(dmk::Address actor_ptr) noexcept
 ```cpp
 namespace
 {
-    std::atomic<dmk::Address> g_camera_vt_cache{dmk::Address{}};
+    dmk::rtti::PointerTableCache s_camera_vtable_cache;
 }
 
 std::optional<dmk::Address> find_camera_component(dmk::Address table) noexcept
@@ -80,13 +80,13 @@ std::optional<dmk::Address> find_camera_component(dmk::Address table) noexcept
     constexpr std::string_view k_camera_rtti = ".?AVCameraComponent@engine@@";
 
     return dmk::rtti::find_in_pointer_table(
-        table, k_component_slots, k_camera_rtti, &g_camera_vt_cache);
+        table, k_component_slots, k_camera_rtti, s_camera_vtable_cache);
 }
 ```
 
-The first successful call walks RTTI for every non-null slot and caches the matching vtable address. Every subsequent call reads the cache once with `memory_order_relaxed` and only compares qwords; slots whose vtable differs from the cached value are skipped without a RTTI walk. The cache assumes one canonical vtable per mangled name, which is correct for MSVC RTTI because mangled names encode the most-derived class.
+The first successful call walks RTTI for every non-null slot and caches the matching vtable address and image generation. A warm call validates that generation and compares qwords first. If the image changed or no slot carries the cached vtable, the function clears the stale identity, performs one cold RTTI pass, and refreshes the cache on a match. Dedicate each cache instance to one expected name and call `reset()` when the owner already knows its module lifecycle changed.
 
-To disable caching, pass `nullptr` for `vtable_cache`. To support tables that interleave per-slot metadata between pointers, pass a `stride` larger than `sizeof(std::uintptr_t)`.
+The raw `std::atomic<Address>*` overload remains source-compatible, but it cannot carry an image generation; clear that atomic at lifecycle boundaries. To disable caching, pass `nullptr`. To support tables that interleave per-slot metadata between pointers, pass a larger `stride`.
 
 ### Zero-allocation logging
 
@@ -117,6 +117,7 @@ Keying on the name rather than the vtable header is deliberate: the `TypeDescrip
 Multiple inheritance and `/OPT:ICF`:
 
 - `vtable_for_type` returns the **primary** vtable (the COL whose `offset` is 0), which is the value an object pointer's first qword holds for a most-derived instance. A class used only as a secondary or virtual base has its first qword pointing at a `COL.offset != 0` sub-object vtable; use `vtables_for_type` to get every sub-object vtable. An ambiguous primary (the same name with two distinct offset-0 vtables, for example a type linked into the image twice) fails closed and returns `std::nullopt`.
+- A unique or absent verdict is trustworthy only across a **complete** sweep. If a section header faults after a valid prefix, a page inside a swept section is unreadable, or the scan saturates its internal buffers, a second primary could hide in the region that was not read, so `vtable_for_type` fails closed rather than authorize a unique vtable from a partial sweep. When you must distinguish an authoritative absence from a sweep that could not finish, use the statusful forms: `vtables_for_type_checked` returns a `{count, completeness}` where `completeness` is `Traversal::{Complete, Incomplete, Saturated}`, and `region_rtti_presence` returns `RttiPresence::{Present, Absent, Incomplete}`.
 - Take identity from the returned vtable **address** (the `[-1]`-COL-anchored value), never from the vtable's slot contents: under the linker's identical-COMDAT folding (`/OPT:ICF`) two distinct classes can share folded function-pointer slots, so a slot-content comparison is not class-unique.
 
 For a cached per-frame identity check, wrap it in `rtti::TypeIdentity`. `TypeIdentity` owns its mangled name (it copies the `std::string_view` into an internal `std::string`), so the handle is self-contained and any string source -- including a temporary -- is safe to pass:
@@ -127,20 +128,22 @@ namespace { dmk::rtti::TypeIdentity g_camera_id{".?AVCameraCombat@engine@@"}; }
 bool is_combat_camera(dmk::Address obj) noexcept
 {
     const auto vt = dmk::memory::read<dmk::Address>(obj);
-    return vt && g_camera_id.matches(*vt); // resolves once, then a qword compare
+    return vt && g_camera_id.matches(*vt);
 }
 ```
 
 Scoping to one `Region` (the default is the host EXE) is load-bearing for correctness, not just ergonomics: the same mangled name can appear in several loaded modules. Pass the game module's range explicitly when the target type lives in a separate DLL.
 
-A successful resolve is cached permanently, so the warm path is a relaxed atomic load and a qword compare. A resolve that misses is deliberately not cached: the owning module may map the type later (a DLL loads, or a game patch finishes relocating the vtable), so `matches()` keeps retrying rather than latching a stale miss. To keep a per-frame `matches()` on an absent type from re-sweeping the whole module every frame, the miss-path re-sweep is throttled to at most once per internal cooldown; the type is still picked up within that cooldown once it appears, so the retry capability is preserved without the per-frame scan cost.
+A successful resolve is cached and stamped with the resolving module's image generation (`rtti::image_generation`, derived from its base, `SizeOfImage`, and PE timestamp). Publication checks the generation before and after the sweep, so a mapping transition cannot attach a new stamp to an old result. Every warm call re-validates that stamp; a changed image drops the stale value, refreshes the full module extent, and re-resolves against the current mapping. Call `invalidate()` to force a cold resolve immediately. A private-buffer scope carries generation `0` and must be reset explicitly. Misses are not latched, but retries are throttled so polling an absent type does not re-sweep the module every frame.
+
+`TypeIdentity` is a concrete public type whose private atomic cache is embedded in the object. DetourModKit does not promise a stable binary layout for it across library releases; clean-rebuild the static library and every consumer object whenever updating the installed headers/archive pair.
 
 ## Performance notes
 
 - The walker issues two SEH-guarded reads per call on the cold path: one for the COL pointer at `vtable - 8`, one batched read of the 24-byte `ColHead`. On MSVC each `__try` frame is essentially free on the success path. On MinGW each read uses the vectored fault guard, so the success path avoids the per-read `VirtualQuery` syscall; the batched ColHead read still matters because it keeps the walker to two guarded calls instead of four.
 - `vtable_is_type` reads `expected.size() + 1` name bytes in a single SEH frame and compares with `memcmp`. There is no heap allocation, no string construction, and no demangle pass.
 - `type_name_of` allocates one `std::string` per call. Prefer `type_name_into` or `vtable_is_type` when the allocation matters; on genuinely hot paths cache a `rtti::TypeIdentity`, since every walker call still runs the loader-querying COL prelude.
-- `find_in_pointer_table` on a cold cache scans every non-null slot with the full walker. With a warm cache it touches each slot exactly once with a qword compare. For a sparse table of 256 slots and a unique target, the warm-path cost is dominated by the slot dereference, not the RTTI machinery.
+- `find_in_pointer_table` on a cold or stale cache scans every non-null slot with the full walker. With a valid warm cache it touches each slot once with a qword compare.
 
 ## When the walker returns nothing
 
@@ -154,10 +157,10 @@ The walker returns `std::nullopt` / `false` / `0` (depending on the call) for ev
 
 None of these raise an exception; the caller can treat all failure modes uniformly through the optional / bool return.
 
-To tell a genuine miss from a module that simply has no MSVC RTTI to search (a `/GR-` host, a still-packed image, or a data-only module), call `rtti::region_has_rtti(range)`. A `false` there is the definite "there are no resolvable RTTI records in this scope, fall back to `scan::find_string_xref` / `scan::read_code_constant`" signal. A `true` only means the module carries at least one record, not that your specific type resolves: a `/GR-` executable that links a `/GR` CRT or middleware returns `true` off those library COLs while an executable-owned type still needs the raw-byte fallback. Act on a `false`; after any resolve miss the raw-byte fallback remains available. It is a setup/control-plane sweep like `vtable_for_type`, so call it once after a miss, never per frame.
+To tell a genuine miss from a module that simply has no MSVC RTTI to search (a `/GR-` host, a still-packed image, or a data-only module), call `rtti::region_has_rtti(range)`. A `true` means the module carries at least one record, not that your specific type resolves: a `/GR-` executable that links a `/GR` CRT or middleware returns `true` off those library COLs while an executable-owned type still needs the raw-byte fallback. A `false` is the "no resolvable RTTI record was found, fall back to `scan::find_string_xref` / `scan::read_code_constant`" signal, and it is safe to act on -- but it is not by itself proof of absence: if the sweep could not complete (a faulted section header or an unreadable page), a record may exist in the un-swept region. When that distinction matters, call `rtti::region_rtti_presence(range)`, which returns `RttiPresence::Incomplete` for a truncated sweep instead of collapsing it into a bare `false`. It is a setup/control-plane sweep like `vtable_for_type`, so call it once after a miss, never per frame.
 
 ## MinGW support
 
 The walker works correctly on both MSVC and MinGW builds of DetourModKit when targeting MSVC-compiled binaries (the typical use case for game mods). The underlying guarded read engine behind `memory::read_into` uses `__try` / `__except` on MSVC and the process-wide vectored fault guard on MinGW. Both toolchains fail closed on unreadable RTTI pages and produce identical results for stable game state; MSVC remains faster because its x64 SEH tables add no success-path setup.
 
-Note: the walker reads the MSVC RTTI ABI. If the target object was compiled by GCC or Clang for the Itanium C++ ABI, the layout at `vtable - 8` is different and the walker will fail. This is by design; DetourModKit consumers building mods for MSVC-compiled games (every major Windows game engine since 2010) will not encounter Itanium RTTI in their target processes.
+Note: the walker reads the MSVC RTTI ABI. If the target object uses the Itanium C++ ABI, the layout at `vtable - 8` differs and the walker fails closed.

--- a/include/DetourModKit/error.hpp
+++ b/include/DetourModKit/error.hpp
@@ -261,8 +261,15 @@ namespace DetourModKit
         HealNoMatch,
         /// Equidistant slots both match, or fingerprint deltas tied.
         HealAmbiguous,
+        /**
+         * A validity-bearing healed-offset slot was not @ref rtti::OffsetValidity::Confirmed for consumption: a
+         * required heal missed (the slot is Invalid) or an optional heal retained an unconfirmed nominal (Unverified).
+         * The value must not authorize a mutation. Consult @ref rtti::HealedSlot::load for the retained value and its
+         * validity.
+         */
+        OffsetNotConfirmed,
 
-        // Manifest (0x05xx): the former ManifestError, 4 codes
+        // Manifest failures (0x05xx).
         /// The first non-blank line was not the manifest header.
         MissingHeader = 0x0500,
         /// A record line had the wrong field count or an unparseable field.
@@ -486,6 +493,8 @@ namespace DetourModKit
             return "HealNoMatch";
         case ErrorCode::HealAmbiguous:
             return "HealAmbiguous";
+        case ErrorCode::OffsetNotConfirmed:
+            return "OffsetNotConfirmed";
         case ErrorCode::MissingHeader:
             return "MissingHeader";
         case ErrorCode::MalformedLine:

--- a/include/DetourModKit/rtti.hpp
+++ b/include/DetourModKit/rtti.hpp
@@ -26,9 +26,7 @@ namespace DetourModKit
      *          ".?AVMyClass@ns@@") so callers can perform an exact byte-equal comparison instead of resolving through
      *          UnDecorateSymbolName.
      *
-     *          The ABI layout this module relies on (COL at vtable - 8, TypeDescriptor RVA at COL + 0x0C, mangled name
-     *          at TD + 0x10, COL.pSelf RVA at COL + 0x14 on x64) has been stable across every release of MSVC since
-     *          Visual C++ 2010.
+     *          The ABI layout this module relies on is the supported MSVC x64 COL and TypeDescriptor layout.
      *
      *          RTTI-disabled host binaries: every resolver in this namespace -- @ref type_name_of,
      *          @ref type_name_into, @ref vtable_is_type, @ref find_in_pointer_table, the reverse-direction
@@ -43,9 +41,9 @@ namespace DetourModKit
      *
      *          The primary fallback for an RTTI-off consumer is @ref scan::find_string_xref or
      *          @ref scan::read_code_constant, which operate on raw bytes and do not require RTTI records. A consumer
-     *          that cannot tell a genuine miss from an RTTI-less module can call @ref region_has_rtti first. A false
-     *          result is the definite "no records to search in this scope, go to the raw-byte fallback" signal; a true
-     *          result only proves the module carries some records, not that the caller's own type resolves. The
+     *          that cannot tell a genuine miss from an RTTI-less module can call @ref region_rtti_presence first. Only
+     *          @ref RttiPresence::Absent proves a complete records-free sweep; a true @ref region_has_rtti result only
+     *          proves the module carries some record, not that the caller's own type resolves. The
      *          long-form failure-mode discussion for each function is in docs/guides/rtti/rtti-walker.md and
      *          docs/guides/rtti/rtti-self-heal.md.
      */
@@ -56,6 +54,79 @@ namespace DetourModKit
 
         /// Hard upper bound on any single mangled-name read.
         inline constexpr std::size_t MAX_TYPE_NAME_LEN = 1024;
+
+        /**
+         * @enum Traversal
+         * @brief Completeness of a reverse-RTTI section/page sweep.
+         * @details A reverse resolver answers "is there a unique vtable for this type" or "does this scope hold any
+         *          record" by sweeping the module's readable non-executable sections. A verdict that depends on having
+         *          seen the WHOLE image -- a unique vtable, an authoritative absence -- is trustworthy only under @ref
+         *          Complete. A truncated sweep can hide a second primary (false uniqueness) or the only record
+         *          (false absence), so the checked reverse forms surface this rather than reporting a positive prefix
+         *          as final.
+         */
+        enum class Traversal : std::uint8_t
+        {
+            /// Every qualifying section was enumerated and every page in it was read.
+            Complete = 0,
+            /** @brief The sweep under-covered the image, so a unique or absent verdict cannot be authorized. */
+            Incomplete = 1,
+            /** @brief More qualifying sections or matches existed than the internal fixed buffer could hold. */
+            Saturated = 2
+        };
+
+        /**
+         * @enum NameStatus
+         * @brief Outcome of a checked mangled-name read (@ref type_name_checked).
+         */
+        enum class NameStatus : std::uint8_t
+        {
+            /// The full NUL-terminated name was copied.
+            Ok = 0,
+            /** @brief The NUL-terminated copy is a proper prefix and must not be compared for identity. */
+            Truncated = 1,
+            /// No name could be read (null/low vtable, missing or forged COL, unreadable page).
+            Failed = 2
+        };
+
+        /**
+         * @struct NameRead
+         * @brief Result of @ref type_name_checked: bytes written plus whether the copy is the complete name.
+         */
+        struct NameRead
+        {
+            /// Name bytes written excluding the NUL terminator.
+            std::size_t written = 0;
+            /// Whether the copy is complete, a truncated prefix, or a failure.
+            NameStatus status = NameStatus::Failed;
+        };
+
+        /**
+         * @struct VtablesResult
+         * @brief Result of @ref vtables_for_type_checked: the match count plus the sweep completeness.
+         */
+        struct VtablesResult
+        {
+            /// Distinct matching sub-object vtables found (the same value @ref vtables_for_type returns).
+            std::size_t count = 0;
+            /** @brief Sweep completeness; under Incomplete or Saturated, count is only a floor. */
+            Traversal completeness = Traversal::Complete;
+        };
+
+        /**
+         * @enum RttiPresence
+         * @brief Trit answer of @ref region_rtti_presence, separating an authoritative absence from an incomplete
+         *        sweep.
+         */
+        enum class RttiPresence : std::uint8_t
+        {
+            /// At least one resolvable RTTI record was found (sound regardless of completeness: a hit is a hit).
+            Present = 0,
+            /// The sweep completed and found no record: an authoritative absence (an MSVC /GR- scope, a data module).
+            Absent = 1,
+            /** @brief The sweep could not complete, so absence cannot be concluded. */
+            Incomplete = 2
+        };
 
         /**
          * @brief Reads the MSVC RTTI mangled type-descriptor name for the object whose runtime vtable is at @p vtable.
@@ -97,6 +168,40 @@ namespace DetourModKit
         [[nodiscard]] std::size_t type_name_into(Address vtable, char *out, std::size_t out_len) noexcept;
 
         /**
+         * @brief Truncation-reporting form of @ref type_name_into.
+         * @details Writes the mangled name into @p out exactly as @ref type_name_into, but distinguishes a name that
+         *          fit from one that was cut. @ref type_name_into cannot: it returns the bytes written, which equals
+         *          the capacity both when the name fit exactly and when it was truncated, so a caller comparing the
+         *          result for identity could match a proper prefix of a longer name against a shorter expected name.
+         *          This form reports @ref NameStatus::Truncated whenever the real name did not fit @p out (or the @ref
+         *          MAX_TYPE_NAME_LEN hard cap), so an identity comparison can reject a truncated read instead of
+         *          treating a prefix as a whole name.
+         * @param vtable Runtime vtable pointer (the first qword of the object).
+         * @param out Destination buffer; always NUL-terminated when @p out_len > 0. Must be non-null when @p
+         *            out_len > 0.
+         * @param out_len Capacity of @p out including the NUL terminator.
+         * @return @ref NameRead::written name bytes (excluding the NUL) and a @ref NameRead::status of @ref
+         *         NameStatus::Ok (complete), @ref NameStatus::Truncated (a prefix; do not compare for identity), or
+         *         @ref NameStatus::Failed (nothing read; @p out is left empty).
+         */
+        [[nodiscard]] NameRead type_name_checked(Address vtable, char *out, std::size_t out_len) noexcept;
+
+        /**
+         * @brief A stable, mapping-scoped identity token for the module currently mapped over @p addr.
+         * @details Derives a 64-bit token from the module's image base, SizeOfImage, and PE TimeDateStamp, read through
+         *          the guarded engine. The token is stable while one image stays mapped and changes when that image is
+         *          unloaded or a DIFFERENT image is mapped at the same base (a same-base remap) -- the case a base-only
+         *          key cannot see. It is the generation @ref TypeIdentity keys its cached resolve on, and the value a
+         *          consumer of a @ref rtti_dissect.hpp @ref HealedOffset compares @ref HealedOffset::generation against
+         *          to decide whether a healed value still refers to the image it was resolved in.
+         * @param addr Any address inside the module of interest (typically a module base or a live object pointer).
+         * @return A nonzero identity token for a module-backed address; 0 when @p addr is not inside any loaded module
+         *         (an unmapped address or a private @c VirtualAlloc buffer carries no module-backed identity to track).
+         * @note Setup/control-plane only -- resolves the owning module through the loader before reading its PE header.
+         */
+        [[nodiscard]] std::uint64_t image_generation(Address addr) noexcept;
+
+        /**
          * @brief Tests whether the MSVC RTTI mangled name for @p vtable equals @p expected exactly.
          * @details Performs a byte-exact comparison of the mangled name plus the terminating NUL, rejecting both proper
          *          prefix and substring matches. The read is bounded by the length of @p expected plus one byte, so no
@@ -112,19 +217,56 @@ namespace DetourModKit
         [[nodiscard]] bool vtable_is_type(Address vtable, std::string_view expected) noexcept;
 
         /**
+         * @class PointerTableCache
+         * @brief Generation-bearing cache for repeated @ref find_in_pointer_table calls with one expected type.
+         * @details Stores the resolved vtable together with its image base and generation. Concurrent reads are
+         *          supported; publication is non-blocking, and a competing publisher leaves the existing snapshot for
+         *          the next call to validate.
+         */
+        class PointerTableCache
+        {
+        public:
+            /// Constructs an empty cache.
+            PointerTableCache() noexcept = default;
+            PointerTableCache(const PointerTableCache &) = delete;
+            PointerTableCache &operator=(const PointerTableCache &) = delete;
+            PointerTableCache(PointerTableCache &&) = delete;
+            PointerTableCache &operator=(PointerTableCache &&) = delete;
+            ~PointerTableCache() noexcept = default;
+
+            /**
+             * @brief Clears the cached identity so the next lookup starts cold.
+             * @note Setup/control-plane only -- waits for an in-progress cache publication to finish.
+             */
+            void reset() noexcept;
+
+        private:
+            friend std::optional<Address> find_in_pointer_table(Address table, std::size_t slot_count,
+                                                                std::string_view expected, PointerTableCache &cache,
+                                                                std::size_t stride) noexcept;
+
+            // Single-writer sequence protects a coherent {vtable, image base, generation} snapshot.
+            std::atomic_flag m_writer{};
+            std::atomic<std::uint32_t> m_seq{0};
+            std::atomic<Address> m_vtable{Address{}};
+            std::atomic<Address> m_image_base{Address{}};
+            std::atomic<std::uint64_t> m_generation{0};
+            // Advanced by reset() so a lookup that started earlier cannot publish across the reset boundary.
+            std::atomic<std::uint64_t> m_epoch{0};
+        };
+
+        /**
          * @brief Scans a pointer-table for the first slot whose object has the given RTTI type-descriptor name.
          * @details Treats @p table as an array of @p slot_count entries each @p stride bytes wide. For every non-null
          *          slot the function dereferences the object pointer, reads the object's first qword as a vtable, and
          *          either:
          *          - on a cold cache (or when @p vtable_cache is nullptr)
          *            calls @ref vtable_is_type to perform the full RTTI walk;
-         *          - on a warm cache (a previously-resolved vtable address)
-         *            performs a single qword compare and skips slots whose vtable differs.
+         *          - on a warm cache (a previously-resolved vtable address), first performs qword comparisons; if no
+         *            slot carries the cached vtable, clears the observed stale value and performs one cold RTTI pass.
          *
-         *          The first matching slot is returned. When a match is found on the cold path and @p vtable_cache is
-         *          non-null, the matching vtable is stored with memory_order_relaxed so subsequent calls can take the
-         *          warm path. Cache writes use a single relaxed store because concurrent first-callers converge on the
-         *          same vtable value (image-resident vtables are unique per concrete type).
+         *          The first matching slot is returned. A cold-path match refreshes @p vtable_cache with
+         *          memory_order_relaxed so subsequent calls can take the warm path.
          *
          *          Caller-owned cache shape: one std::atomic<Address> per expected name, default-initialised to a null
          *          Address. A null Address encodes "cold".
@@ -136,19 +278,36 @@ namespace DetourModKit
          *               pointer array; pass a larger stride for tables that interleave per-slot metadata between
          *               pointers.
          * @return The object pointer (the value stored in the slot) on first match, or std::nullopt if no slot matched.
-         * @note The cold path runs the RTTI walk per slot (setup / first-resolve cost); the warm-cache path is a single
-         *       qword compare per slot, so pass a @p vtable_cache whenever this is called repeatedly.
+         * @note The cold path runs the RTTI walk per slot; a valid warm cache needs only one qword compare per slot.
          * @warning The warm-cache path assumes one canonical vtable address per expected name. If multiple derived
          *          concrete classes share the same base-mangled name and the table holds a mix of them, only slots
          *          whose vtable equals the
          *          first-resolved instance are returned on the warm path;
          *          other matches are skipped. For MSVC RTTI this is correct because mangled names encode the
          *          most-derived class, not the base.
+         * @warning This compatibility overload's raw atomic carries no image generation. Clear it at module-lifecycle
+         *          boundaries, or use the @ref PointerTableCache overload for generation-checked caching.
          */
         [[nodiscard]] std::optional<Address>
         find_in_pointer_table(Address table, std::size_t slot_count, std::string_view expected,
                               std::atomic<Address> *vtable_cache = nullptr,
                               std::size_t stride = sizeof(std::uintptr_t)) noexcept;
+
+        /**
+         * @brief Generation-checked overload of @ref find_in_pointer_table.
+         * @details A warm snapshot is accepted only while its image generation remains current. A stale snapshot is
+         *          cleared and cold-resolved; publication revalidates the type and generation before caching it.
+         * @param table Base address of the pointer table.
+         * @param slot_count Number of slots to scan.
+         * @param expected Mangled name to match; one cache instance is dedicated to one expected name.
+         * @param cache Caller-owned generation-bearing cache.
+         * @param stride Byte distance between adjacent slot addresses.
+         * @return The first matching object pointer, or std::nullopt.
+         * @note Prefer this overload when the cache survives module unload/reload boundaries.
+         */
+        [[nodiscard]] std::optional<Address>
+        find_in_pointer_table(Address table, std::size_t slot_count, std::string_view expected,
+                              PointerTableCache &cache, std::size_t stride = sizeof(std::uintptr_t)) noexcept;
 
         /**
          * @brief Resolves the primary (most-derived) vtable for a class by its
@@ -166,13 +325,12 @@ namespace DetourModKit
          *          as a secondary or virtual base has its first qword pointing at a COL.offset != 0 sub-object vtable;
          *          use @ref vtables_for_type for that case.
          * @param mangled Exact MSVC mangled name (e.g. ".?AVMyClass@ns@@").
-         * @param range Module image to search. Defaults to the host EXE. The scope is load-bearing for correctness, not
-         *              merely
-         *              ergonomic: the same mangled name can appear in several
-         *              loaded modules and COL RVAs are image-base-relative.
-         * @return The primary vtable address on a unique match; std::nullopt when no COL.offset == 0 match exists, when
-         *         @p range is invalid, or when more than one distinct primary vtable shares the name (an ambiguous
-         *         image: the resolver fails closed rather than guessing).
+         * @param range Module image to search. Defaults to the host EXE. The scope is required because the same mangled
+         *              name can appear in several loaded modules and COL RVAs are image-base-relative.
+         * @return The primary vtable on a unique match; std::nullopt on absence, invalid scope, ambiguous primaries, or
+         *         incomplete traversal. A partial sweep cannot authorize uniqueness because a second primary may be in
+         *         the un-swept region. Use @ref vtables_for_type_checked to distinguish absence from an incomplete
+         *         traversal.
          * @note Setup/control-plane only: it sweeps the module's readable sections, so run it once at init (or behind a
          *       cached @ref TypeIdentity), never per-frame.
          */
@@ -199,22 +357,44 @@ namespace DetourModKit
                                                    Region range = Region::host()) noexcept;
 
         /**
+         * @brief Completeness-reporting form of @ref vtables_for_type.
+         * @details Writes the matching sub-object vtables into @p out exactly as @ref vtables_for_type, but also
+         *          reports whether the section/page sweep that produced them was complete. @ref vtables_for_type
+         *          returns only a count, which a caller cannot distinguish from a truncated sweep, so "count == 0"
+         *          could mean either a
+         *          genuine absence or a sweep that faulted before reaching the record. This form returns @ref
+         *          VtablesResult::completeness so a caller reasoning about absence or uniqueness accepts the count as
+         *          final only under @ref Traversal::Complete.
+         * @param mangled Exact MSVC mangled name.
+         * @param out Destination buffer for the matching vtable addresses, ascending COL.offset order (primary first).
+         *            May be nullptr only when @p out_cap is 0 (count-only query).
+         * @param out_cap Capacity of @p out; at most @p out_cap addresses are written even when more matches exist.
+         * @param range Module image to search. Defaults to the host EXE.
+         * @return The distinct-match @ref VtablesResult::count (a @ref VtablesResult::completeness other than @ref
+         *         Traversal::Complete means the count is a floor, not the authoritative total).
+         * @note Setup/control-plane only: a full module-section sweep, like @ref vtable_for_type; run it at init.
+         */
+        [[nodiscard]] VtablesResult vtables_for_type_checked(std::string_view mangled, Address *out,
+                                                             std::size_t out_cap,
+                                                             Region range = Region::host()) noexcept;
+
+        /**
          * @brief Reports whether a module region currently contains any resolvable MSVC RTTI record.
          * @details Sweeps @p range for any COL that passes the reverse resolver's x64 signature, pSelf/base, and
          *          in-module bounds checks.
          *
          *          The predicate is region-level and its two answers are deliberately asymmetric:
-         *          - false is authoritative: this region, as currently mapped, holds zero resolvable RTTI records -- an
-         *            MSVC /GR- host with no /GR static libs, a still-packed or section-merged image, or a data-only
-         *            module. This is the definite "reverse RTTI is futile here, use the raw-byte fallback" signal.
-         *          - true is not conclusive for a specific type: it only proves at least one record exists somewhere in
-         *            the module, not that the caller's type resolves. A /GR- executable that links a /GR CRT or
-         *            middleware returns true off those library COLs while an executable-owned type still needs the
-         *            raw-byte fallback. Act on a false; a true still leaves that fallback available after any resolve
-         *            miss.
+         *          - true is sound: at least one resolvable record was found. It only proves SOME record exists, not
+         *            that the caller's type resolves -- a /GR- executable that links a /GR CRT returns true off those
+         *            library COLs while an executable-owned type still needs the raw-byte fallback.
+         *          - false means "no record was found in what was swept" and is the go-to-raw-fallback signal, but it
+         *            is not by itself proof of absence: if the sweep could not complete (a faulted section header or an
+         *            unreadable page), a record may exist in the un-swept region. Use @ref region_rtti_presence when
+         *            the difference between an authoritative absence and an incomplete sweep matters (it returns @ref
+         *            RttiPresence::Incomplete instead of collapsing the two into a bare false).
          * @param range Module image to inspect. Defaults to the host EXE.
-         * @return true if @p range holds at least one resolvable RTTI record; false if it holds none or @p range is not
-         *         a valid mapped image.
+         * @return true if @p range holds at least one resolvable RTTI record; false if none was found in the swept
+         *         portion or @p range is not a valid mapped image.
          * @note Setup/control-plane only: it sweeps the module's readable sections like @ref vtable_for_type, so run it
          *       once after a resolve miss, never per-frame. It carries no re-sweep throttle, so a records-free scope
          *       pays a full sweep on every call.
@@ -224,12 +404,30 @@ namespace DetourModKit
         [[nodiscard]] bool region_has_rtti(Region range = Region::host()) noexcept;
 
         /**
-         * @brief Cached, self-healing identity handle for a class vtable.
-         * @details Resolves the primary vtable for a mangled name once (lazily, on first use) via @ref vtable_for_type
-         *          and caches it, so a per-frame identity check is a single qword compare with no RTTI walk -- the same
-         *          warm-cache shape as @ref find_in_pointer_table. Because the cached value is keyed on the stable
-         *          class name, it survives a game patch that relocates the vtable (the name does not move), which a
-         *          hard-coded vtable literal does not.
+         * @brief Completeness-reporting form of @ref region_has_rtti.
+         * @details Sweeps @p range exactly as @ref region_has_rtti but reports a trit that keeps an authoritative
+         *          absence distinct from a sweep that could not finish. @ref region_has_rtti collapses both into false;
+         *          this returns @ref RttiPresence::Absent only when the sweep completed and found nothing, and @ref
+         *          RttiPresence::Incomplete when a section header faulted or a page was unreadable before a record
+         *          could be found -- so a caller never mistakes "the sweep stopped early" for "this module has no
+         *          RTTI".
+         * @param range Module image to inspect. Defaults to the host EXE.
+         * @return @ref RttiPresence::Present (a record was found), @ref RttiPresence::Absent (completed, none found),
+         *         or @ref RttiPresence::Incomplete (invalid range or incomplete sweep, so absence cannot be concluded).
+         * @note Setup/control-plane only, like @ref region_has_rtti.
+         */
+        [[nodiscard]] RttiPresence region_rtti_presence(Region range = Region::host()) noexcept;
+
+        /**
+         * @brief Cached, self-healing, generation-aware identity handle for a class vtable.
+         * @details Resolves the primary vtable for a mangled name lazily via @ref vtable_for_type and caches it. Warm
+         *          calls re-read the image identity without repeating the RTTI sweep. Because the cached value is keyed
+         *          on the stable class name, it survives a game patch that relocates the vtable (the name does not
+         *          move), which a hard-coded vtable literal does not.
+         * @details A module-backed resolve is published only when the image generation is stable across the sweep. The
+         *          warm path re-validates that stamp on every call and refreshes the full module extent after a remap.
+         *          @ref invalidate forces an immediate cold resolve. A private-buffer scope has no module generation
+         *          and must be reset explicitly.
          * @note Take identity from the cached vtable ADDRESS (the vtable[-1]
          *       COL-anchored value), never from the vtable's slot contents: under the MSVC linker's identical-COMDAT
          *       folding (/OPT:ICF) two distinct classes can share folded function-pointer slots, so a slot-content
@@ -253,6 +451,9 @@ namespace DetourModKit
 
             TypeIdentity(const TypeIdentity &) = delete;
             TypeIdentity &operator=(const TypeIdentity &) = delete;
+            TypeIdentity(TypeIdentity &&) = delete;
+            TypeIdentity &operator=(TypeIdentity &&) = delete;
+            ~TypeIdentity() noexcept = default;
 
             /**
              * @brief Tests whether @p vtable is this type's primary vtable.
@@ -260,25 +461,34 @@ namespace DetourModKit
              *          missing type never matches.
              * @param vtable Candidate vtable (an object's first qword).
              * @return true when @p vtable equals the resolved primary vtable.
-             * @note Callback-safe once warm: the first call resolves (a module sweep), every later call is a single
-             *       cached qword compare, so this is the per-frame identity check.
+             * @note Callback-safe once warm: the generation check performs bounded guarded PE-header reads; a changed
+             *       image triggers a setup-cost resolve.
              */
             [[nodiscard]] bool matches(Address vtable) const noexcept;
 
             /**
              * @brief Returns the resolved primary vtable, resolving on first use.
              * @return The vtable address, or std::nullopt if it cannot be resolved in the configured module range.
-             * @note Callback-safe once warm: the first call resolves (a setup-cost module sweep), a successful
-             *       result is cached, so a later call is a relaxed atomic load. An unresolved result is not
+             * @note Callback-safe once warm: the first call resolves (a setup-cost module sweep), and a successful
+             *       result is cached. An unresolved result is not
              *       cached (the owning module may map the type later), but the re-sweep is throttled to at most
              *       once per internal cooldown, so polling this every frame for a type that is not present does
              *       not re-scan the whole module each frame.
              */
             [[nodiscard]] std::optional<Address> vtable() const noexcept;
 
+            /**
+             * @brief Drops the cached resolve so the next @ref vtable / @ref matches re-resolves from scratch.
+             * @details Idempotent and safe to call at any time. Use it when a consumer knows the resolving module was
+             *          unloaded or reloaded. Does not change the mangled name or range the handle was constructed with.
+             * @note Setup/control-plane only -- waits for an in-progress cache publication to finish; never throws.
+             */
+            void invalidate() noexcept;
+
         private:
             std::string m_mangled;
             Region m_range;
+            bool m_tracks_module_range{false};
 
             // m_cached holds the resolved primary vtable and is written only on a SUCCESSFUL (non-null) resolve.
             // m_resolved latches that success and is published with release after m_cached is stored, so an
@@ -288,10 +498,20 @@ namespace DetourModKit
             mutable std::atomic<Address> m_cached{Address{}};
             mutable std::atomic<bool> m_resolved{false};
 
-            // Millisecond timestamp of the last unresolved re-sweep attempt (0 = never attempted). Because a miss is
-            // never latched, a per-frame identity check for an absent type would re-sweep the whole module every frame;
-            // vtable() throttles that by skipping the sweep until a cooldown elapses. Only the miss path reads or
-            // writes this; a resolved identity returns from the m_resolved fast path and never touches it again.
+            // The resolving module's image_generation at the last successful resolve (0 = none, or a non-module range).
+            // The warm path re-reads the current generation and drops the cache when it differs, so an unload or a
+            // same-base remap invalidates the cached vtable instead of matching against a module that is no longer
+            // mapped.
+            mutable std::atomic<std::uint64_t> m_image_stamp{0};
+            mutable std::atomic<Address> m_image_base{Address{}};
+
+            // Serializes the short publish/clear transaction; the RTTI sweep itself runs without holding it.
+            mutable std::atomic_flag m_cache_writer{};
+            // Incremented whenever the cache is cleared so a resolve already in flight cannot republish afterward.
+            mutable std::atomic<std::uint64_t> m_cache_epoch{0};
+
+            // Millisecond timestamp of the last unresolved sweep (0 = never). It bounds whole-module retries for a type
+            // that is not present; successful warm calls do not modify it.
             mutable std::atomic<std::uint64_t> m_last_attempt_ms{0};
         };
     } // namespace rtti

--- a/include/DetourModKit/rtti_dissect.hpp
+++ b/include/DetourModKit/rtti_dissect.hpp
@@ -450,6 +450,110 @@ namespace DetourModKit
         [[nodiscard]] std::size_t heal_report(std::span<const Landmark> landmarks, std::span<DriftEntry> out) noexcept;
 
         /**
+         * @enum OffsetValidity
+         * @brief Whether a healed-offset value may be consumed, and how
+         *        strongly.
+         */
+        enum class OffsetValidity : std::uint8_t
+        {
+            /// A required heal missed: the retained value is unverified and has no established image generation.
+            Invalid = 0,
+            /** @brief An optional miss retained a nominal that is only usable as a hint. */
+            Unverified = 1,
+            /// A heal resolved the offset with a nonzero image generation.
+            Confirmed = 2
+        };
+
+        /**
+         * @struct HealedOffset
+         * @brief A consistent snapshot of a healed-offset slot: value, resolving-image generation, and validity.
+         * @details A confirmed value is stamped from the resolved vtable's image. Invalid and Unverified snapshots use
+         *          generation 0 because no matching image established the layout.
+         */
+        struct HealedOffset
+        {
+            /** @brief The offset, meaningful for consumption only when validity is Confirmed. */
+            std::ptrdiff_t value = 0;
+            /// @ref rtti::image_generation of the resolved vtable's image; 0 until a heal confirms the value.
+            std::uint64_t generation = 0;
+            /// Whether @ref value may be consumed.
+            OffsetValidity validity = OffsetValidity::Invalid;
+
+            /// True only when the value is Confirmed and carries a nonzero image generation.
+            [[nodiscard]] bool usable() const noexcept
+            {
+                return validity == OffsetValidity::Confirmed && generation != 0;
+            }
+        };
+
+        /**
+         * @class HealedSlot
+         * @brief Validity-bearing cross-thread channel for one healed offset: the safe alternative to a bare
+         *        @c std::atomic<std::ptrdiff_t>.
+         * @details A heal group publishes {value, generation, validity} here; a consumer on another thread loads a
+         *          consistent snapshot or asks a checked accessor whether the value may authorize a mutation.
+         *          Publishing is single-producer (the render/heal thread); loads use a bounded seqlock retry and return
+         *          an Invalid snapshot if contention persists, so a consumer never blocks the producer or accepts a
+         *          torn value. Hold one per offset at a stable address.
+         * @note The raw @c std::atomic<std::ptrdiff_t> @ref HealRun::heal_into overload remains for compatibility, but
+         *       it is caller-owned-unsafe for mutation: it carries no validity, so a required miss leaves a consumable
+         *       nominal. Prefer this channel whenever a healed offset authorizes a write or a hook.
+         */
+        class HealedSlot
+        {
+        public:
+            HealedSlot() noexcept = default;
+            HealedSlot(const HealedSlot &) = delete;
+            HealedSlot &operator=(const HealedSlot &) = delete;
+            HealedSlot(HealedSlot &&) = delete;
+            HealedSlot &operator=(HealedSlot &&) = delete;
+            ~HealedSlot() noexcept = default;
+
+            /**
+             * @brief Seeds the slot with an unconfirmed nominal offset (generation 0, @ref OffsetValidity::Unverified).
+             * @details The starting state before any heal runs: a consumer that reads the slot before the first
+             *          successful heal gets the nominal with an explicit Unverified status, never a Confirmed value it
+             *          could mistake for a resolved one.
+             */
+            void seed_nominal(std::ptrdiff_t nominal) noexcept;
+
+            /**
+             * @brief Publishes a snapshot atomically (single producer).
+             * @details Non-Confirmed states are normalized to generation 0; Confirmed with generation 0 becomes
+             * Invalid.
+             */
+            void publish(std::ptrdiff_t value, std::uint64_t generation, OffsetValidity validity) noexcept;
+
+            /// Returns a consistent snapshot, or Invalid if bounded retries cannot observe one.
+            [[nodiscard]] HealedOffset load() const noexcept;
+
+            /**
+             * @brief Returns the offset only when it is @ref OffsetValidity::Confirmed.
+             * @return The Confirmed value, or @ref ErrorCode::OffsetNotConfirmed when validity or generation is absent.
+             *         This is the validity gate; it does not check the current
+             *         generation -- use the overload taking @p current_generation to also reject a stale image.
+             * @warning For mutation authorization tied to a module mapping, use the generation-checking overload.
+             */
+            [[nodiscard]] Result<std::ptrdiff_t> authorized() const noexcept;
+
+            /**
+             * @brief Returns the offset only when it is Confirmed AND still tied to @p current_generation.
+             * @param current_generation A nonzero, current @ref rtti::image_generation of the resolved type's module.
+             * @return The value, or @ref ErrorCode::OffsetNotConfirmed when the slot is not Confirmed or its generation
+             *         is zero or no longer matches @p current_generation.
+             */
+            [[nodiscard]] Result<std::ptrdiff_t> authorized(std::uint64_t current_generation) const noexcept;
+
+        private:
+            // Single-producer seqlock: even = stable, odd = write in progress. The payload atomics are read/written
+            // relaxed and made consistent by the sequence counter's acquire/release fences.
+            std::atomic<std::uint32_t> m_seq{0};
+            std::atomic<std::ptrdiff_t> m_value{0};
+            std::atomic<std::uint64_t> m_generation{0};
+            std::atomic<std::uint8_t> m_validity{static_cast<std::uint8_t>(OffsetValidity::Invalid)};
+        };
+
+        /**
          * @enum HealEscalation
          * @brief Log-severity policy a @ref HealScheduler applies to a landmark that does not resolve during a scan.
          */
@@ -485,6 +589,7 @@ namespace DetourModKit
             /**
              * @brief A realised drift whose absolute delta exceeds this threshold fires the one-shot layout-drift
              *        Warning. The default of 0 warns on ANY nonzero drift.
+             * @note A negative value is rejected by @ref HealScheduler::start with @ref ErrorCode::InvalidArg.
              */
             std::ptrdiff_t drift_warn_threshold = 0;
             /// Log-severity policy for a landmark that does not resolve during a scan.
@@ -526,9 +631,42 @@ namespace DetourModKit
              * @param slot The caller-owned offset cache slot (typically seeded with the nominal offset).
              * @param required Whether an unresolved miss escalates to Warning under @ref HealEscalation::WarnRequired.
              * @return The @ref heal_landmark result (the caller can inspect the details or the Error).
+             * @warning Caller-owned-unsafe for mutation authorization. A bare @c std::atomic<std::ptrdiff_t> carries no
+             *          validity: after a required miss it holds the seeded (possibly dangerous) nominal, and a consumer
+             *          that reads only the slot cannot tell that from a confirmed offset. DetourModKit cannot prevent a
+             *          direct load from a caller-owned atomic, so it does not promise the slot is safe. When a healed
+             *          offset authorizes a write or a hook, use the @ref HealedSlot overload, whose validity gate
+             *          rejects an unconfirmed value. This overload remains for read-only / compatibility use.
              */
             [[nodiscard]] Result<HealHit> heal_into(std::string_view label, const Landmark &landmark, Address base,
                                                     std::atomic<std::ptrdiff_t> &slot, bool required = true) noexcept;
+
+            /**
+             * @brief Validity-bearing form of @ref heal_into: publishes {value, generation, validity} to a @ref
+             *        HealedSlot instead of a bare atomic.
+             * @details Identical heal and logging to the raw-atomic overload, but the published snapshot carries the
+             *          information a slot-only consumer needs to fail closed. On a resolve the slot takes the healed
+             *          offset with @ref OffsetValidity::Confirmed and the resolved vtable image's @ref
+             *          rtti::image_generation. A resolve whose vtable image reports generation 0 (an untracked or
+             *          non-module mapping) fails closed like a miss: it returns @ref ErrorCode::OffsetNotConfirmed and
+             *          publishes Invalid (required) or Unverified (optional).
+             *          On a REQUIRED miss (@p required true) it publishes @ref OffsetValidity::Invalid; on an OPTIONAL
+             *          miss (@p required false) it publishes @ref OffsetValidity::Unverified. Either way the retained
+             *          value stays whatever the slot last held (the seeded nominal), so a consumer that ignores
+             *          validity sees the retained value, while @ref HealedSlot::authorized rejects a non-Confirmed
+             *          value.
+             * @param label Short human-readable field name for the log lines.
+             * @param landmark The landmark template; its own @c base is ignored in favour of @p base.
+             * @param base The live, resolved struct base for this frame.
+             * @param slot The caller-owned validity-bearing slot (typically @ref HealedSlot::seed_nominal'd first).
+             * @param required True marks a missing target as a required-field failure: it escalates the log to Warning
+             *                  under @ref HealEscalation::WarnRequired AND publishes @ref OffsetValidity::Invalid
+             *                  rather than @ref OffsetValidity::Unverified.
+             * @return The @ref heal_landmark result, or @ref ErrorCode::OffsetNotConfirmed when the heal resolved but
+             *         its vtable image carried no generation.
+             */
+            [[nodiscard]] Result<HealHit> heal_into(std::string_view label, const Landmark &landmark, Address base,
+                                                    HealedSlot &slot, bool required = true) noexcept;
 
             /**
              * @brief Report a drift a group recovered itself (e.g. through @ref solve_fingerprint), so the one-shot
@@ -591,7 +729,7 @@ namespace DetourModKit
             /**
              * @brief Constructs a scheduler with the given config.
              * @param config Retry cadence, drift-warning threshold, and miss escalation.
-             * @return The scheduler, or @ref ErrorCode::InvalidArg when @c config.interval_frames is 0.
+             * @return The scheduler, or @ref ErrorCode::InvalidArg for a zero interval or negative drift threshold.
              */
             [[nodiscard]] static Result<HealScheduler> start(HealConfig config = {}) noexcept;
 

--- a/src/internal/memory_guarded.hpp
+++ b/src/internal/memory_guarded.hpp
@@ -76,6 +76,14 @@ namespace DetourModKit
         [[nodiscard]] Region module_image_region(Address module_base) noexcept;
 
         /**
+         * @brief Resolves the current loader owner of @p address and reads its image span without the module-range
+         * cache.
+         * @return The live module span, or an empty Region when the loader lookup or PE-header read fails.
+         * @note Setup/control-plane only -- performs a loader query and guarded PE-header reads.
+         */
+        [[nodiscard]] Region live_module_region(Address address) noexcept;
+
+        /**
          * @brief module_image_region cached per module handle and lifecycle generation.
          * @param module_base The module's base address (its HMODULE value); null yields an empty Region.
          * @return The module image span, or an empty Region when @p module_base is null or its PE headers do not

--- a/src/internal/rtti_shared.hpp
+++ b/src/internal/rtti_shared.hpp
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <type_traits>
 
 namespace DetourModKit
@@ -32,10 +33,7 @@ namespace DetourModKit
     {
         namespace detail
         {
-            // MSVC x64 RTTI layout constants. Stable across every Visual C++ release since 2010 and assumed to remain
-            // stable; the ABI is not officially documented but is what every disassembler (IDA, Ghidra, Binary Ninja)
-            // and every interop tool (MinHook, Detours, EasyHook, SafetyHook) relies on, so DetourModKit treats it as a
-            // long-term contract.
+            // MSVC x64 RTTI ABI layout constants shared by the forward and reverse walkers.
             inline constexpr std::ptrdiff_t COL_OFFSET_FROM_VTABLE = -8;
             inline constexpr std::ptrdiff_t TD_NAME_OFFSET = 0x10;
             inline constexpr std::uint32_t COL_SIGNATURE_X64 = 1;
@@ -44,6 +42,51 @@ namespace DetourModKit
             // Page size used to bound name reads so a single SEH read never spans a page boundary; this lets the walker
             // tolerate a string that ends just before an unmapped page rather than failing the whole read.
             inline constexpr std::uintptr_t PAGE_MASK = 0xFFF;
+
+            /**
+             * @brief Two's-complement magnitude of a signed offset, defined for every value including PTRDIFF_MIN.
+             * @details The naive `(v < 0) ? -v : v` is undefined behavior at PTRDIFF_MIN, whose magnitude is not
+             *          representable in std::ptrdiff_t. Computing the negation in the unsigned domain (2^64 - v) yields
+             *          the exact magnitude for every input, so a drift/delta comparison never trips signed-overflow UB.
+             */
+            [[nodiscard]] constexpr std::uint64_t ptrdiff_magnitude(std::ptrdiff_t value) noexcept
+            {
+                const std::uint64_t bits = static_cast<std::uint64_t>(value);
+                return (value < 0) ? (~bits + 1U) : bits;
+            }
+
+            /**
+             * @brief Subtracts two offsets and saturates when their mathematical difference is not representable.
+             * @details Saturation preserves the direction and severity of an extreme drift; wrapping could turn
+             *          PTRDIFF_MAX - PTRDIFF_MIN into -1 and suppress a configured drift warning.
+             */
+            [[nodiscard]] constexpr std::ptrdiff_t saturating_sub(std::ptrdiff_t a, std::ptrdiff_t b) noexcept
+            {
+                constexpr std::ptrdiff_t MIN = std::numeric_limits<std::ptrdiff_t>::min();
+                constexpr std::ptrdiff_t MAX = std::numeric_limits<std::ptrdiff_t>::max();
+                if (b > 0 && a < MIN + b)
+                    return MIN;
+                if (b < 0 && a > MAX + b)
+                    return MAX;
+                return a - b;
+            }
+
+            /** @brief Returns @p address - @p base as a signed offset, saturating when it is not representable. */
+            [[nodiscard]] constexpr std::ptrdiff_t address_offset(std::uintptr_t address, std::uintptr_t base) noexcept
+            {
+                constexpr auto MIN = std::numeric_limits<std::ptrdiff_t>::min();
+                constexpr auto MAX = std::numeric_limits<std::ptrdiff_t>::max();
+                constexpr std::uint64_t MIN_MAGNITUDE = static_cast<std::uint64_t>(MAX) + 1U;
+                if (address >= base)
+                {
+                    const std::uint64_t difference = address - base;
+                    return difference > static_cast<std::uint64_t>(MAX) ? MAX : static_cast<std::ptrdiff_t>(difference);
+                }
+                const std::uint64_t difference = base - address;
+                if (difference >= MIN_MAGNITUDE)
+                    return MIN;
+                return -static_cast<std::ptrdiff_t>(difference);
+            }
 
             /**
              * @struct ColHead

--- a/src/memory_module.cpp
+++ b/src/memory_module.cpp
@@ -170,6 +170,20 @@ namespace DetourModKit
                 }
             }
         }
+
+        Region live_module_region(Address address) noexcept
+        {
+            if (!address)
+                return Region{};
+
+            HMODULE owning_module = nullptr;
+            if (!::GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                                          GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                                      address.as<LPCWSTR>(), &owning_module) ||
+                owning_module == nullptr)
+                return Region{};
+            return module_image_region(Address{owning_module});
+        }
     } // namespace detail
 
     namespace memory
@@ -212,23 +226,15 @@ namespace DetourModKit
         Region module_of(Address address) noexcept
         {
             if (!address)
-            {
                 return Region{};
-            }
 
-            // FROM_ADDRESS resolves the module that contains the address; UNCHANGED_REFCOUNT looks it up without taking
-            // a reference, matching the transient-scope contract a Region keeps.
             HMODULE owning_module = nullptr;
             if (!::GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
                                           GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                                       address.as<LPCWSTR>(), &owning_module) ||
                 owning_module == nullptr)
-            {
                 return Region{};
-            }
 
-            // The resolved image span is cached per module handle by cached_module_image_region, so a repeated probe of
-            // the same module degenerates to this loader lookup plus a hash hit rather than re-walking the PE headers.
             return detail::cached_module_image_region(Address{owning_module});
         }
 

--- a/src/rtti.cpp
+++ b/src/rtti.cpp
@@ -14,9 +14,9 @@
  * rtti_shared.hpp header so the reverse dissector in rtti_dissect.cpp reuses them byte-for-byte rather than
  * duplicating the walk.
  *
- * The public surface speaks the v4 Address vocabulary; the raw ABI sweepers below stay on std::uintptr_t because they
- * do qword-granular pointer arithmetic over image memory, and the Address <-> integer punning is confined to the
- * boundary conversions at each public entry point.
+ * The public surface uses Address; the raw ABI sweepers below stay on std::uintptr_t because they do qword-granular
+ * pointer arithmetic over image memory, and the Address <-> integer punning is confined to the boundary conversions at
+ * each public entry point.
  */
 
 #include "DetourModKit/rtti.hpp"
@@ -40,11 +40,15 @@ namespace DetourModKit::detail
 
 namespace DetourModKit::detail
 {
+#if defined(DMK_ENABLE_TEST_SEAMS)
     // Test-only override for the monotonic millisecond clock TypeIdentity's unresolved re-sweep throttle reads. Null in
-    // production, where the throttle uses GetTickCount64(); a test installs a controllable source to drive the cooldown
-    // deterministically instead of sleeping on wall-clock time. Mirrors the g_*_loader_lock_override seams; set and
-    // cleared on a single thread inside a test fixture, so a plain function pointer suffices.
+    // test builds unless a fixture installs a controllable source.
     std::uint64_t (*g_rtti_resolve_clock_override)() noexcept = nullptr;
+
+    // Test-only controls for mapping-generation and module-extent transitions.
+    std::uint64_t (*g_rtti_image_generation_override)(std::uintptr_t address) noexcept = nullptr;
+    Region (*g_rtti_module_region_override)(Address address) noexcept = nullptr;
+#endif
 } // namespace DetourModKit::detail
 
 namespace DetourModKit
@@ -56,10 +60,12 @@ namespace DetourModKit
         // so the suite can advance time deterministically without a real sleep.
         [[nodiscard]] std::uint64_t rtti_now_ms() noexcept
         {
+#if defined(DMK_ENABLE_TEST_SEAMS)
             if (auto *override_fn = DetourModKit::detail::g_rtti_resolve_clock_override)
             {
                 return override_fn();
             }
+#endif
             return ::GetTickCount64();
         }
 
@@ -69,6 +75,16 @@ namespace DetourModKit
         // would re-sweep the entire module every frame, the one genuine per-frame cliff. 250 ms bounds that to at most
         // ~4 module sweeps per second while keeping the eventual resolve latency sub-second once the type appears.
         constexpr std::uint64_t RESOLVE_RETRY_COOLDOWN_MS = 250;
+
+        // Complete < Incomplete < Saturated, so the maximum retains the strongest reason a verdict is not
+        // authoritative.
+        [[nodiscard]] rtti::Traversal merge_traversal(rtti::Traversal a, rtti::Traversal b) noexcept
+        {
+            return (static_cast<std::uint8_t>(a) < static_cast<std::uint8_t>(b)) ? b : a;
+        }
+
+        [[nodiscard]] Region current_module_region(Address address) noexcept;
+        [[nodiscard]] std::uint64_t current_image_stamp(std::uintptr_t module_base) noexcept;
     } // namespace
 
     bool rtti::detail::resolve_col_site(std::uintptr_t vtable, const DetourModKit::detail::ModuleSpan &mod_range,
@@ -147,7 +163,7 @@ namespace DetourModKit
         if (vtable < MIN_VALID_PTR)
             return false;
         const DetourModKit::detail::ModuleSpan mod_range =
-            DetourModKit::detail::module_span(memory::module_of(Address{vtable}));
+            DetourModKit::detail::module_span(DetourModKit::detail::live_module_region(Address{vtable}));
         return resolve_col_site(vtable, mod_range, out);
     }
 
@@ -285,6 +301,52 @@ namespace DetourModKit
         return detail::read_name_seh(name_addr, out, out_len, module_end);
     }
 
+    rtti::NameRead rtti::type_name_checked(Address vtable, char *out, std::size_t out_len) noexcept
+    {
+        NameRead result;
+        if (!out || out_len == 0)
+            return result;
+        out[0] = '\0';
+        std::uintptr_t module_end = 0;
+        const std::uintptr_t name_addr = resolve_name_site(vtable.raw(), module_end);
+        if (name_addr == 0)
+            return result;
+
+        const std::size_t written = detail::read_name_seh(name_addr, out, out_len, module_end);
+        if (written == 0)
+        {
+            // A one-byte destination has room only for the terminator. Distinguish that zero-length truncation from a
+            // read failure; an empty RTTI name, while not emitted by MSVC, is still a complete read.
+            if (out_len == 1)
+            {
+                char first = 1;
+                if (DetourModKit::detail::guarded_read_bytes(name_addr, &first, 1))
+                    result.status = (first == '\0') ? NameStatus::Ok : NameStatus::Truncated;
+            }
+            return result;
+        }
+        result.written = written;
+
+        // read_name_seh stopped at the first NUL or at the length cap. The byte immediately after the copied prefix
+        // decides which: the terminator (complete) or another name byte (truncated). A byte at or past the module
+        // boundary, or one that faults, means the name has no in-module terminator within the cap -- not a trustworthy
+        // whole name, so report Truncated so an identity comparison rejects it rather than matching a prefix.
+        const std::uintptr_t next = name_addr + written;
+        if (module_end != 0 && next >= module_end)
+        {
+            result.status = NameStatus::Truncated;
+            return result;
+        }
+        char probe = 1;
+        if (!DetourModKit::detail::guarded_read_bytes(next, &probe, 1))
+        {
+            result.status = NameStatus::Truncated;
+            return result;
+        }
+        result.status = (probe == '\0') ? NameStatus::Ok : NameStatus::Truncated;
+        return result;
+    }
+
     bool rtti::vtable_is_type(Address vtable, std::string_view expected) noexcept
     {
         if (expected.empty() || expected.size() >= MAX_TYPE_NAME_LEN)
@@ -312,6 +374,23 @@ namespace DetourModKit
         return std::memcmp(buf, expected.data(), expected.size()) == 0;
     }
 
+    void rtti::PointerTableCache::reset() noexcept
+    {
+        while (m_writer.test_and_set(std::memory_order_acquire))
+            (void)::SwitchToThread();
+
+        const std::uint32_t sequence = m_seq.load(std::memory_order_relaxed);
+        m_seq.store(sequence + 1, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_release);
+        m_vtable.store(Address{}, std::memory_order_relaxed);
+        m_image_base.store(Address{}, std::memory_order_relaxed);
+        m_generation.store(0, std::memory_order_relaxed);
+        m_epoch.fetch_add(1, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_release);
+        m_seq.store(sequence + 2, std::memory_order_relaxed);
+        m_writer.clear(std::memory_order_release);
+    }
+
     std::optional<Address> rtti::find_in_pointer_table(Address table, std::size_t slot_count, std::string_view expected,
                                                        std::atomic<Address> *vtable_cache, std::size_t stride) noexcept
     {
@@ -337,33 +416,150 @@ namespace DetourModKit
         if (vtable_cache)
             cached_vt = vtable_cache->load(std::memory_order_relaxed);
 
-        for (std::size_t i = 0; i < slot_count; ++i)
+        const auto scan = [&](Address warm_vtable) noexcept -> std::optional<Address>
         {
-            const std::uintptr_t slot_addr = table_raw + i * stride;
-
-            const auto obj_opt = DetourModKit::detail::guarded_read<std::uintptr_t>(slot_addr);
-            if (!obj_opt || *obj_opt < detail::MIN_VALID_PTR)
-                continue;
-            const std::uintptr_t obj = *obj_opt;
-
-            const auto vt_opt = DetourModKit::detail::guarded_read<std::uintptr_t>(obj);
-            if (!vt_opt || *vt_opt < detail::MIN_VALID_PTR)
-                continue;
-            const Address vt{*vt_opt};
-
-            if (cached_vt)
+            for (std::size_t i = 0; i < slot_count; ++i)
             {
-                if (vt == cached_vt)
+                const std::uintptr_t slot_addr = table_raw + i * stride;
+                const auto obj_opt = DetourModKit::detail::guarded_read<std::uintptr_t>(slot_addr);
+                if (!obj_opt || *obj_opt < detail::MIN_VALID_PTR)
+                    continue;
+                const std::uintptr_t obj = *obj_opt;
+
+                const auto vt_opt = DetourModKit::detail::guarded_read<std::uintptr_t>(obj);
+                if (!vt_opt || *vt_opt < detail::MIN_VALID_PTR)
+                    continue;
+                const Address vt{*vt_opt};
+
+                if (warm_vtable)
+                {
+                    if (vt == warm_vtable)
+                        return Address{obj};
+                    continue;
+                }
+
+                if (vtable_is_type(vt, expected))
+                {
+                    if (vtable_cache)
+                        vtable_cache->store(vt, std::memory_order_relaxed);
                     return Address{obj};
+                }
+            }
+            return std::nullopt;
+        };
+
+        if (cached_vt)
+        {
+            if (const auto warm = scan(cached_vt))
+                return warm;
+
+            // No slot carried the cached vtable. Clear only the value this call observed, then run one cold pass so a
+            // remapped table refreshes immediately instead of remaining wedged on a stale address.
+            if (vtable_cache)
+            {
+                Address expected_cache = cached_vt;
+                (void)vtable_cache->compare_exchange_strong(expected_cache, Address{}, std::memory_order_relaxed);
+            }
+        }
+        return scan(Address{});
+    }
+
+    std::optional<Address> rtti::find_in_pointer_table(Address table, std::size_t slot_count, std::string_view expected,
+                                                       PointerTableCache &cache, std::size_t stride) noexcept
+    {
+        struct CacheSnapshot
+        {
+            Address vtable{};
+            Address image_base{};
+            std::uint64_t generation{0};
+            std::uint64_t epoch{0};
+        };
+
+        const auto load_cache = [&cache]() noexcept -> CacheSnapshot
+        {
+            constexpr std::size_t MAX_ATTEMPTS = 16;
+            for (std::size_t attempt = 0; attempt < MAX_ATTEMPTS; ++attempt)
+            {
+                const std::uint32_t sequence = cache.m_seq.load(std::memory_order_acquire);
+                if ((sequence & 1U) != 0U)
+                    continue;
+                const CacheSnapshot snapshot{
+                    cache.m_vtable.load(std::memory_order_relaxed), cache.m_image_base.load(std::memory_order_relaxed),
+                    cache.m_generation.load(std::memory_order_relaxed), cache.m_epoch.load(std::memory_order_relaxed)};
+                std::atomic_thread_fence(std::memory_order_acquire);
+                if (cache.m_seq.load(std::memory_order_relaxed) == sequence)
+                    return snapshot;
+            }
+            return {};
+        };
+
+        const auto publish_cache = [&cache](CacheSnapshot desired, CacheSnapshot expected_snapshot) noexcept
+        {
+            if (cache.m_writer.test_and_set(std::memory_order_acquire))
+                return;
+            if (cache.m_vtable.load(std::memory_order_relaxed) != expected_snapshot.vtable ||
+                cache.m_image_base.load(std::memory_order_relaxed) != expected_snapshot.image_base ||
+                cache.m_generation.load(std::memory_order_relaxed) != expected_snapshot.generation ||
+                cache.m_epoch.load(std::memory_order_relaxed) != expected_snapshot.epoch)
+            {
+                cache.m_writer.clear(std::memory_order_release);
+                return;
+            }
+            const std::uint32_t sequence = cache.m_seq.load(std::memory_order_relaxed);
+            cache.m_seq.store(sequence + 1, std::memory_order_relaxed);
+            std::atomic_thread_fence(std::memory_order_release);
+            cache.m_vtable.store(desired.vtable, std::memory_order_relaxed);
+            cache.m_image_base.store(desired.image_base, std::memory_order_relaxed);
+            cache.m_generation.store(desired.generation, std::memory_order_relaxed);
+            std::atomic_thread_fence(std::memory_order_release);
+            cache.m_seq.store(sequence + 2, std::memory_order_relaxed);
+            cache.m_writer.clear(std::memory_order_release);
+        };
+
+        for (std::size_t attempt = 0; attempt < 2; ++attempt)
+        {
+            const CacheSnapshot snapshot = load_cache();
+            const bool warm = snapshot.vtable && snapshot.image_base && snapshot.generation != 0 &&
+                              current_image_stamp(snapshot.image_base.raw()) == snapshot.generation;
+            std::atomic<Address> candidate_cache{warm ? snapshot.vtable : Address{}};
+            const auto hit = find_in_pointer_table(table, slot_count, expected, &candidate_cache, stride);
+            if (!hit)
+            {
+                if (snapshot.vtable)
+                    publish_cache({}, snapshot);
+                return std::nullopt;
+            }
+
+            const Address candidate_vtable = candidate_cache.load(std::memory_order_relaxed);
+            if (warm && candidate_vtable == snapshot.vtable)
+            {
+                if (current_image_stamp(snapshot.image_base.raw()) == snapshot.generation)
+                    return hit;
+                publish_cache({}, snapshot);
                 continue;
             }
 
-            if (vtable_is_type(vt, expected))
+            const Region image_before = current_module_region(candidate_vtable);
+            const std::uint64_t generation_before =
+                image_before.base ? current_image_stamp(image_before.base.raw()) : 0;
+            if (!image_before.base || generation_before == 0 || !vtable_is_type(candidate_vtable, expected))
             {
-                if (vtable_cache)
-                    vtable_cache->store(vt, std::memory_order_relaxed);
-                return Address{obj};
+                publish_cache({}, snapshot);
+                return std::nullopt;
             }
+
+            const auto object_vtable = DetourModKit::detail::guarded_read<std::uintptr_t>(hit->raw());
+            const Region image_after = current_module_region(candidate_vtable);
+            const std::uint64_t generation_after = image_after.base ? current_image_stamp(image_after.base.raw()) : 0;
+            if (!object_vtable || *object_vtable != candidate_vtable.raw() || image_after.base != image_before.base ||
+                generation_after != generation_before)
+            {
+                publish_cache({}, snapshot);
+                continue;
+            }
+
+            publish_cache({candidate_vtable, image_after.base, generation_after}, snapshot);
+            return hit;
         }
         return std::nullopt;
     }
@@ -374,6 +570,12 @@ namespace DetourModKit
         // produces a handful at most; the cap keeps the reverse scan allocation-free (matches live in a stack array)
         // and bounds a pathological duplicate-type image.
         inline constexpr std::size_t MAX_REVERSE_MATCHES = 64;
+
+        // Cap on the readable non-executable sections collected into the stack range buffer for one reverse sweep. A
+        // normal PE keeps vtables and their RTTI meta-pointers in one or two sections (.rdata, .data), so this is
+        // generous; a scope with more qualifying sections than fit reports Traversal::Saturated rather than silently
+        // dropping the overflow.
+        inline constexpr std::size_t MAX_RTTI_SCAN_RANGES = 32;
 
         // One readable, non-executable image-resident scan window.
         struct ScanRange
@@ -390,6 +592,51 @@ namespace DetourModKit
             std::uint32_t col_offset = 0;
         };
 
+        [[nodiscard]] Region current_module_region(Address address) noexcept
+        {
+#if defined(DMK_ENABLE_TEST_SEAMS)
+            if (auto *override_fn = DetourModKit::detail::g_rtti_module_region_override)
+                return override_fn(address);
+#endif
+            return DetourModKit::detail::live_module_region(address);
+        }
+
+        /** @brief Reads the bounded PE identity fields at a known module base without consulting the loader. */
+        [[nodiscard]] std::uint64_t read_image_stamp_from_base(std::uintptr_t module_base) noexcept
+        {
+            if (!DetourModKit::detail::is_plausible_ptr(module_base))
+                return 0;
+
+            const auto dos = DetourModKit::detail::guarded_read<IMAGE_DOS_HEADER>(module_base);
+            if (!dos || dos->e_magic != IMAGE_DOS_SIGNATURE || dos->e_lfanew <= 0 ||
+                static_cast<std::uint32_t>(dos->e_lfanew) > 0x100000U)
+                return 0;
+            const std::uintptr_t nt_addr = module_base + static_cast<std::uint32_t>(dos->e_lfanew);
+            const auto nt = DetourModKit::detail::guarded_read<IMAGE_NT_HEADERS64>(nt_addr);
+            if (!nt || nt->Signature != IMAGE_NT_SIGNATURE ||
+                nt->OptionalHeader.Magic != IMAGE_NT_OPTIONAL_HDR64_MAGIC || nt->OptionalHeader.SizeOfImage == 0)
+                return 0;
+
+            const auto mix = [](std::uint64_t seed, std::uint64_t value) noexcept -> std::uint64_t
+            {
+                seed ^= value + 0x9E3779B97F4A7C15ULL + (seed << 6) + (seed >> 2);
+                return seed;
+            };
+            std::uint64_t token = static_cast<std::uint64_t>(module_base);
+            token = mix(token, static_cast<std::uint64_t>(nt->OptionalHeader.SizeOfImage));
+            token = mix(token, static_cast<std::uint64_t>(nt->FileHeader.TimeDateStamp));
+            return token == 0 ? 1 : token;
+        }
+
+        [[nodiscard]] std::uint64_t current_image_stamp(std::uintptr_t module_base) noexcept
+        {
+#if defined(DMK_ENABLE_TEST_SEAMS)
+            if (auto *override_fn = DetourModKit::detail::g_rtti_image_generation_override)
+                return override_fn(module_base);
+#endif
+            return read_image_stamp_from_base(module_base);
+        }
+
         /**
          * @brief Enumerates the module's readable, non-executable, non-discardable sections -- where MSVC keeps vtables
          *        and their
@@ -399,20 +646,25 @@ namespace DetourModKit
          *          is bound- and signature-checked so a malformed or hostile image fails closed instead of being read
          *          through.
          * @return The number of ranges written into @p out; 0 means the PE headers could not be parsed and the caller
-         *         falls back to the whole module image.
+         *         falls back to the whole module image. @p completeness is set to @ref rtti::Traversal::Incomplete when
+         *         a section header could not be read after a valid prefix, or @ref rtti::Traversal::Saturated when a
+         *         qualifying section did not fit @p out; it is left @ref rtti::Traversal::Complete otherwise (including
+         *         the 0-return, where the caller's whole-image fallback determines its own completeness).
          */
-        std::size_t collect_rtti_scan_ranges(DetourModKit::detail::ModuleSpan mod, ScanRange *out,
-                                             std::size_t cap) noexcept
+        std::size_t collect_rtti_scan_ranges(DetourModKit::detail::ModuleSpan mod, ScanRange *out, std::size_t cap,
+                                             rtti::Traversal &completeness) noexcept
         {
             const auto dos = DetourModKit::detail::guarded_read<IMAGE_DOS_HEADER>(mod.base);
-            if (!dos || dos->e_magic != IMAGE_DOS_SIGNATURE)
+            if (!dos || dos->e_magic != IMAGE_DOS_SIGNATURE || dos->e_lfanew <= 0)
                 return 0;
 
-            const std::uintptr_t nt_addr =
-                mod.base + static_cast<std::uintptr_t>(static_cast<std::uint32_t>(dos->e_lfanew));
+            const std::uintptr_t nt_offset = static_cast<std::uint32_t>(dos->e_lfanew);
+            if (nt_offset >= mod.end - mod.base)
+                return 0;
+            const std::uintptr_t nt_addr = mod.base + nt_offset;
             // The NT headers must lie inside the image; a wild e_lfanew is the signature of a forged or truncated
             // header.
-            if (!mod.contains(nt_addr) || !mod.contains(nt_addr + sizeof(IMAGE_NT_HEADERS64)))
+            if (!mod.contains(nt_addr) || mod.end - nt_addr < sizeof(IMAGE_NT_HEADERS64))
                 return 0;
 
             const auto nt = DetourModKit::detail::guarded_read<IMAGE_NT_HEADERS64>(nt_addr);
@@ -432,16 +684,25 @@ namespace DetourModKit
                 nt_addr + offsetof(IMAGE_NT_HEADERS64, OptionalHeader) + nt->FileHeader.SizeOfOptionalHeader;
 
             std::size_t count = 0;
-            for (std::uint32_t i = 0; i < num_sections && count < cap; ++i)
+            for (std::uint32_t i = 0; i < num_sections; ++i)
             {
                 const std::uintptr_t hdr_addr =
                     sec_table + static_cast<std::uintptr_t>(i) * sizeof(IMAGE_SECTION_HEADER);
-                if (!mod.contains(hdr_addr + sizeof(IMAGE_SECTION_HEADER)))
+                // A section header that escapes the image, or one whose guarded read faults, truncates the enumeration
+                // after a valid prefix: the sections past it are never examined, so a unique/absent verdict built on
+                // this range set is not authoritative. Surface Incomplete rather than silently returning the prefix.
+                if (!mod.contains(hdr_addr) || mod.end - hdr_addr < sizeof(IMAGE_SECTION_HEADER))
+                {
+                    completeness = rtti::Traversal::Incomplete;
                     break;
+                }
 
                 const auto sec = DetourModKit::detail::guarded_read<IMAGE_SECTION_HEADER>(hdr_addr);
                 if (!sec)
+                {
+                    completeness = rtti::Traversal::Incomplete;
                     break;
+                }
 
                 const std::uint32_t ch = sec->Characteristics;
                 const bool readable = (ch & IMAGE_SCN_MEM_READ) != 0;
@@ -453,11 +714,28 @@ namespace DetourModKit
                 // Use the in-memory extent (VirtualAddress + VirtualSize), never the on-disk
                 // PointerToRawData/SizeOfRawData: those are file offsets and do not survive section alignment once
                 // mapped.
-                const std::uintptr_t begin = mod.base + sec->VirtualAddress;
-                const std::uintptr_t end = begin + sec->Misc.VirtualSize;
-                if (end <= begin || !mod.contains(begin) || end > mod.end)
+                if (sec->Misc.VirtualSize == 0)
                     continue;
+                if (sec->VirtualAddress >= mod.end - mod.base)
+                {
+                    completeness = merge_traversal(completeness, rtti::Traversal::Incomplete);
+                    continue;
+                }
+                const std::uintptr_t begin = mod.base + sec->VirtualAddress;
+                if (sec->Misc.VirtualSize > mod.end - begin)
+                {
+                    completeness = merge_traversal(completeness, rtti::Traversal::Incomplete);
+                    continue;
+                }
+                const std::uintptr_t end = begin + sec->Misc.VirtualSize;
 
+                // A qualifying section that will not fit the caller's fixed range buffer means the sweep would omit a
+                // region that could hold the type: report Saturated so the verdict is not treated as authoritative.
+                if (count == cap)
+                {
+                    completeness = rtti::Traversal::Saturated;
+                    break;
+                }
                 out[count].begin = begin;
                 out[count].end = end;
                 ++count;
@@ -501,7 +779,7 @@ namespace DetourModKit
          */
         void sweep_range_for_name(DetourModKit::detail::ModuleSpan mod, DetourModKit::detail::ModuleSpan owning,
                                   std::uintptr_t begin, std::uintptr_t end, std::string_view mangled, VtMatch *out,
-                                  std::size_t cap, std::size_t &count) noexcept
+                                  std::size_t cap, std::size_t &count, bool &page_unreadable) noexcept
         {
             // Image-resident pointer storage is 8-byte aligned, so only qword-aligned slots can hold a vtable
             // meta-pointer.
@@ -523,7 +801,15 @@ namespace DetourModKit
                 // a 4 KiB page holds at most 512 qwords
                 std::uintptr_t buf[512];
                 const std::size_t want = (qwords < 512) ? qwords : 512;
-                if (DetourModKit::detail::guarded_read_bytes(addr, buf, want * sizeof(std::uintptr_t)))
+                if (!DetourModKit::detail::guarded_read_bytes(addr, buf, want * sizeof(std::uintptr_t)))
+                {
+                    // A page inside a qualifying section could not be read, so a meta-slot on it (and the vtable it
+                    // anchors) is invisible to this sweep. Record the gap: a unique/absent verdict built on a sweep
+                    // that skipped a page is not authoritative. The page is skipped (advance past it) rather than
+                    // aborting, so the readable remainder of the range is still scanned.
+                    page_unreadable = true;
+                }
+                else
                 {
                     for (std::size_t j = 0; j < want && count < cap; ++j)
                     {
@@ -581,10 +867,13 @@ namespace DetourModKit
          *          binary.
          */
         std::size_t scan_vtables_for_name(DetourModKit::detail::ModuleSpan mod, std::string_view mangled, VtMatch *out,
-                                          std::size_t cap) noexcept
+                                          std::size_t cap, rtti::Traversal &completeness) noexcept
         {
             if (!mod.valid() || mangled.empty() || mangled.size() >= rtti::MAX_TYPE_NAME_LEN)
+            {
+                completeness = merge_traversal(completeness, rtti::Traversal::Incomplete);
                 return 0;
+            }
 
             // Resolve the vtables' owning module once for the whole sweep. resolve_col_site needs the true module base
             // and extent (for the pSelf/base cross-check and RVA->VA), which is not the scan scope `mod`: a caller may
@@ -593,26 +882,37 @@ namespace DetourModKit
             // the per-candidate loader lookup is hoisted here. An invalid result (the scope base is not in a loaded
             // module) leaves each candidate to resolve its own module in sweep_range_for_name, preserving behaviour.
             const DetourModKit::detail::ModuleSpan owning =
-                DetourModKit::detail::module_span(memory::module_of(Address{mod.base}));
+                DetourModKit::detail::module_span(DetourModKit::detail::live_module_region(Address{mod.base}));
 
-            ScanRange ranges[32];
-            const std::size_t range_count = collect_rtti_scan_ranges(mod, ranges, 32);
+            ScanRange ranges[MAX_RTTI_SCAN_RANGES];
+            const std::size_t range_count = collect_rtti_scan_ranges(mod, ranges, MAX_RTTI_SCAN_RANGES, completeness);
 
             std::size_t count = 0;
+            bool page_unreadable = false;
             if (range_count == 0)
             {
                 // No usable scan window (the PE headers could not be parsed, or no readable non-executable section
                 // qualified): sweep the whole image rather than report a confident-but-wrong "not found" for a packed
                 // or section-merged binary. The whole-image sweep is a strict superset, and resolve_col_site still
                 // validates every candidate.
-                sweep_range_for_name(mod, owning, mod.base, mod.end, mangled, out, cap, count);
-                return count;
+                sweep_range_for_name(mod, owning, mod.base, mod.end, mangled, out, cap, count, page_unreadable);
+            }
+            else
+            {
+                for (std::size_t i = 0; i < range_count && count < cap; ++i)
+                {
+                    sweep_range_for_name(mod, owning, ranges[i].begin, ranges[i].end, mangled, out, cap, count,
+                                         page_unreadable);
+                }
             }
 
-            for (std::size_t i = 0; i < range_count && count < cap; ++i)
-            {
-                sweep_range_for_name(mod, owning, ranges[i].begin, ranges[i].end, mangled, out, cap, count);
-            }
+            // An unreadable page anywhere in the sweep means a match could have hidden on it; a match buffer that
+            // filled to capacity means the same for the matches past the cap. Either makes a uniqueness or absence
+            // verdict unsafe, so fold both into the completeness the caller gates on.
+            if (page_unreadable)
+                completeness = merge_traversal(completeness, rtti::Traversal::Incomplete);
+            if (count == cap)
+                completeness = merge_traversal(completeness, rtti::Traversal::Saturated);
             return count;
         }
 
@@ -621,7 +921,7 @@ namespace DetourModKit
          * @details Mirrors the name sweep's page-bounded read, meta-slot pre-filter, and resolve_col_site validation,
          *          but returns on the first hit instead of collecting and deduping matches. The page-walk is duplicated
          *          from @ref sweep_range_for_name rather than factored into a shared callback-driven core: sharing one
-         *          would re-open the audited name-resolve sweep (the security-critical COL-validation path) purely to
+         *          would complicate the security-critical name-resolve sweep purely to
          *          save the mechanical loop, and the two sweeps terminate differently (collect-to-cap versus first-hit
          *          exit). The validation authority, @ref resolve_col_site, IS shared, so the two paths cannot diverge
          *          on what counts as a resolvable COL; only the copied loop could drift, and a drift there is
@@ -631,7 +931,7 @@ namespace DetourModKit
          *        candidate resolves its own module (mirrors @ref sweep_range_for_name).
          */
         bool sweep_range_for_first_col(DetourModKit::detail::ModuleSpan mod, DetourModKit::detail::ModuleSpan owning,
-                                       std::uintptr_t begin, std::uintptr_t end) noexcept
+                                       std::uintptr_t begin, std::uintptr_t end, bool &page_unreadable) noexcept
         {
             std::uintptr_t addr = (begin + 7) & ~static_cast<std::uintptr_t>(7);
 
@@ -650,7 +950,13 @@ namespace DetourModKit
                 // A 4 KiB page holds at most 512 qwords.
                 std::uintptr_t buf[512];
                 const std::size_t want = (qwords < 512) ? qwords : 512;
-                if (DetourModKit::detail::guarded_read_bytes(addr, buf, want * sizeof(std::uintptr_t)))
+                if (!DetourModKit::detail::guarded_read_bytes(addr, buf, want * sizeof(std::uintptr_t)))
+                {
+                    // An unreadable page hides any COL on it; record the gap so a "no records" answer built on this
+                    // sweep is reported as Incomplete rather than an authoritative absence.
+                    page_unreadable = true;
+                }
+                else
                 {
                     for (std::size_t j = 0; j < want; ++j)
                     {
@@ -687,39 +993,60 @@ namespace DetourModKit
          *          parse -- a packed or section-merged image, or a tight non-PE scope window. The caller
          *          (@ref rtti::region_has_rtti) has already proven @p mod valid.
          */
-        bool scope_has_rtti(DetourModKit::detail::ModuleSpan mod) noexcept
+        rtti::RttiPresence scope_has_rtti(DetourModKit::detail::ModuleSpan mod) noexcept
         {
             const DetourModKit::detail::ModuleSpan owning =
-                DetourModKit::detail::module_span(memory::module_of(Address{mod.base}));
+                DetourModKit::detail::module_span(DetourModKit::detail::live_module_region(Address{mod.base}));
 
-            ScanRange ranges[32];
-            const std::size_t range_count = collect_rtti_scan_ranges(mod, ranges, 32);
+            rtti::Traversal completeness = rtti::Traversal::Complete;
+            ScanRange ranges[MAX_RTTI_SCAN_RANGES];
+            const std::size_t range_count = collect_rtti_scan_ranges(mod, ranges, MAX_RTTI_SCAN_RANGES, completeness);
 
+            bool page_unreadable = false;
             if (range_count == 0)
             {
                 // No parseable section table (packed / section-merged / a non-PE scope window): sweep the whole image
                 // as a strict superset, exactly as scan_vtables_for_name does on the same condition.
-                return sweep_range_for_first_col(mod, owning, mod.base, mod.end);
+                if (sweep_range_for_first_col(mod, owning, mod.base, mod.end, page_unreadable))
+                    return rtti::RttiPresence::Present;
+            }
+            else
+            {
+                for (std::size_t i = 0; i < range_count; ++i)
+                {
+                    if (sweep_range_for_first_col(mod, owning, ranges[i].begin, ranges[i].end, page_unreadable))
+                        return rtti::RttiPresence::Present;
+                }
             }
 
-            for (std::size_t i = 0; i < range_count; ++i)
-            {
-                if (sweep_range_for_first_col(mod, owning, ranges[i].begin, ranges[i].end))
-                    return true;
-            }
-            return false;
+            // No record was found. Only call that an authoritative absence when the sweep was complete: a faulted
+            // section header (in `completeness`) or an unreadable page (`page_unreadable`) could have hidden the only
+            // record, so report Incomplete instead of a false Absent.
+            if (page_unreadable)
+                completeness = merge_traversal(completeness, rtti::Traversal::Incomplete);
+            return (completeness == rtti::Traversal::Complete) ? rtti::RttiPresence::Absent
+                                                               : rtti::RttiPresence::Incomplete;
         }
     } // anonymous namespace
 
     std::optional<Address> rtti::vtable_for_type(std::string_view mangled, Region range) noexcept
     {
         VtMatch matches[MAX_REVERSE_MATCHES];
-        const std::size_t match_count =
-            scan_vtables_for_name(DetourModKit::detail::module_span(range), mangled, matches, MAX_REVERSE_MATCHES);
+        rtti::Traversal completeness = rtti::Traversal::Complete;
+        const std::size_t match_count = scan_vtables_for_name(DetourModKit::detail::module_span(range), mangled,
+                                                              matches, MAX_REVERSE_MATCHES, completeness);
+
+        // A unique or absent verdict is the inverse of vtable_is_type and is trustworthy only across a COMPLETE sweep.
+        // An Incomplete sweep (a faulted section header or an unreadable page) or a Saturated one (the section-range or
+        // match buffer filled) could hide a second distinct primary -- making a "unique" answer wrong -- or the only
+        // primary -- making an "absent" answer wrong. Fail closed rather than authorize a verdict from a partial sweep;
+        // match-buffer exhaustion is reported as Traversal::Saturated by the same completeness gate.
+        if (completeness != rtti::Traversal::Complete)
+            return std::nullopt;
 
         // The primary vtable is the COL.offset == 0 sub-object: the value an object pointer's first qword holds for a
-        // most-derived instance, i.e. the faithful inverse of vtable_is_type. More than one distinct primary for the
-        // same name (a type linked into the image twice) is ambiguous; fail closed rather than return an arbitrary one.
+        // most-derived instance. More than one distinct primary for the same name (a type linked into the image twice)
+        // is ambiguous; fail closed rather than return an arbitrary one.
         std::optional<std::uintptr_t> primary;
         for (std::size_t i = 0; i < match_count; ++i)
         {
@@ -730,28 +1057,21 @@ namespace DetourModKit
             primary = matches[i].vtable;
         }
 
-        // scan_vtables_for_name saturated its match buffer (match_count reached the cap), so vtables for this name may
-        // exist beyond MAX_REVERSE_MATCHES that the loop above never inspected -- including a second distinct primary
-        // that would make the result ambiguous. The uniqueness guarantee cannot hold across a truncated scan, so fail
-        // closed rather than hand back a primary that might not be the only one. A name with this many sub-object
-        // vtables is already a pathological / ODR-duplicated image; the documented happy case is a handful.
-        if (match_count == MAX_REVERSE_MATCHES && primary)
-            return std::nullopt;
-
         if (!primary)
             return std::nullopt;
         return Address{*primary};
     }
 
-    std::size_t rtti::vtables_for_type(std::string_view mangled, Address *out, std::size_t out_cap,
-                                       Region range) noexcept
+    rtti::VtablesResult rtti::vtables_for_type_checked(std::string_view mangled, Address *out, std::size_t out_cap,
+                                                       Region range) noexcept
     {
         if (!out)
             out_cap = 0;
 
         VtMatch matches[MAX_REVERSE_MATCHES];
-        const std::size_t match_count =
-            scan_vtables_for_name(DetourModKit::detail::module_span(range), mangled, matches, MAX_REVERSE_MATCHES);
+        rtti::Traversal completeness = rtti::Traversal::Complete;
+        const std::size_t match_count = scan_vtables_for_name(DetourModKit::detail::module_span(range), mangled,
+                                                              matches, MAX_REVERSE_MATCHES, completeness);
 
         // Ascending COL.offset so the primary (offset 0) sorts first. The match count is tiny (one per base
         // sub-object), so an in-place insertion sort is both adequate and allocation-free.
@@ -770,62 +1090,153 @@ namespace DetourModKit
         const std::size_t to_write = (match_count < out_cap) ? match_count : out_cap;
         for (std::size_t i = 0; i < to_write; ++i)
             out[i] = Address{matches[i].vtable};
-        return match_count;
+        return VtablesResult{match_count, completeness};
+    }
+
+    std::size_t rtti::vtables_for_type(std::string_view mangled, Address *out, std::size_t out_cap,
+                                       Region range) noexcept
+    {
+        // Best-effort count-only face over the checked form: it discards the completeness, so a caller that must
+        // distinguish an authoritative absence from a truncated sweep uses vtables_for_type_checked instead.
+        return vtables_for_type_checked(mangled, out, out_cap, range).count;
     }
 
     bool rtti::region_has_rtti(Region range) noexcept
     {
-        const auto mod = DetourModKit::detail::module_span(range);
-        // An empty or malformed Region yields an invalid span; report "no records" so a caller that passes an
-        // unmapped range receives the same fail-closed "use the raw-byte fallback" answer as a genuinely records-free
-        // module, never a false positive that would steer it away from string-xref.
-        return mod.valid() && scope_has_rtti(mod);
+        // true only on a found record (sound regardless of completeness); Absent and Incomplete both collapse to the
+        // fail-closed "no record found, use the raw-byte fallback" answer, the same one an invalid range receives.
+        return region_rtti_presence(range) == RttiPresence::Present;
     }
 
-    rtti::TypeIdentity::TypeIdentity(std::string_view mangled, Region range) : m_mangled(mangled), m_range(range) {}
+    rtti::RttiPresence rtti::region_rtti_presence(Region range) noexcept
+    {
+        const auto mod = DetourModKit::detail::module_span(range);
+        // No sweep can establish absence from an invalid range.
+        if (!mod.valid())
+            return RttiPresence::Incomplete;
+        return scope_has_rtti(mod);
+    }
+
+    std::uint64_t rtti::image_generation(Address addr) noexcept
+    {
+#if defined(DMK_ENABLE_TEST_SEAMS)
+        if (auto *override_fn = DetourModKit::detail::g_rtti_image_generation_override)
+            return override_fn(addr.raw());
+#endif
+        const Region module = current_module_region(addr);
+        return module.base ? read_image_stamp_from_base(module.base.raw()) : 0;
+    }
+
+    rtti::TypeIdentity::TypeIdentity(std::string_view mangled, Region range) : m_mangled(mangled), m_range(range)
+    {
+        const Region module = current_module_region(range.base);
+        m_tracks_module_range = module.base == range.base && module.size == range.size;
+    }
+
+    void rtti::TypeIdentity::invalidate() noexcept
+    {
+        while (m_cache_writer.test_and_set(std::memory_order_acquire))
+            (void)::SwitchToThread();
+        m_cache_epoch.fetch_add(1, std::memory_order_acq_rel);
+        m_resolved.store(false, std::memory_order_release);
+        m_cached.store(Address{}, std::memory_order_relaxed);
+        m_image_stamp.store(0, std::memory_order_relaxed);
+        m_image_base.store(Address{}, std::memory_order_relaxed);
+        m_last_attempt_ms.store(0, std::memory_order_relaxed);
+        m_cache_writer.clear(std::memory_order_release);
+    }
 
     std::optional<Address> rtti::TypeIdentity::vtable() const noexcept
     {
-        // Fast path: a completed resolve stored m_cached before publishing m_resolved with release, so an acquire-load
-        // that sees m_resolved also sees the cached value.
+        const std::uint64_t cache_epoch = m_cache_epoch.load(std::memory_order_acquire);
+        const auto resolve_and_cache = [this](std::uint64_t expected_epoch) -> std::optional<Address>
+        {
+            Region resolve_range = m_range;
+            if (m_tracks_module_range)
+            {
+                resolve_range = current_module_region(m_range.base);
+                if (!resolve_range.base || resolve_range.size == 0)
+                    return std::nullopt;
+            }
+
+            const Region image_before = current_module_region(resolve_range.base);
+            const std::uint64_t stamp_before = image_before.base ? current_image_stamp(image_before.base.raw()) : 0;
+            const auto resolved = vtable_for_type(m_mangled, resolve_range);
+            if (!resolved)
+                return std::nullopt;
+
+            const Region image_after = current_module_region(*resolved);
+            const std::uint64_t stamp_after = image_after.base ? current_image_stamp(image_after.base.raw()) : 0;
+            const bool module_backed_before = image_before.base && image_before.size != 0;
+            const bool module_backed_after = image_after.base && image_after.size != 0;
+            if (module_backed_before != module_backed_after || image_before.base != image_after.base ||
+                stamp_before != stamp_after || (module_backed_after && stamp_after == 0))
+                return std::nullopt;
+
+            if (m_cache_writer.test_and_set(std::memory_order_acquire))
+                return std::nullopt;
+            if (m_cache_epoch.load(std::memory_order_acquire) != expected_epoch)
+            {
+                m_cache_writer.clear(std::memory_order_release);
+                return std::nullopt;
+            }
+            m_image_base.store(image_after.base, std::memory_order_relaxed);
+            m_image_stamp.store(stamp_after, std::memory_order_relaxed);
+            m_cached.store(*resolved, std::memory_order_relaxed);
+            m_resolved.store(true, std::memory_order_release);
+            m_cache_writer.clear(std::memory_order_release);
+            return resolved;
+        };
+
         if (m_resolved.load(std::memory_order_acquire))
         {
+            const Address image_base = m_image_base.load(std::memory_order_relaxed);
+            const std::uint64_t image_stamp = m_image_stamp.load(std::memory_order_relaxed);
+            if (image_stamp != 0 && current_image_stamp(image_base.raw()) != image_stamp)
+            {
+                if (m_cache_writer.test_and_set(std::memory_order_acquire))
+                    return std::nullopt;
+                if (m_cache_epoch.load(std::memory_order_acquire) != cache_epoch)
+                {
+                    m_cache_writer.clear(std::memory_order_release);
+                    return std::nullopt;
+                }
+                const std::uint64_t next_epoch = m_cache_epoch.fetch_add(1, std::memory_order_acq_rel) + 1;
+                m_resolved.store(false, std::memory_order_release);
+                m_cached.store(Address{}, std::memory_order_relaxed);
+                m_image_stamp.store(0, std::memory_order_relaxed);
+                m_image_base.store(Address{}, std::memory_order_relaxed);
+                m_cache_writer.clear(std::memory_order_release);
+                return resolve_and_cache(next_epoch);
+            }
             const Address cached = m_cached.load(std::memory_order_relaxed);
+            if (m_cache_epoch.load(std::memory_order_acquire) != cache_epoch ||
+                !m_resolved.load(std::memory_order_acquire))
+                return std::nullopt;
             return cached ? std::optional<Address>(cached) : std::nullopt;
         }
 
-        // First use (or a retry after an earlier miss): resolve and cache. Concurrent first-callers converge on the
-        // same vtable, so a benign double-resolve needs no lock. vtable_for_type sweeps every RTTI-bearing section of
-        // the scope module -- a heavy walk. Because a miss is deliberately NOT latched (the owning module may map the
-        // type later), a TypeIdentity polled every frame for an absent type would otherwise re-sweep the whole module
-        // every frame. Throttle the re-sweep: after a miss, skip the sweep until RESOLVE_RETRY_COOLDOWN_MS has elapsed,
-        // turning a per-frame full-module scan into at most one scan per cooldown while still eventually retrying.
+        // Miss path. vtable_for_type sweeps every RTTI-bearing section -- a heavy walk -- so throttle the re-sweep:
+        // after a miss, skip until RESOLVE_RETRY_COOLDOWN_MS has elapsed, turning a per-frame full-module scan for an
+        // absent type into at most one scan per cooldown while still eventually retrying. last == 0 is the
+        // never-attempted sentinel; the now >= last guard keeps a non-monotonic clock from underflowing into a skip.
         const std::uint64_t now = rtti_now_ms();
-        const std::uint64_t last = m_last_attempt_ms.load(std::memory_order_acquire);
-        // last == 0 is the never-attempted sentinel (the first call always sweeps). The now >= last guard keeps a
-        // non-monotonic clock (or a test clock reset) from underflowing the subtraction into a spurious skip.
-        if (last != 0 && now >= last && (now - last) < RESOLVE_RETRY_COOLDOWN_MS)
+        if (m_cache_writer.test_and_set(std::memory_order_acquire))
+            return std::nullopt;
+        if (m_cache_epoch.load(std::memory_order_acquire) != cache_epoch)
         {
+            m_cache_writer.clear(std::memory_order_release);
             return std::nullopt;
         }
-        // Record this attempt before sweeping so a concurrent caller inside the cooldown also skips. Clamp to >= 1 so a
-        // clock reading of 0 is never mistaken for the never-attempted sentinel. The release store is conservative for
-        // a performance throttle; at worst a lost update allows one extra sweep.
-        m_last_attempt_ms.store(now == 0 ? 1 : now, std::memory_order_release);
-
-        const auto resolved = vtable_for_type(m_mangled, m_range);
-
-        // Latch only a SUCCESSFUL resolve as permanent. A failed resolve is not cached: the vtable may simply not be
-        // mapped yet (the owning module loads later, or a game patch is mid-relocation), so leaving m_resolved false
-        // lets a subsequent call retry once the type becomes resolvable rather than wedging on a stale miss forever.
-        // The store of m_cached is published with release before m_resolved, so the fast path's acquire-load that sees
-        // m_resolved == true also sees the cached value.
-        if (resolved)
+        const std::uint64_t last = m_last_attempt_ms.load(std::memory_order_acquire);
+        if (last != 0 && now >= last && (now - last) < RESOLVE_RETRY_COOLDOWN_MS)
         {
-            m_cached.store(*resolved, std::memory_order_release);
-            m_resolved.store(true, std::memory_order_release);
+            m_cache_writer.clear(std::memory_order_release);
+            return std::nullopt;
         }
-        return resolved;
+        m_last_attempt_ms.store(now == 0 ? 1 : now, std::memory_order_release);
+        m_cache_writer.clear(std::memory_order_release);
+        return resolve_and_cache(cache_epoch);
     }
 
     bool rtti::TypeIdentity::matches(Address vtable) const noexcept

--- a/src/rtti_dissect.cpp
+++ b/src/rtti_dissect.cpp
@@ -14,8 +14,7 @@
  * SEH-guarded, module-bound-checked prelude the forward walker uses, so an unmapped page or forged COL is a clean
  * non-match, never a fault. Matching is byte-exact on the MSVC most-derived mangled name (no UnDecorateSymbolName).
  *
- * The public surface speaks the v4 Address vocabulary and reports failures through the unified Error/ErrorCode channel
- * (the former IdentifyError / HealError enumerators now live in the ErrorCategory::Rtti block). Address <-> integer
+ * The public surface uses Address and reports failures through the ErrorCategory::Rtti block. Address <-> integer
  * punning is confined to the raw-slot arithmetic below.
  */
 
@@ -94,7 +93,7 @@ namespace DetourModKit
                                              const rtti::PointeeType &pt) noexcept
         {
             rtti::HealHit h;
-            h.healed_offset = static_cast<std::ptrdiff_t>(slot_addr - base);
+            h.healed_offset = rtti::detail::address_offset(slot_addr, base);
             h.slot_addr = Address{slot_addr};
             h.object_addr = pt.object_base;
             h.vtable = pt.vtable;
@@ -224,9 +223,9 @@ namespace DetourModKit
 
         // Resolve the candidate vtable's owning-module span once and reuse it across both shape attempts when the
         // second candidate lives in the same module. resolve_col_site's single-argument overload calls
-        // memory::module_of (a GetModuleHandleExW loader-lock acquisition) on every call, so the two-attempt probe
-        // below would otherwise take the loader lock up to twice per slot. The common direct-object case -- an object's
-        // vtable and its first virtual function both live in the class-defining module -- then costs a single
+        // the live-module resolver (a GetModuleHandleExW loader-lock acquisition) on every call, so the two-attempt
+        // probe below would otherwise take the loader lock up to twice per slot. The common direct-object case -- an
+        // object's vtable and its first virtual function both live in the class-defining module -- then costs a single
         // acquisition. A genuinely cross-module second candidate (identify_pointee resolves an object whose vtable
         // lives in a different DLL than the struct) still falls back to a fresh module_of, so the cross-DLL capability
         // is preserved rather than regressed.
@@ -239,7 +238,7 @@ namespace DetourModKit
         const auto vt2_opt = DetourModKit::detail::guarded_read<std::uintptr_t>(slot_val);
         if (vt2_opt && *vt2_opt >= detail::MIN_VALID_PTR)
         {
-            first_span = DetourModKit::detail::module_span(memory::module_of(Address{*vt2_opt}));
+            first_span = DetourModKit::detail::module_span(DetourModKit::detail::live_module_region(Address{*vt2_opt}));
             first_span_resolved = true;
             if (detail::resolve_col_site(*vt2_opt, first_span, site))
             {
@@ -482,8 +481,9 @@ namespace DetourModKit
                 entry.ok = true;
                 entry.healed_offset = heal->healed_offset;
                 // delta is the realised layout shift: 0 when the field did not move, signed when it did. It is the
-                // headline number a changelog wants, derived purely from the existing heal result.
-                entry.delta = heal->healed_offset - landmark.nominal_offset;
+                // reported layout shift, derived purely from the existing heal result. Saturation preserves the
+                // direction of a difference that does not fit in ptrdiff_t.
+                entry.delta = rtti::detail::saturating_sub(heal->healed_offset, landmark.nominal_offset);
             }
             else
             {
@@ -515,14 +515,16 @@ namespace DetourModKit
         // `groups` after the scan loop, so add_group can never reallocate `groups` while tick's range-for holds a
         // reference into it.
         std::vector<Group> pending;
-        bool ticking = false;
+        // Re-entrancy depth of tick(): 0 outside a scan and 1 while one is in flight. A rejected nested tick never
+        // changes the outer scan's in-flight state.
+        unsigned tick_depth = 0;
     };
 
     Result<rtti::HealScheduler> rtti::HealScheduler::start(HealConfig config) noexcept
     {
         // A zero interval would divide-by-nothing the retry budget (every tick is a scan), which is a caller mistake,
         // not a valid cadence; reject it up front rather than silently reinterpret it.
-        if (config.interval_frames == 0)
+        if (config.interval_frames == 0 || config.drift_warn_threshold < 0)
             return std::unexpected(Error{ErrorCode::InvalidArg, "rtti::HealScheduler::start"});
         try
         {
@@ -552,7 +554,7 @@ namespace DetourModKit
         // Defer a group added from within a running tick (a work/gate callback re-entering add_group) so tick's
         // range-for reference into `groups` is never invalidated by a reallocation mid-iteration; it starts scanning on
         // the next tick.
-        std::vector<Impl::Group> &target = m_impl->ticking ? m_impl->pending : m_impl->groups;
+        std::vector<Impl::Group> &target = m_impl->tick_depth != 0 ? m_impl->pending : m_impl->groups;
         target.push_back(Impl::Group{std::move(work), std::move(gate), false, 0});
     }
 
@@ -560,9 +562,14 @@ namespace DetourModKit
     {
         if (!m_impl)
             return;
-        // Mark the scan in flight so a re-entrant add_group (from a work/gate callback) defers into `pending` rather
-        // than mutating `groups` under the range-for below.
-        m_impl->ticking = true;
+        // Reject a re-entrant tick (a work or gate callback calling tick() again on this scheduler). Running the inner
+        // scan would clear the in-flight state on return, after which the outer scan's range-for still holds a
+        // reference into `groups` and a subsequent add_group would push directly into `groups`, reallocating it
+        // mid-iteration. A nested tick is a no-op; the groups it would have scanned run on the next outer tick. Because
+        // the reject returns before the depth is bumped, it cannot clear the outer scan's in-flight marker.
+        if (m_impl->tick_depth != 0)
+            return;
+        ++m_impl->tick_depth;
         for (Impl::Group &group : m_impl->groups)
         {
             if (group.latched)
@@ -611,10 +618,11 @@ namespace DetourModKit
                 group.latched = true;
         }
 
-        // The scan loop is done; adopt any groups a callback deferred while ticking. insert() reserves once up front
-        // (so on OOM it throws before moving any element, leaving `pending` intact to retry next tick) and then
-        // move-constructs each element (a std::move_only_function move is noexcept), keeping tick() noexcept.
-        m_impl->ticking = false;
+        // The scan loop is done; drop the in-flight depth, then adopt any groups a callback deferred while ticking.
+        // insert() reserves once up front (so on OOM it throws before moving any element, leaving `pending` intact to
+        // retry next tick) and then move-constructs each element (a std::move_only_function move is noexcept), keeping
+        // tick() noexcept.
+        --m_impl->tick_depth;
         if (!m_impl->pending.empty())
         {
             try
@@ -657,8 +665,11 @@ namespace DetourModKit
 
     void rtti::HealRun::warn_drift_once(std::string_view label, std::ptrdiff_t delta) noexcept
     {
-        const std::ptrdiff_t magnitude = (delta < 0) ? -delta : delta;
-        if (magnitude <= m_config.drift_warn_threshold)
+        // Compare magnitudes in the unsigned domain: the naive (delta < 0) ? -delta : delta is undefined at
+        // PTRDIFF_MIN, whose negation is not representable. A drift delta can reach that bound for a caller-supplied
+        // nominal, so route both operands through the PTRDIFF_MIN-safe magnitude helper.
+        const std::uint64_t magnitude = rtti::detail::ptrdiff_magnitude(delta);
+        if (magnitude <= rtti::detail::ptrdiff_magnitude(m_config.drift_warn_threshold))
             return;
         // CAS one-shot: the first drift to clear the latch emits the single actionable Warning. The recovered POINTER
         // offsets self-healed, but the non-healable scalar/flag offsets in the same structs silently rode the same
@@ -683,7 +694,7 @@ namespace DetourModKit
         if (result)
         {
             slot.store(result->healed_offset, std::memory_order_relaxed);
-            const std::ptrdiff_t delta = result->healed_offset - landmark.nominal_offset;
+            const std::ptrdiff_t delta = rtti::detail::saturating_sub(result->healed_offset, landmark.nominal_offset);
             if (delta != 0)
             {
                 warn_drift_once(label, delta);
@@ -717,10 +728,132 @@ namespace DetourModKit
         return result;
     }
 
+    void rtti::HealedSlot::seed_nominal(std::ptrdiff_t nominal) noexcept
+    {
+        // A nominal that has never been confirmed: carry it with generation 0 and Unverified, so a consumer reading the
+        // slot before the first heal gets an explicit best-guess status rather than a Confirmed value it could trust.
+        publish(nominal, 0, OffsetValidity::Unverified);
+    }
+
+    void rtti::HealedSlot::publish(std::ptrdiff_t value, std::uint64_t generation, OffsetValidity validity) noexcept
+    {
+        if (validity == OffsetValidity::Confirmed)
+        {
+            if (generation == 0)
+                validity = OffsetValidity::Invalid;
+        }
+        else
+        {
+            generation = 0;
+        }
+
+        // Single-producer seqlock write: bump the sequence to odd (write in progress), store the payload, bump to even
+        // (stable). The release fences pair with the consumer's acquire fence in load() so a reader either sees the
+        // whole new snapshot or retries -- never a torn mix of an old and a new field.
+        const std::uint32_t seq = m_seq.load(std::memory_order_relaxed);
+        m_seq.store(seq + 1, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_release);
+        m_value.store(value, std::memory_order_relaxed);
+        m_generation.store(generation, std::memory_order_relaxed);
+        m_validity.store(static_cast<std::uint8_t>(validity), std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_release);
+        m_seq.store(seq + 2, std::memory_order_relaxed);
+    }
+
+    rtti::HealedOffset rtti::HealedSlot::load() const noexcept
+    {
+        constexpr std::size_t MAX_ATTEMPTS = 16;
+        for (std::size_t attempt = 0; attempt < MAX_ATTEMPTS; ++attempt)
+        {
+            const std::uint32_t seq1 = m_seq.load(std::memory_order_acquire);
+            if ((seq1 & 1U) != 0U)
+                continue; // A publish is in progress; retry once it completes (single producer, so this is brief).
+            const std::ptrdiff_t value = m_value.load(std::memory_order_relaxed);
+            const std::uint64_t generation = m_generation.load(std::memory_order_relaxed);
+            const std::uint8_t validity = m_validity.load(std::memory_order_relaxed);
+            std::atomic_thread_fence(std::memory_order_acquire);
+            if (m_seq.load(std::memory_order_relaxed) == seq1)
+                return HealedOffset{value, generation, static_cast<OffsetValidity>(validity)};
+        }
+        return {};
+    }
+
+    Result<std::ptrdiff_t> rtti::HealedSlot::authorized() const noexcept
+    {
+        const HealedOffset snap = load();
+        if (snap.validity != OffsetValidity::Confirmed || snap.generation == 0)
+            return std::unexpected(Error{ErrorCode::OffsetNotConfirmed, "rtti::HealedSlot::authorized"});
+        return snap.value;
+    }
+
+    Result<std::ptrdiff_t> rtti::HealedSlot::authorized(std::uint64_t current_generation) const noexcept
+    {
+        const HealedOffset snap = load();
+        if (snap.validity != OffsetValidity::Confirmed || snap.generation == 0 || current_generation == 0 ||
+            snap.generation != current_generation)
+            return std::unexpected(
+                Error{ErrorCode::OffsetNotConfirmed, "rtti::HealedSlot::authorized", snap.generation});
+        return snap.value;
+    }
+
+    Result<rtti::HealHit> rtti::HealRun::heal_into(std::string_view label, const Landmark &landmark, Address base,
+                                                   HealedSlot &slot, bool required) noexcept
+    {
+        Result<HealHit> result = heal_from(landmark, base);
+        Logger &logger = log();
+        if (result)
+        {
+            // The vtable, unlike the live struct buffer, identifies the image whose RTTI established this layout.
+            const std::uint64_t generation = rtti::image_generation(result->vtable);
+            if (generation != 0)
+            {
+                slot.publish(result->healed_offset, generation, OffsetValidity::Confirmed);
+                const std::ptrdiff_t delta =
+                    rtti::detail::saturating_sub(result->healed_offset, landmark.nominal_offset);
+                if (delta != 0)
+                {
+                    warn_drift_once(label, delta);
+                    (void)logger.try_log(LogLevel::Info, "Self-heal: {} moved {:+#x} ({:#x} -> {:#x})", label, delta,
+                                         landmark.nominal_offset, result->healed_offset);
+                }
+                else
+                {
+                    (void)logger.try_log(LogLevel::Debug, "Self-heal: {} confirmed at nominal {:#x}", label,
+                                         landmark.nominal_offset);
+                }
+                return result;
+            }
+            result =
+                std::unexpected(Error{ErrorCode::OffsetNotConfirmed, "rtti::HealRun::heal_into", result->vtable.raw()});
+        }
+
+        // Miss: keep the retained value (whatever nominal the slot was seeded with) but publish the validity a
+        // slot-only consumer needs -- Invalid for a required field (do not consume) or Unverified for an optional one
+        // (best-guess only). A raw atomic slot leaves the dangerous nominal with no in-band signal that the required
+        // heal failed; this channel carries one, so a consumer reading only the slot can still fail closed.
+        const HealedOffset retained = slot.load();
+        slot.publish(retained.value, 0, required ? OffsetValidity::Invalid : OffsetValidity::Unverified);
+
+        const std::string_view reason = to_string(result.error().code);
+        if (required && m_config.escalate == HealEscalation::WarnRequired)
+        {
+            (void)logger.try_log(LogLevel::Warning,
+                                 "Self-heal: {} unresolved ({}); kept nominal {:#x} (re-author "
+                                 "if drifted)",
+                                 label, reason, landmark.nominal_offset);
+        }
+        else
+        {
+            (void)logger.try_log(LogLevel::Debug, "Self-heal: {} not resolvable now ({}); keeping nominal {:#x}", label,
+                                 reason, landmark.nominal_offset);
+        }
+        return result;
+    }
+
     void rtti::HealRun::note_drift(std::string_view label, std::ptrdiff_t nominal_offset,
                                    std::ptrdiff_t healed_offset) noexcept
     {
-        const std::ptrdiff_t delta = healed_offset - nominal_offset;
+        const std::ptrdiff_t delta = rtti::detail::saturating_sub(healed_offset, nominal_offset);
         Logger &logger = log();
         if (delta != 0)
         {

--- a/tests/package_smoke/main.cpp
+++ b/tests/package_smoke/main.cpp
@@ -45,5 +45,17 @@ int main()
     {
         return 5;
     }
+
+    // Compile and link the concrete RTTI cache layouts through the installed headers and static archive.
+    DetourModKit::rtti::PointerTableCache pointer_table_cache;
+    pointer_table_cache.reset();
+    DetourModKit::rtti::TypeIdentity identity{".?AVPackageSmoke@@", DetourModKit::Region{}};
+    identity.invalidate();
+    DetourModKit::rtti::HealedSlot healed_offset;
+    healed_offset.seed_nominal(0);
+    if (healed_offset.load().validity != DetourModKit::rtti::OffsetValidity::Unverified)
+    {
+        return 6;
+    }
     return 0;
 }

--- a/tests/test_heal_scheduler.cpp
+++ b/tests/test_heal_scheduler.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -23,6 +24,13 @@ namespace rtti = DetourModKit::rtti;
 using DetourModKit::Address;
 using DetourModKit::ErrorCode;
 
+namespace DetourModKit::detail
+{
+#if defined(DMK_ENABLE_TEST_SEAMS)
+    extern std::uint64_t (*g_rtti_image_generation_override)(std::uintptr_t address) noexcept;
+#endif
+} // namespace DetourModKit::detail
+
 // These cases pin the HealScheduler's render-loop discipline, frame for frame: a fixed retry interval (NOT a geometric
 // backoff), a per-group latch that stops scanning once a group resolves (with no attempt cap while it has not), a
 // silent pre-gate that polls a not-yet-live target without spending the retry budget, and a fail-closed heal that keeps
@@ -36,6 +44,13 @@ TEST(HealSchedulerTest, StartRejectsZeroInterval)
     const auto sched = rtti::HealScheduler::start(rtti::HealConfig{.interval_frames = 0});
     ASSERT_FALSE(sched.has_value());
     EXPECT_EQ(sched.error().code, ErrorCode::InvalidArg);
+}
+
+TEST(HealSchedulerTest, StartRejectsNegativeDriftThreshold)
+{
+    const auto scheduler = rtti::HealScheduler::start(rtti::HealConfig{.drift_warn_threshold = -1});
+    ASSERT_FALSE(scheduler.has_value());
+    EXPECT_EQ(scheduler.error().code, ErrorCode::InvalidArg);
 }
 
 TEST(HealSchedulerTest, ScansOnFixedCadenceNotEveryFrame)
@@ -290,6 +305,28 @@ namespace
     alignas(8) std::array<std::byte, SYN_POOL_SIZE> s_syn_pool{};
     std::size_t s_syn_offset = 0;
 
+#if defined(DMK_ENABLE_TEST_SEAMS)
+    std::atomic<std::uint64_t> s_heal_image_generation{0};
+
+    std::uint64_t heal_image_generation(std::uintptr_t) noexcept
+    {
+        return s_heal_image_generation.load(std::memory_order_relaxed);
+    }
+
+    class ScopedHealImageGeneration
+    {
+    public:
+        explicit ScopedHealImageGeneration(std::uint64_t generation) noexcept
+        {
+            s_heal_image_generation.store(generation, std::memory_order_relaxed);
+            DetourModKit::detail::g_rtti_image_generation_override = &heal_image_generation;
+        }
+        ~ScopedHealImageGeneration() noexcept { DetourModKit::detail::g_rtti_image_generation_override = nullptr; }
+        ScopedHealImageGeneration(const ScopedHealImageGeneration &) = delete;
+        ScopedHealImageGeneration &operator=(const ScopedHealImageGeneration &) = delete;
+    };
+#endif
+
     [[nodiscard]] std::byte *syn_alloc() noexcept
     {
         if (s_syn_offset + SYN_BUF_SIZE > s_syn_pool.size())
@@ -506,4 +543,248 @@ TEST_F(HealSchedulerHealTest, HealIntoKeepsNominalOnMissThenHealsWhenTargetAppea
     }
     EXPECT_TRUE(sched.all_resolved());
     EXPECT_EQ(slot.load(), nominal);
+}
+
+// The validity-bearing HealedSlot channel. A required miss must leave the slot Invalid so a slot-only consumer fails
+// closed on the retained (readable, dangerous) nominal; an optional miss is Unverified; a resolve is Confirmed and
+// authorizes.
+
+TEST_F(HealSchedulerHealTest, RequiredMissPublishesInvalidGeneration)
+{
+    // Seed the slot's nominal to point at a readable but WRONG-typed object (dangerous: a
+    // slot-only consumer would happily dereference it), then heal a REQUIRED landmark for a type absent from the
+    // window. The slot must publish Invalid, and every DMK-provided checked accessor must reject it -- a null-only
+    // fixture would not prove this, since a dangerous readable value survives.
+    SyntheticVtable decoy(".?AVHealDecoyType@@");
+    SynStruct st;
+    constexpr std::ptrdiff_t nominal = 0x80;
+    st.put(static_cast<std::size_t>(nominal), heap_object(decoy.vtable())); // readable + resolvable, but wrong type
+
+    const rtti::Landmark lm{.nominal_offset = nominal,
+                            .window = 0x8,                              // tight: no matching type nearby
+                            .expected_mangled = ".?AVHealWantedType@@", // absent -> required miss
+                            .indirection = rtti::Indirection::PointerToObject};
+
+    rtti::HealedSlot slot;
+    slot.seed_nominal(nominal);
+    ASSERT_EQ(slot.load().validity, rtti::OffsetValidity::Unverified); // a seeded nominal starts Unverified
+    ASSERT_FALSE(slot.authorized().has_value());                       // and is not authorized
+
+    auto started =
+        rtti::HealScheduler::start(rtti::HealConfig{.interval_frames = 1, .escalate = rtti::HealEscalation::Quiet});
+    ASSERT_TRUE(started.has_value());
+    rtti::HealScheduler &sched = *started;
+    bool healed = true;
+    sched.add_group(
+        [&](rtti::HealRun &run) noexcept
+        {
+            healed = run.heal_into("wanted", lm, Address{st.base()}, slot, /*required=*/true).has_value();
+            return true;
+        });
+    sched.tick();
+
+    EXPECT_FALSE(healed) << "the required heal must miss";
+    const rtti::HealedOffset snap = slot.load();
+    EXPECT_EQ(snap.validity, rtti::OffsetValidity::Invalid) << "a required miss publishes Invalid";
+    EXPECT_EQ(snap.value, nominal) << "the dangerous nominal is retained (fail closed) but marked unsafe";
+    EXPECT_EQ(snap.generation, 0u);
+    EXPECT_FALSE(snap.usable());
+
+    const auto authorized = slot.authorized();
+    ASSERT_FALSE(authorized.has_value());
+    EXPECT_EQ(authorized.error().code, DetourModKit::ErrorCode::OffsetNotConfirmed);
+}
+
+TEST_F(HealSchedulerHealTest, OptionalMissPublishesUnverified)
+{
+    // An OPTIONAL heal that misses publishes Unverified (a best-guess), not Invalid; authorized() still rejects it
+    // (only Confirmed authorizes a mutation), but load() reports Unverified so a caller may use it as a hint.
+    SynStruct st; // empty: the target is absent
+    constexpr std::ptrdiff_t nominal = 0x40;
+
+    const rtti::Landmark lm{.nominal_offset = nominal,
+                            .window = 0x8,
+                            .expected_mangled = ".?AVHealOptionalAbsent@@",
+                            .indirection = rtti::Indirection::PointerToObject};
+    rtti::HealedSlot slot;
+    slot.seed_nominal(nominal);
+
+    auto started =
+        rtti::HealScheduler::start(rtti::HealConfig{.interval_frames = 1, .escalate = rtti::HealEscalation::Quiet});
+    ASSERT_TRUE(started.has_value());
+    rtti::HealScheduler &sched = *started;
+    sched.add_group(
+        [&](rtti::HealRun &run) noexcept
+        {
+            (void)run.heal_into("optional", lm, Address{st.base()}, slot, /*required=*/false);
+            return true;
+        });
+    sched.tick();
+
+    const rtti::HealedOffset snap = slot.load();
+    EXPECT_EQ(snap.validity, rtti::OffsetValidity::Unverified);
+    EXPECT_EQ(snap.value, nominal);
+    EXPECT_EQ(snap.generation, 0u);
+    EXPECT_FALSE(snap.usable());
+    EXPECT_FALSE(slot.authorized().has_value()); // Unverified is not Confirmed
+}
+
+TEST_F(HealSchedulerHealTest, HealedSlotResolvePublishesConfirmedAndAuthorizes)
+{
+    // A resolve publishes Confirmed; both checked accessors then return the value, and the generation-checked overload
+    // rejects a stale generation (a same-base remap since the heal).
+    SyntheticVtable t(".?AVHealConfirmed@@");
+    SynStruct st;
+    constexpr std::ptrdiff_t nominal = 0x80;
+    st.put(static_cast<std::size_t>(nominal), heap_object(t.vtable()));
+
+    const rtti::Landmark lm{.nominal_offset = nominal,
+                            .expected_mangled = ".?AVHealConfirmed@@",
+                            .indirection = rtti::Indirection::PointerToObject};
+    rtti::HealedSlot slot;
+    slot.seed_nominal(nominal);
+
+    auto started = rtti::HealScheduler::start(rtti::HealConfig{.interval_frames = 1});
+    ASSERT_TRUE(started.has_value());
+    rtti::HealScheduler &sched = *started;
+    sched.add_group(
+        [&](rtti::HealRun &run) noexcept
+        { return run.heal_into("confirmed", lm, Address{st.base()}, slot, /*required=*/true).has_value(); });
+    sched.tick();
+    EXPECT_TRUE(sched.all_resolved());
+
+    const rtti::HealedOffset snap = slot.load();
+    EXPECT_EQ(snap.validity, rtti::OffsetValidity::Confirmed);
+    EXPECT_TRUE(snap.usable());
+    EXPECT_EQ(snap.value, nominal);
+    const std::uint64_t expected_generation = rtti::image_generation(Address{t.vtable()});
+    ASSERT_NE(expected_generation, 0u);
+    EXPECT_EQ(snap.generation, expected_generation);
+
+    const auto authorized = slot.authorized();
+    ASSERT_TRUE(authorized.has_value());
+    EXPECT_EQ(*authorized, nominal);
+
+    EXPECT_TRUE(slot.authorized(snap.generation).has_value());
+    EXPECT_FALSE(slot.authorized(0).has_value());
+    const std::uint64_t stale_generation = snap.generation == UINT64_MAX ? snap.generation - 1 : snap.generation + 1;
+    const auto stale = slot.authorized(stale_generation);
+    ASSERT_FALSE(stale.has_value());
+    EXPECT_EQ(stale.error().code, DetourModKit::ErrorCode::OffsetNotConfirmed);
+}
+
+#if defined(DMK_ENABLE_TEST_SEAMS)
+TEST_F(HealSchedulerHealTest, MissingImageGenerationDoesNotLatchConfirmedHeal)
+{
+    ScopedHealImageGeneration generation(0);
+    SyntheticVtable target(".?AVHealNoGeneration@@");
+    SynStruct structure;
+    constexpr std::ptrdiff_t nominal = 0x80;
+    structure.put(static_cast<std::size_t>(nominal), heap_object(target.vtable()));
+    const rtti::Landmark landmark{.nominal_offset = nominal,
+                                  .expected_mangled = ".?AVHealNoGeneration@@",
+                                  .indirection = rtti::Indirection::PointerToObject};
+    rtti::HealedSlot slot;
+    slot.seed_nominal(nominal);
+
+    auto started = rtti::HealScheduler::start(rtti::HealConfig{.interval_frames = 1});
+    ASSERT_TRUE(started.has_value());
+    rtti::HealScheduler &scheduler = *started;
+    scheduler.add_group(
+        [&](rtti::HealRun &run) noexcept
+        { return run.heal_into("no-generation", landmark, Address{structure.base()}, slot).has_value(); });
+    scheduler.tick();
+
+    EXPECT_FALSE(scheduler.all_resolved());
+    EXPECT_EQ(slot.load().validity, rtti::OffsetValidity::Invalid);
+    EXPECT_FALSE(slot.authorized().has_value());
+}
+#endif
+
+TEST(HealSchedulerTest, RecursiveTickIsRejectedAndDoesNotInvalidateIteration)
+{
+    // A recursive tick is rejected, leaving the outer in-flight state active so additions remain deferred.
+    auto started = rtti::HealScheduler::start(rtti::HealConfig{.interval_frames = 1});
+    ASSERT_TRUE(started.has_value());
+    rtti::HealScheduler &sched = *started;
+
+    std::atomic<int> deferred_ran{0};
+    for (int i = 0; i < 4; ++i)
+    {
+        sched.add_group(
+            [&](rtti::HealRun &) noexcept
+            {
+                sched.tick(); // nested tick: must be rejected, must not clear the outer in-flight state
+                // Add many groups: were this to push into `groups` rather than `pending`, the reallocation would
+                // invalidate the outer range-for and crash.
+                for (int k = 0; k < 32; ++k)
+                {
+                    sched.add_group(
+                        [&](rtti::HealRun &) noexcept
+                        {
+                            deferred_ran.fetch_add(1, std::memory_order_relaxed);
+                            return true;
+                        });
+                }
+                return true; // latch
+            });
+    }
+
+    sched.tick(); // outer scan must complete without UB
+    sched.tick(); // the deferred groups run now
+    EXPECT_GT(deferred_ran.load(), 0);
+}
+
+TEST(HealedSlotTest, ConcurrentLoadsObserveCoherentSnapshots)
+{
+    rtti::HealedSlot slot;
+    slot.publish(17, 101, rtti::OffsetValidity::Confirmed);
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> done{false};
+    std::atomic<std::uint32_t> incoherent{0};
+    std::thread writer(
+        [&]() noexcept
+        {
+            while (!start.load(std::memory_order_acquire))
+            {
+            }
+            for (std::size_t i = 0; i < 20'000; ++i)
+            {
+                if ((i & 1U) == 0)
+                    slot.publish(17, 101, rtti::OffsetValidity::Confirmed);
+                else
+                    slot.publish(-29, 202, rtti::OffsetValidity::Invalid);
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+    start.store(true, std::memory_order_release);
+    do
+    {
+        const rtti::HealedOffset snapshot = slot.load();
+        const bool first =
+            snapshot.value == 17 && snapshot.generation == 101 && snapshot.validity == rtti::OffsetValidity::Confirmed;
+        const bool second =
+            snapshot.value == -29 && snapshot.generation == 0 && snapshot.validity == rtti::OffsetValidity::Invalid;
+        const bool contention_fallback =
+            snapshot.value == 0 && snapshot.generation == 0 && snapshot.validity == rtti::OffsetValidity::Invalid;
+        if (!first && !second && !contention_fallback)
+            incoherent.fetch_add(1, std::memory_order_relaxed);
+    } while (!done.load(std::memory_order_acquire));
+
+    writer.join();
+    EXPECT_EQ(incoherent.load(std::memory_order_relaxed), 0u);
+}
+
+TEST(HealedSlotTest, ConfirmedWithoutGenerationFailsClosed)
+{
+    rtti::HealedSlot slot;
+    slot.publish(42, 0, rtti::OffsetValidity::Confirmed);
+    const rtti::HealedOffset snapshot = slot.load();
+    EXPECT_EQ(snapshot.validity, rtti::OffsetValidity::Invalid);
+    EXPECT_EQ(snapshot.generation, 0u);
+    EXPECT_FALSE(snapshot.usable());
+    EXPECT_FALSE(slot.authorized().has_value());
+    EXPECT_FALSE(slot.authorized(0).has_value());
 }

--- a/tests/test_rtti.cpp
+++ b/tests/test_rtti.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cstddef>
@@ -18,6 +19,13 @@
 namespace memory = DetourModKit::memory;
 namespace rtti = DetourModKit::rtti;
 using DetourModKit::Address;
+
+namespace DetourModKit::detail
+{
+#if defined(DMK_ENABLE_TEST_SEAMS)
+    extern std::uint64_t (*g_rtti_image_generation_override)(std::uintptr_t address) noexcept;
+#endif
+} // namespace DetourModKit::detail
 
 namespace
 {
@@ -126,6 +134,20 @@ namespace
         /// Overwrites COL.p_self with @p rva for poisoned-input tests.
         void poison_self_rva(std::uint32_t rva) noexcept { write_at(SYN_COL_OFFSET + 20, rva); }
 
+        /// Replaces the name prefix with nonzero bytes and omits a terminator for the requested span.
+        void make_name_non_terminated(std::size_t span) noexcept
+        {
+            const std::size_t capacity = SYN_COL_PTR_OFFSET - SYN_TD_NAME_OFFSET;
+            std::memset(m_buf + SYN_TD_NAME_OFFSET, 'X', std::min(span, capacity));
+        }
+
+        void overwrite_name(std::string_view name) noexcept
+        {
+            const std::size_t capacity = SYN_COL_PTR_OFFSET - SYN_TD_NAME_OFFSET;
+            std::memset(m_buf + SYN_TD_NAME_OFFSET, 0, capacity);
+            std::memcpy(m_buf + SYN_TD_NAME_OFFSET, name.data(), std::min(name.size(), capacity - 1));
+        }
+
     private:
         template <typename T> void write_at(std::size_t offset, const T &value) noexcept
         {
@@ -155,6 +177,32 @@ namespace
     private:
         std::uintptr_t m_vtable;
     };
+
+#if defined(DMK_ENABLE_TEST_SEAMS)
+    std::atomic<std::uint64_t> s_pointer_image_generation{0};
+
+    std::uint64_t pointer_image_generation(std::uintptr_t) noexcept
+    {
+        return s_pointer_image_generation.load(std::memory_order_relaxed);
+    }
+
+    class ScopedPointerImageGeneration
+    {
+    public:
+        explicit ScopedPointerImageGeneration(std::uint64_t generation) noexcept
+        {
+            set(generation);
+            DetourModKit::detail::g_rtti_image_generation_override = &pointer_image_generation;
+        }
+        ~ScopedPointerImageGeneration() noexcept { DetourModKit::detail::g_rtti_image_generation_override = nullptr; }
+        void set(std::uint64_t generation) noexcept
+        {
+            s_pointer_image_generation.store(generation, std::memory_order_relaxed);
+        }
+        ScopedPointerImageGeneration(const ScopedPointerImageGeneration &) = delete;
+        ScopedPointerImageGeneration &operator=(const ScopedPointerImageGeneration &) = delete;
+    };
+#endif
 } // anonymous namespace
 
 class RttiTest : public ::testing::Test
@@ -446,20 +494,55 @@ TEST_F(RttiTest, FindInTable_WarmCacheSkipsRttiWalk)
     EXPECT_EQ(hit->raw(), obj_target.address());
 }
 
-TEST_F(RttiTest, FindInTable_WarmCacheRejectsForeignVtables)
+TEST_F(RttiTest, FindInTable_StaleWarmCacheFallsBackAndRefreshes)
 {
-    SyntheticVtable wrong(".?AVWrong@@");
-    SyntheticObject obj(wrong.vtable());
+    SyntheticVtable target(".?AVRefreshed@@");
+    SyntheticObject obj(target.vtable());
 
     std::array<std::uintptr_t, 1> table{obj.address()};
 
-    // Cache points at an entirely unrelated vtable address. The single slot does not match the cached vtable, so the
-    // warm path returns nullopt without ever invoking the RTTI walker.
     std::atomic<Address> cache{Address{0xDEADBEEFCAFEULL}};
     auto hit = rtti::find_in_pointer_table(Address{reinterpret_cast<std::uintptr_t>(table.data())}, table.size(),
-                                           ".?AVWrong@@", &cache);
-    EXPECT_FALSE(hit.has_value());
+                                           ".?AVRefreshed@@", &cache);
+    ASSERT_TRUE(hit.has_value());
+    EXPECT_EQ(hit->raw(), obj.address());
+    EXPECT_EQ(cache.load(std::memory_order_relaxed).raw(), target.vtable());
 }
+
+#if defined(DMK_ENABLE_TEST_SEAMS)
+TEST_F(RttiTest, FindInTable_GenerationCacheRejectsSameAddressReplacement)
+{
+    ScopedPointerImageGeneration generation(101);
+    SyntheticVtable original(".?AVOriginal@@");
+    SyntheticObject first_object(original.vtable());
+    std::array<std::uintptr_t, 1> table{first_object.address()};
+    rtti::PointerTableCache cache;
+
+    ASSERT_TRUE(rtti::find_in_pointer_table(Address{reinterpret_cast<std::uintptr_t>(table.data())}, table.size(),
+                                            ".?AVOriginal@@", cache)
+                    .has_value());
+
+    original.overwrite_name(".?AVReplacement@@");
+    generation.set(202);
+    EXPECT_FALSE(rtti::find_in_pointer_table(Address{reinterpret_cast<std::uintptr_t>(table.data())}, table.size(),
+                                             ".?AVOriginal@@", cache)
+                     .has_value());
+
+    SyntheticVtable current(".?AVOriginal@@");
+    SyntheticObject current_object(current.vtable());
+    table[0] = current_object.address();
+    generation.set(303);
+    ASSERT_TRUE(rtti::find_in_pointer_table(Address{reinterpret_cast<std::uintptr_t>(table.data())}, table.size(),
+                                            ".?AVOriginal@@", cache)
+                    .has_value());
+
+    cache.reset();
+    current.overwrite_name(".?AVReplacement@@");
+    EXPECT_FALSE(rtti::find_in_pointer_table(Address{reinterpret_cast<std::uintptr_t>(table.data())}, table.size(),
+                                             ".?AVOriginal@@", cache)
+                     .has_value());
+}
+#endif
 
 TEST_F(RttiTest, FindInTable_NullTableRejected)
 {
@@ -571,4 +654,71 @@ TEST(RttiConstantsTest, Defaults)
 {
     static_assert(rtti::DEFAULT_TYPE_NAME_MAX > 0);
     static_assert(rtti::MAX_TYPE_NAME_LEN > rtti::DEFAULT_TYPE_NAME_MAX);
+}
+
+// type_name_checked -- distinguishes a complete name from a truncated prefix, which type_name_into cannot (it returns
+// the capacity in both cases, so a caller comparing for identity could match a proper prefix of a longer name against a
+// shorter expected name).
+
+TEST_F(RttiTest, TypeNameChecked_ReportsOkForCompleteName)
+{
+    SyntheticVtable v(".?AVChecked@@");
+    char out[64] = {};
+    const rtti::NameRead r = rtti::type_name_checked(Address{v.vtable()}, out, sizeof(out));
+    EXPECT_EQ(r.status, rtti::NameStatus::Ok);
+    EXPECT_EQ(r.written, std::strlen(".?AVChecked@@"));
+    EXPECT_STREQ(out, ".?AVChecked@@");
+}
+
+TEST_F(RttiTest, TypeNameChecked_ReportsTruncatedWhenBufferTooSmall)
+{
+    SyntheticVtable v(".?AVCheckedLongName@@");
+    char out[8] = {}; // capacity 7 chars + NUL, far shorter than the name
+    const rtti::NameRead r = rtti::type_name_checked(Address{v.vtable()}, out, sizeof(out));
+    EXPECT_EQ(r.status, rtti::NameStatus::Truncated) << "a name longer than the buffer must not read as Ok";
+    EXPECT_EQ(r.written, sizeof(out) - 1);
+    EXPECT_EQ(std::string_view(out, r.written), std::string_view(".?AVChe")); // a proper prefix
+    EXPECT_EQ(out[sizeof(out) - 1], '\0');                                    // still NUL-terminated
+}
+
+TEST_F(RttiTest, TypeNameChecked_OneByteBufferReportsTruncated)
+{
+    SyntheticVtable v(".?AVOneByte@@");
+    char out[1] = {'x'};
+    const rtti::NameRead result = rtti::type_name_checked(Address{v.vtable()}, out, sizeof(out));
+    EXPECT_EQ(result.status, rtti::NameStatus::Truncated);
+    EXPECT_EQ(result.written, 0u);
+    EXPECT_EQ(out[0], '\0');
+}
+
+TEST_F(RttiTest, TypeNameChecked_NonTerminatedNameAtHardCapReportsTruncated)
+{
+    SyntheticVtable v("placeholder");
+    v.make_name_non_terminated(rtti::MAX_TYPE_NAME_LEN + 1);
+    std::array<char, rtti::MAX_TYPE_NAME_LEN + 1> out{};
+    const rtti::NameRead result = rtti::type_name_checked(Address{v.vtable()}, out.data(), out.size());
+    EXPECT_EQ(result.status, rtti::NameStatus::Truncated);
+    EXPECT_EQ(result.written, rtti::MAX_TYPE_NAME_LEN);
+    EXPECT_EQ(out.back(), '\0');
+}
+
+TEST_F(RttiTest, TypeNameChecked_ExactFitReportsOk)
+{
+    // A name that exactly fills the buffer capacity (out_len - 1) is complete, not truncated: the byte after the copy
+    // is the terminator. type_name_into cannot tell this from a real truncation (both return the capacity); this must.
+    SyntheticVtable v("ABCDEFG"); // 7 characters
+    char out[8] = {};             // capacity exactly 7 + NUL
+    const rtti::NameRead r = rtti::type_name_checked(Address{v.vtable()}, out, sizeof(out));
+    EXPECT_EQ(r.status, rtti::NameStatus::Ok);
+    EXPECT_EQ(r.written, 7u);
+    EXPECT_STREQ(out, "ABCDEFG");
+}
+
+TEST_F(RttiTest, TypeNameChecked_ReportsFailedOnBadVtable)
+{
+    char out[64] = {'x'};
+    const rtti::NameRead r = rtti::type_name_checked(Address{0x100}, out, sizeof(out));
+    EXPECT_EQ(r.status, rtti::NameStatus::Failed);
+    EXPECT_EQ(r.written, 0u);
+    EXPECT_EQ(out[0], '\0'); // failure clears the buffer
 }

--- a/tests/test_rtti_dissect.cpp
+++ b/tests/test_rtti_dissect.cpp
@@ -20,6 +20,8 @@
 #include "DetourModKit/rtti.hpp"
 #include "DetourModKit/rtti_dissect.hpp"
 
+#include "internal/rtti_shared.hpp"
+
 #include "test_alloc_probe.hpp"
 
 namespace memory = DetourModKit::memory;
@@ -518,7 +520,7 @@ TEST_F(RttiDissectTest, IdentifyOr_AllFailResetsOutToDefault)
 
 TEST_F(RttiDissectTest, Identify_ErrorStringsAreDistinct)
 {
-    // The identify error codes now fold into DetourModKit::ErrorCode; to_string(ErrorCode) supplies the human-readable
+    // The identify error codes use DetourModKit::ErrorCode; to_string(ErrorCode) supplies the human-readable
     // rendering. Preserve the "distinct, non-empty strings" coverage over the three identify codes.
     const auto bad_slot = dmk::to_string(ErrorCode::BadSlotAddress);
     const auto unreadable = dmk::to_string(ErrorCode::UnreadableSlot);
@@ -1143,7 +1145,7 @@ TEST_F(RttiDissectTest, Heal_ZeroStrideTreatedAsPointerSize)
 
 TEST_F(RttiDissectTest, Heal_ErrorStringsAreDistinct)
 {
-    // The heal error codes now fold into DetourModKit::ErrorCode; to_string(ErrorCode) supplies the human-readable
+    // The heal error codes use DetourModKit::ErrorCode; to_string(ErrorCode) supplies the human-readable
     // rendering. Preserve the "distinct, non-empty strings" coverage over the three heal codes.
     const auto bad_descriptor = dmk::to_string(ErrorCode::BadDescriptor);
     const auto no_match = dmk::to_string(ErrorCode::HealNoMatch);
@@ -1472,4 +1474,54 @@ TEST_F(RttiDissectTest, HealReport_RespectsOutputCapacity)
     EXPECT_TRUE(report[0].ok);
     EXPECT_TRUE(report[1].ok);
     EXPECT_EQ(report[0].name, ".?AVCapReport@@");
+}
+
+// The signed offset/delta arithmetic the heal path uses must be defined for every value, including the PTRDIFF_MIN
+// negation (undefined for the naive (delta < 0) ? -delta : delta) and a subtraction whose true result leaves the
+// ptrdiff_t range. The helpers are consumed by warn_drift_once, heal_into, note_drift, and heal_report; proving them at
+// compile time is the strongest available guard on a platform with no UBSan.
+TEST(RttiSignedArith, PtrdiffMagnitudeIsDefinedAtExtremes)
+{
+    using rtti::detail::ptrdiff_magnitude;
+    static_assert(ptrdiff_magnitude(0) == 0U);
+    static_assert(ptrdiff_magnitude(1) == 1U);
+    static_assert(ptrdiff_magnitude(-1) == 1U);
+    static_assert(ptrdiff_magnitude(PTRDIFF_MAX) == static_cast<std::uint64_t>(PTRDIFF_MAX));
+    // PTRDIFF_MIN's magnitude is not representable in a ptrdiff_t (this is the -delta UB the helper replaces); as an
+    // unsigned value it is exactly 2^63.
+    static_assert(ptrdiff_magnitude(PTRDIFF_MIN) == (std::uint64_t{1} << 63));
+    EXPECT_EQ(ptrdiff_magnitude(PTRDIFF_MIN), std::uint64_t{1} << 63);
+    EXPECT_EQ(ptrdiff_magnitude(-1234), 1234U);
+}
+
+TEST(RttiSignedArith, SaturatingSubPreservesExtremeDriftSeverity)
+{
+    using rtti::detail::saturating_sub;
+    static_assert(saturating_sub(5, 3) == 2);
+    static_assert(saturating_sub(3, 5) == -2);
+    static_assert(saturating_sub(PTRDIFF_MAX, PTRDIFF_MIN) == PTRDIFF_MAX);
+    static_assert(saturating_sub(PTRDIFF_MIN, PTRDIFF_MAX) == PTRDIFF_MIN);
+    EXPECT_EQ(saturating_sub(PTRDIFF_MAX, PTRDIFF_MIN), PTRDIFF_MAX);
+    EXPECT_EQ(saturating_sub(PTRDIFF_MIN, PTRDIFF_MAX), PTRDIFF_MIN);
+}
+
+TEST(RttiSignedArith, AddressOffsetIsDefinedAtExtremes)
+{
+    using rtti::detail::address_offset;
+    static_assert(address_offset(100, 80) == 20);
+    static_assert(address_offset(80, 100) == -20);
+    static_assert(address_offset(UINTPTR_MAX, 0) == PTRDIFF_MAX);
+    static_assert(address_offset(0, UINTPTR_MAX) == PTRDIFF_MIN);
+}
+
+TEST(RttiSignedArith, ExtremeNominalOffsetsFailBeforeMemoryAccess)
+{
+    for (const std::ptrdiff_t offset : {PTRDIFF_MIN, PTRDIFF_MAX})
+    {
+        const rtti::Landmark landmark{
+            .base = Address{0x10000}, .nominal_offset = offset, .expected_mangled = ".?AVExtreme@@"};
+        const auto result = rtti::heal_landmark(landmark);
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error().code, DetourModKit::ErrorCode::BadDescriptor);
+    }
 }

--- a/tests/test_rtti_reverse.cpp
+++ b/tests/test_rtti_reverse.cpp
@@ -22,9 +22,11 @@ using DetourModKit::Region;
 
 namespace DetourModKit::detail
 {
-    // Defined in rtti.cpp. RttiClockScope installs this so the TypeIdentity unresolved re-sweep throttle can be driven
-    // deterministically (advance a counter) instead of sleeping on wall-clock time.
+#if defined(DMK_ENABLE_TEST_SEAMS)
     extern std::uint64_t (*g_rtti_resolve_clock_override)() noexcept;
+    extern std::uint64_t (*g_rtti_image_generation_override)(std::uintptr_t address) noexcept;
+    extern Region (*g_rtti_module_region_override)(Address address) noexcept;
+#endif
 } // namespace DetourModKit::detail
 
 namespace
@@ -129,14 +131,12 @@ namespace
         return Region{Address{buf_base}, REV_BUF_SIZE};
     }
 
-    // Controllable millisecond clock for the TypeIdentity re-sweep throttle. RttiClockScope points the rtti.cpp seam at
-    // fake_clock, so a test advances time by storing into g_fake_clock_ms rather than sleeping on the real clock. The
-    // seam function pointer cannot capture, hence the file-scope counter.
-    std::atomic<std::uint64_t> g_fake_clock_ms{0};
+#if defined(DMK_ENABLE_TEST_SEAMS)
+    std::atomic<std::uint64_t> s_fake_clock_ms{0};
 
     std::uint64_t fake_clock() noexcept
     {
-        return g_fake_clock_ms.load(std::memory_order_relaxed);
+        return s_fake_clock_ms.load(std::memory_order_relaxed);
     }
 
     struct RttiClockScope
@@ -146,6 +146,7 @@ namespace
         RttiClockScope(const RttiClockScope &) = delete;
         RttiClockScope &operator=(const RttiClockScope &) = delete;
     };
+#endif
 } // anonymous namespace
 
 class RttiReverseTest : public ::testing::Test
@@ -299,7 +300,7 @@ TEST_F(RttiReverseTest, TypeIdentityFailedResolveRetriesWhenTypeAppearsLater)
     // throttled, so advance the controllable clock past the cooldown before the retry: the retry capability is
     // preserved, it is just rate-limited rather than every-frame.
     RttiClockScope clock_scope;
-    g_fake_clock_ms.store(1000);
+    s_fake_clock_ms.store(1000);
 
     const std::uintptr_t pool_base = reinterpret_cast<std::uintptr_t>(s_rev_pool.data());
     const Region full_pool{Address{pool_base}, s_rev_pool.size()};
@@ -312,7 +313,7 @@ TEST_F(RttiReverseTest, TypeIdentityFailedResolveRetriesWhenTypeAppearsLater)
 
     // Advance well past any reasonable cooldown so the next call re-sweeps instead of skipping. A large jump keeps this
     // test independent of the exact internal cooldown constant.
-    g_fake_clock_ms.store(1000 + 1'000'000);
+    s_fake_clock_ms.store(1000 + 1'000'000);
 
     const auto resolved = id.vtable();
     ASSERT_TRUE(resolved.has_value());
@@ -330,7 +331,7 @@ TEST_F(RttiReverseTest, TypeIdentityUnresolvedReSweepThrottledWithinCooldown)
     // the throttle that call would resolve the now-present type. Advancing past the cooldown then resolves it,
     // confirming the retry capability survives the throttle.
     RttiClockScope clock_scope;
-    g_fake_clock_ms.store(5000);
+    s_fake_clock_ms.store(5000);
 
     const std::uintptr_t pool_base = reinterpret_cast<std::uintptr_t>(s_rev_pool.data());
     const Region full_pool{Address{pool_base}, s_rev_pool.size()};
@@ -345,7 +346,7 @@ TEST_F(RttiReverseTest, TypeIdentityUnresolvedReSweepThrottledWithinCooldown)
     EXPECT_FALSE(id.vtable().has_value());
 
     // Past the cooldown: the sweep runs again and finds it.
-    g_fake_clock_ms.store(5000 + 1'000'000);
+    s_fake_clock_ms.store(5000 + 1'000'000);
     const auto resolved = id.vtable();
     ASSERT_TRUE(resolved.has_value());
     EXPECT_EQ(resolved->raw(), vt);
@@ -385,7 +386,7 @@ TEST_F(RttiReverseTest, VtablesForTypeTruncatesButReportsFullCount)
 
 TEST_F(RttiReverseTest, TypeIdentityOwnsNameAcceptsAnyStringSource)
 {
-    // TypeIdentity now owns its name: the constructor takes a std::string_view and copies it into an internal
+    // TypeIdentity owns its name: the constructor takes a std::string_view and copies it into an internal
     // std::string, so nothing borrowed can dangle. Every string source is therefore safe to construct from -- a literal
     // (const char*), a std::string_view, a long-lived std::string lvalue, and even a std::string temporary (its
     // contents are copied before it dies).
@@ -482,3 +483,434 @@ TEST_F(RttiReverseTest, RegionHasRttiScansHostPeSections)
     EXPECT_FALSE(rtti::region_has_rtti(Region::host()));
 #endif
 }
+
+// A reverse-RTTI sweep that could not read every section header or every page must report the gap and must not
+// authorize a unique or absent verdict from the partial result. TypeIdentity keys its warm cache on the resolving
+// module's image generation and exposes invalidate() so a same-base remap drops a stale resolve.
+
+namespace
+{
+    constexpr std::size_t PAGE = 0x1000;
+
+    // Advances the pool cursor to the next page boundary so the following build_synth lands a whole 4 KiB record on one
+    // page, which a test can flip to PAGE_NOACCESS to hide the record from the sweep. Returns that page-aligned
+    // address.
+    [[nodiscard]] std::uintptr_t rev_page_align_cursor() noexcept
+    {
+        const std::uintptr_t base = reinterpret_cast<std::uintptr_t>(s_rev_pool.data());
+        const std::uintptr_t cur = base + s_rev_used;
+        const std::uintptr_t aligned = (cur + (PAGE - 1)) & ~static_cast<std::uintptr_t>(PAGE - 1);
+        s_rev_used = static_cast<std::size_t>(aligned - base);
+        return aligned;
+    }
+
+    // RAII: flips one already-committed, page-aligned address to PAGE_NOACCESS and restores its prior protection on
+    // scope exit. The reverse sweep's guarded read faults on it (contained on both toolchains) and reports Incomplete;
+    // restoring on exit keeps the shared static pool usable by the next test.
+    class ScopedNoAccess
+    {
+    public:
+        explicit ScopedNoAccess(std::uintptr_t page_addr) noexcept : m_addr(page_addr)
+        {
+            MEMORY_BASIC_INFORMATION mbi{};
+            if (VirtualQuery(reinterpret_cast<void *>(page_addr), &mbi, sizeof(mbi)) == sizeof(mbi))
+            {
+                m_prev = mbi.Protect;
+                m_ok = VirtualProtect(reinterpret_cast<void *>(page_addr), PAGE, PAGE_NOACCESS, &m_prev) != 0;
+            }
+        }
+        ~ScopedNoAccess() noexcept
+        {
+            if (m_ok)
+            {
+                DWORD ignored = 0;
+                (void)VirtualProtect(reinterpret_cast<void *>(m_addr), PAGE, m_prev, &ignored);
+            }
+        }
+        [[nodiscard]] bool ok() const noexcept { return m_ok; }
+        ScopedNoAccess(const ScopedNoAccess &) = delete;
+        ScopedNoAccess &operator=(const ScopedNoAccess &) = delete;
+
+    private:
+        std::uintptr_t m_addr;
+        DWORD m_prev = PAGE_READWRITE;
+        bool m_ok = false;
+    };
+
+    // A synthetic PE image (DOS + NT64 header + section table) in a VirtualAlloc'd region. It is NOT a loaded module,
+    // so no COL validates -- the point is that collect_rtti_scan_ranges parses the header/section table straight from
+    // the base, so a faulted section header (page 1 flipped NOACCESS) or a section count over the range cap sets the
+    // traversal completeness regardless of whether any record resolves.
+    class SynthPe
+    {
+    public:
+        explicit SynthPe(std::size_t pages) noexcept
+        {
+            m_size = pages * PAGE;
+            m_base = static_cast<std::byte *>(VirtualAlloc(nullptr, m_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
+            if (!m_base)
+                m_size = 0;
+        }
+        ~SynthPe() noexcept
+        {
+            if (m_base)
+            {
+                DWORD old = 0;
+                (void)VirtualProtect(m_base, m_size, PAGE_READWRITE, &old);
+                (void)VirtualFree(m_base, 0, MEM_RELEASE);
+            }
+        }
+        SynthPe(const SynthPe &) = delete;
+        SynthPe &operator=(const SynthPe &) = delete;
+
+        [[nodiscard]] bool ok() const noexcept { return m_base != nullptr; }
+        [[nodiscard]] std::uintptr_t base() const noexcept { return reinterpret_cast<std::uintptr_t>(m_base); }
+        [[nodiscard]] Region range() const noexcept { return Region{Address{base()}, m_size}; }
+
+        template <typename T> void put(std::size_t off, const T &value) noexcept
+        {
+            std::memcpy(m_base + off, &value, sizeof(T));
+        }
+
+        void protect_page(std::size_t page_index, DWORD prot) noexcept
+        {
+            DWORD old = 0;
+            (void)VirtualProtect(m_base + page_index * PAGE, PAGE, prot, &old);
+        }
+
+    private:
+        std::byte *m_base = nullptr;
+        std::size_t m_size = 0;
+    };
+
+    // Writes a DOS+NT header and @p num_sections readable, non-executable section headers (each with a valid in-range
+    // extent, so every one qualifies for the reverse scan) into @p pe, with the NT header at @p e_lfanew. Returns the
+    // file offset of the section table.
+    std::size_t write_synth_pe(SynthPe &pe, std::uint16_t num_sections, std::uint32_t e_lfanew) noexcept
+    {
+        IMAGE_DOS_HEADER dos{};
+        dos.e_magic = IMAGE_DOS_SIGNATURE;
+        dos.e_lfanew = static_cast<LONG>(e_lfanew);
+        pe.put(0, dos);
+
+        IMAGE_NT_HEADERS64 nt{};
+        nt.Signature = IMAGE_NT_SIGNATURE;
+        nt.FileHeader.Machine = IMAGE_FILE_MACHINE_AMD64;
+        nt.FileHeader.NumberOfSections = num_sections;
+        nt.FileHeader.SizeOfOptionalHeader = static_cast<std::uint16_t>(sizeof(IMAGE_OPTIONAL_HEADER64));
+        nt.OptionalHeader.Magic = IMAGE_NT_OPTIONAL_HDR64_MAGIC;
+        pe.put(e_lfanew, nt);
+
+        const std::size_t sec_table =
+            e_lfanew + offsetof(IMAGE_NT_HEADERS64, OptionalHeader) + sizeof(IMAGE_OPTIONAL_HEADER64);
+        for (std::uint16_t i = 0; i < num_sections; ++i)
+        {
+            IMAGE_SECTION_HEADER sh{};
+            sh.Characteristics = IMAGE_SCN_MEM_READ; // readable, non-executable, non-discardable => qualifies
+            sh.VirtualAddress = 0x100;               // a valid in-range extent [base+0x100, base+0x180)
+            sh.Misc.VirtualSize = 0x80;
+            pe.put(sec_table + static_cast<std::size_t>(i) * sizeof(IMAGE_SECTION_HEADER), sh);
+        }
+        return sec_table;
+    }
+
+#if defined(DMK_ENABLE_TEST_SEAMS)
+    std::atomic<std::uint64_t> s_fake_image_gen_first{0};
+    std::atomic<std::uint64_t> s_fake_image_gen_later{0};
+    std::atomic<std::uint32_t> s_fake_image_gen_calls{0};
+    Region s_fake_module_region{};
+
+    std::uint64_t fake_image_gen(std::uintptr_t) noexcept
+    {
+        const std::uint32_t call = s_fake_image_gen_calls.fetch_add(1, std::memory_order_relaxed);
+        return (call == 0 ? s_fake_image_gen_first : s_fake_image_gen_later).load(std::memory_order_relaxed);
+    }
+
+    Region fake_module_region(Address) noexcept
+    {
+        return s_fake_module_region;
+    }
+
+    struct ScopedImageGen
+    {
+        explicit ScopedImageGen(std::uint64_t value) noexcept
+        {
+            set(value);
+            DetourModKit::detail::g_rtti_image_generation_override = &fake_image_gen;
+        }
+        ~ScopedImageGen() noexcept { DetourModKit::detail::g_rtti_image_generation_override = nullptr; }
+        void set(std::uint64_t value) noexcept
+        {
+            s_fake_image_gen_first.store(value, std::memory_order_relaxed);
+            s_fake_image_gen_later.store(value, std::memory_order_relaxed);
+            s_fake_image_gen_calls.store(0, std::memory_order_relaxed);
+        }
+        void transition(std::uint64_t first, std::uint64_t later) noexcept
+        {
+            s_fake_image_gen_first.store(first, std::memory_order_relaxed);
+            s_fake_image_gen_later.store(later, std::memory_order_relaxed);
+            s_fake_image_gen_calls.store(0, std::memory_order_relaxed);
+        }
+        ScopedImageGen(const ScopedImageGen &) = delete;
+        ScopedImageGen &operator=(const ScopedImageGen &) = delete;
+    };
+
+    struct ScopedModuleRegion
+    {
+        explicit ScopedModuleRegion(Region region) noexcept
+        {
+            s_fake_module_region = region;
+            DetourModKit::detail::g_rtti_module_region_override = &fake_module_region;
+        }
+        ~ScopedModuleRegion() noexcept { DetourModKit::detail::g_rtti_module_region_override = nullptr; }
+        void set(Region region) noexcept { s_fake_module_region = region; }
+        ScopedModuleRegion(const ScopedModuleRegion &) = delete;
+        ScopedModuleRegion &operator=(const ScopedModuleRegion &) = delete;
+    };
+#endif
+} // anonymous namespace
+
+class RttiReverseProof : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        (void)memory::init_cache();
+        rev_reset();
+    }
+    void TearDown() override { memory::shutdown_cache(); }
+};
+
+TEST_F(RttiReverseProof, IncompleteSectionOrPageTraversalCannotAuthorizeVerdict)
+{
+    // Primary A is on a readable page; duplicate primary B is on a page that can be made inaccessible. A complete
+    // sweep sees both and reports the name ambiguous; a sweep that cannot read B's page sees
+    // only A and must NOT report A as the unique primary, because a second primary hides in the region it could not
+    // read.
+    const std::uintptr_t a = build_synth(".?AVRevIncomplete@@", 0);
+    ASSERT_NE(a, 0u);
+
+    const std::uintptr_t b_page = rev_page_align_cursor();
+    const std::uintptr_t b = build_synth(".?AVRevIncomplete@@", 0); // a second, distinct primary of the same name
+    ASSERT_NE(b, 0u);
+    ASSERT_EQ(b_page, b & ~static_cast<std::uintptr_t>(PAGE - 1)); // B's whole record sits on the aligned page
+
+    const Region scope = pool_range();
+
+    // Control: every page readable. The sweep is Complete, sees BOTH primaries, and fails closed on AMBIGUITY --
+    // proving B is a real, resolvable duplicate primary that a complete sweep catches.
+    {
+        Address out[4] = {};
+        const rtti::VtablesResult complete = rtti::vtables_for_type_checked(".?AVRevIncomplete@@", out, 4, scope);
+        EXPECT_EQ(complete.completeness, rtti::Traversal::Complete);
+        EXPECT_EQ(complete.count, 2u);
+        EXPECT_FALSE(rtti::vtable_for_type(".?AVRevIncomplete@@", scope).has_value());
+    }
+
+    // Hide B: its page is unreadable, so the sweep sees only A. It must report Incomplete, and vtable_for_type must
+    // fail closed rather than hand back A as the unique primary from a sweep that could not read where the second one
+    // lives.
+    {
+        ScopedNoAccess hide(b_page);
+        ASSERT_TRUE(hide.ok());
+
+        Address out[4] = {};
+        const rtti::VtablesResult partial = rtti::vtables_for_type_checked(".?AVRevIncomplete@@", out, 4, scope);
+        EXPECT_EQ(partial.completeness, rtti::Traversal::Incomplete);
+        EXPECT_EQ(partial.count, 1u); // only A was visible
+
+        EXPECT_FALSE(rtti::vtable_for_type(".?AVRevIncomplete@@", scope).has_value());
+    }
+}
+
+TEST_F(RttiReverseProof, SectionHeaderFaultAfterValidPrefixReportsIncomplete)
+{
+    // A synthetic 2-section PE whose FIRST section header is readable (a valid prefix) and whose SECOND lives on a page
+    // flipped to PAGE_NOACCESS. collect_rtti_scan_ranges must fault on the second header and report the enumeration
+    // Incomplete rather than returning the positive prefix as an authoritative range set.
+    SynthPe pe(2);
+    ASSERT_TRUE(pe.ok());
+    // e_lfanew places the section table at 0xFD8: section header 0 ends exactly at the page boundary (0x1000) and
+    // section header 1 begins on page 1.
+    const std::uint32_t e_lfanew = static_cast<std::uint32_t>(
+        0xFD8u - (offsetof(IMAGE_NT_HEADERS64, OptionalHeader) + sizeof(IMAGE_OPTIONAL_HEADER64)));
+    const std::size_t sec_table = write_synth_pe(pe, 2, e_lfanew);
+    ASSERT_EQ(sec_table, 0xFD8u);
+    pe.protect_page(1, PAGE_NOACCESS);
+
+    // The region probe must return Incomplete, not an authoritative Absent: the sweep could not finish, so absence
+    // cannot be concluded even though no record resolves in a non-module image.
+    EXPECT_EQ(rtti::region_rtti_presence(pe.range()), rtti::RttiPresence::Incomplete);
+
+    Address out[4] = {};
+    const rtti::VtablesResult r = rtti::vtables_for_type_checked(".?AVWhatever@@", out, 4, pe.range());
+    EXPECT_EQ(r.completeness, rtti::Traversal::Incomplete);
+
+    pe.protect_page(1, PAGE_READWRITE); // restore before the region is freed
+}
+
+TEST_F(RttiReverseProof, SaturatedSectionScanReportsSaturated)
+{
+    // A synthetic PE with more qualifying sections than the internal range buffer holds (MAX_RTTI_SCAN_RANGES == 32).
+    // collect must report Saturated rather than silently dropping the overflow and treating the sweep as authoritative.
+    SynthPe pe(2);
+    ASSERT_TRUE(pe.ok());
+    write_synth_pe(pe, 40, 0x40); // 40 readable sections; the section table fits on page 0
+
+    EXPECT_EQ(rtti::region_rtti_presence(pe.range()), rtti::RttiPresence::Incomplete); // Saturated => not authoritative
+
+    Address out[4] = {};
+    const rtti::VtablesResult r = rtti::vtables_for_type_checked(".?AVAnything@@", out, 4, pe.range());
+    EXPECT_EQ(r.completeness, rtti::Traversal::Saturated);
+}
+
+TEST_F(RttiReverseProof, InvalidSectionExtentReportsIncomplete)
+{
+    SynthPe pe(2);
+    ASSERT_TRUE(pe.ok());
+    const std::size_t section_table = write_synth_pe(pe, 1, 0x40);
+
+    IMAGE_SECTION_HEADER section{};
+    section.Characteristics = IMAGE_SCN_MEM_READ;
+    section.VirtualAddress = static_cast<DWORD>(pe.range().size + PAGE);
+    section.Misc.VirtualSize = 0x80;
+    pe.put(section_table, section);
+
+    Address out[1] = {};
+    const rtti::VtablesResult result = rtti::vtables_for_type_checked(".?AVOutside@@", out, 1, pe.range());
+    EXPECT_EQ(result.completeness, rtti::Traversal::Incomplete);
+    EXPECT_EQ(rtti::region_rtti_presence(pe.range()), rtti::RttiPresence::Incomplete);
+}
+
+TEST_F(RttiReverseProof, InvalidRegionReportsIncomplete)
+{
+    Address out[1] = {};
+    const rtti::VtablesResult result = rtti::vtables_for_type_checked(".?AVInvalid@@", out, 1, Region{});
+    EXPECT_EQ(result.completeness, rtti::Traversal::Incomplete);
+    EXPECT_EQ(result.count, 0u);
+    EXPECT_EQ(rtti::region_rtti_presence(Region{}), rtti::RttiPresence::Incomplete);
+}
+
+TEST_F(RttiReverseProof, CompleteSweepStillAuthorizesUniqueAndAbsent)
+{
+    // The completeness gate must not over-fire: a fully readable sweep still resolves a unique primary and still
+    // reports an authoritative absence for a records-free scope.
+    const std::uintptr_t vt = build_synth(".?AVRevComplete@@", 0);
+    ASSERT_NE(vt, 0u);
+    const Region scope = pool_range();
+
+    Address out[4] = {};
+    const rtti::VtablesResult r = rtti::vtables_for_type_checked(".?AVRevComplete@@", out, 4, scope);
+    EXPECT_EQ(r.completeness, rtti::Traversal::Complete);
+    EXPECT_EQ(r.count, 1u);
+
+    const auto found = rtti::vtable_for_type(".?AVRevComplete@@", scope);
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(found->raw(), vt);
+    EXPECT_EQ(rtti::region_rtti_presence(scope), rtti::RttiPresence::Present);
+
+    // A readable scope with an in-range non-COL decoy holds no resolvable record: a complete sweep => authoritative
+    // Absent, distinct from the Incomplete a truncated sweep returns.
+    const Region decoy = build_in_range_decoy();
+    ASSERT_NE(decoy.size, 0u);
+    EXPECT_EQ(rtti::region_rtti_presence(decoy), rtti::RttiPresence::Absent);
+}
+
+TEST_F(RttiReverseProof, ImageGenerationIdentifiesModuleAndRejectsNonModule)
+{
+    // A module-backed address carries a nonzero, stable generation; a private (non-module) allocation carries 0.
+    const Address host_addr{reinterpret_cast<std::uintptr_t>(GetModuleHandleW(nullptr))};
+    const std::uint64_t host_gen = rtti::image_generation(host_addr);
+    EXPECT_NE(host_gen, 0u);
+    EXPECT_EQ(host_gen, rtti::image_generation(host_addr)); // stable across calls
+
+    void *priv = VirtualAlloc(nullptr, PAGE, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    ASSERT_NE(priv, nullptr);
+    EXPECT_EQ(rtti::image_generation(Address{reinterpret_cast<std::uintptr_t>(priv)}), 0u);
+    (void)VirtualFree(priv, 0, MEM_RELEASE);
+}
+
+TEST_F(RttiReverseProof, TypeIdentityInvalidateForcesColdReResolve)
+{
+    // invalidate() drops the cached success so the next call re-resolves against current memory. The pool lives in the
+    // test-exe module, whose generation does not change, so the warm cache is otherwise sticky -- exactly the case
+    // invalidate() exists for.
+    const std::uintptr_t vt1 = build_synth(".?AVRevInval@@", 0);
+    ASSERT_NE(vt1, 0u);
+    rtti::TypeIdentity id(".?AVRevInval@@", pool_range());
+    ASSERT_TRUE(id.vtable().has_value());
+    EXPECT_EQ(id.vtable()->raw(), vt1);
+
+    // Wipe the record. Without invalidate the warm cache keeps returning vt1 (the module generation is unchanged).
+    rev_reset();
+    ASSERT_TRUE(id.vtable().has_value());
+    EXPECT_EQ(id.vtable()->raw(), vt1);
+
+    id.invalidate();
+    EXPECT_FALSE(id.vtable().has_value()); // cache dropped => a fresh resolve misses the wiped record
+}
+
+#if defined(DMK_ENABLE_TEST_SEAMS)
+TEST_F(RttiReverseProof, TypeIdentityDropsWarmCacheOnGenerationChange)
+{
+    // Simulate a same-base remap: image_generation returns 1111, the identity resolves and stamps it; after the
+    // generation changes to 2222, the next warm call must drop the stale cache and re-resolve against current memory
+    // rather than keep matching the old vtable.
+    ScopedImageGen gen(1111);
+
+    const std::uintptr_t vt1 = build_synth(".?AVRevRemap@@", 0);
+    ASSERT_NE(vt1, 0u);
+    rtti::TypeIdentity id(".?AVRevRemap@@", pool_range());
+    ASSERT_TRUE(id.vtable().has_value());
+    EXPECT_EQ(id.vtable()->raw(), vt1); // resolved, stamped generation 1111
+
+    // Wipe the record: a re-resolve would now miss. A warm cache that does not re-validate keeps returning vt1.
+    rev_reset();
+
+    // An unchanged generation keeps the cached value.
+    ASSERT_TRUE(id.vtable().has_value());
+    EXPECT_EQ(id.vtable()->raw(), vt1);
+
+    // A same-base generation change is observed immediately; current memory no longer holds the record.
+    gen.set(2222);
+    EXPECT_FALSE(id.vtable().has_value());
+}
+
+TEST_F(RttiReverseProof, TypeIdentityRefreshesTrackedModuleExtent)
+{
+    ScopedImageGen generation(1111);
+
+    const std::uintptr_t old_vtable = build_synth(".?AVRevExtent@@", 0);
+    ASSERT_NE(old_vtable, 0u);
+    ScopedModuleRegion module(pool_range());
+    rtti::TypeIdentity identity(".?AVRevExtent@@", pool_range());
+    ASSERT_EQ(identity.vtable(), Address{old_vtable});
+
+    rev_reset();
+    ASSERT_NE(build_in_range_decoy().size, 0u);
+    const std::uintptr_t current_vtable = build_synth(".?AVRevExtent@@", 0);
+    ASSERT_NE(current_vtable, 0u);
+    ASSERT_NE(current_vtable, old_vtable);
+    module.set(pool_range());
+    generation.set(2222);
+
+    ASSERT_EQ(identity.vtable(), Address{current_vtable});
+}
+
+TEST_F(RttiReverseProof, TypeIdentityDoesNotPublishAcrossGenerationTransition)
+{
+    RttiClockScope clock;
+    s_fake_clock_ms.store(1000);
+    ScopedImageGen generation(1111);
+    const std::uintptr_t vtable = build_synth(".?AVRevTransactional@@", 0);
+    ASSERT_NE(vtable, 0u);
+
+    generation.transition(1111, 2222);
+    rtti::TypeIdentity identity(".?AVRevTransactional@@", pool_range());
+    EXPECT_FALSE(identity.vtable().has_value());
+
+    generation.set(2222);
+    s_fake_clock_ms.store(1000 + 1'000'000);
+    ASSERT_EQ(identity.vtable(), Address{vtable});
+}
+#endif


### PR DESCRIPTION
## Summary

Prevents incomplete scans or stale same-base caches from authorizing RTTI and self-heal results, and makes mutation callers consume offset validity explicitly.

## Highlights
- `TypeIdentity` and a new `PointerTableCache` are keyed by full image generation with explicit invalidate/reset and same-base remap handling; the raw atomic overloads remain as documented compatibility surfaces.
- Pointer-table lookups cold-fall back from a stale warm candidate and distinguish primary from secondary vtables.
- Section and page traversal now carry Complete/Incomplete/Saturated status: `vtable_for_type` fails closed on any non-complete sweep, `vtables_for_type_checked` reports coverage, and `region_rtti_presence` never turns a partial sweep into an authoritative absence. `region_has_rtti` stays boolean-identical.
- `type_name_checked` returns Ok/Truncated/Failed; the best-effort name APIs are unchanged.
- `HealScheduler` re-entry uses a depth guard instead of one boolean, so a nested tick cannot corrupt an in-flight scan, and all RTTI/healing offset and delta math is checked for PTRDIFF and PE bounds.
- A new `HealedSlot` channel carries {value, generation, validity}: a required miss publishes Invalid, an optional miss Unverified, and the checked accessors reject anything not Confirmed. The raw atomic authorization path stays documented as caller-owned-unsafe.

## Compatibility
The statusful APIs and `HealedOffset` are additive. The `TypeIdentity` layout change is ABI-affecting and requires a clean rebuild of the library and every consumer, plus package smoke.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added completeness-aware RTTI inspection, including truncation reporting and reliable distinction between absent and incomplete results.
  * Added generation-aware caching and invalidation to improve correctness across module reloads.
  * Added validity-tracked healed offsets with authorization checks to prevent unsafe use of unconfirmed results.
  * Added clearer RTTI failure reporting, including `OffsetNotConfirmed`.

* **Bug Fixes**
  * Improved handling of stale cache entries, unreadable memory, extreme offsets, and recursive scheduler ticks.
  * Negative drift thresholds are now rejected with a clear argument error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->