### PR TITLE
feat(util): narrow utility contract cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Header: [`detail/event_dispatcher.hpp`](include/DetourModKit/detail/event_dispat
 <details>
 <summary><b>Format Utilities</b> - header-only <strong>std::format</strong> helpers for addresses, bytes, and VK codes</summary>
 
-Turns raw modding values into readable, log-friendly hex strings. The `format` namespace offers `format_address` for pointers, overloaded `format_hex` for signed, unsigned, and `ptrdiff_t` inputs, `format_byte` for single bytes, and `format_vkcode` / `format_vkcode_list` / `format_int_vector` for key codes and integer lists. The separate `string::trim` strips leading and trailing whitespace. Every function is header-only and `[[nodiscard]]`, built on `std::format`.
+Turns raw modding values into readable, log-friendly hex strings. The `format` namespace offers `format_address` for pointers, overloaded `format_hex` for `int`, `long` (the Win32 `HRESULT`/`LONG`/`LSTATUS` family), unsigned, and `ptrdiff_t` inputs, `format_byte` for single bytes, and `format_vkcode` / `format_vkcode_list` / `format_int_vector` for key codes and integer lists. The separate `string::trim` strips leading and trailing whitespace. Every function is header-only and `[[nodiscard]]`, built on `std::format`.
 
 Header: [`format.hpp`](include/DetourModKit/format.hpp)
 </details>
@@ -171,7 +171,7 @@ Header: [`format.hpp`](include/DetourModKit/format.hpp)
 <details>
 <summary><b>Filesystem Utilities</b> - cached module-directory resolution with wide-string and UTF-8 APIs</summary>
 
-Resolves the on-disk directory of the currently loaded module (DLL or EXE) so a mod can locate its own config and asset files regardless of the game's working directory. Call `get_runtime_directory()` for a wide-string path that preserves full Unicode fidelity, or `get_runtime_directory_utf8()` for a UTF-8 encoding of the same path. Both results are cached after first resolution, making repeat calls allocation-free, and both fall back gracefully if module detection fails.
+Resolves the on-disk directory of the currently loaded module (DLL or EXE) so a mod can locate its own config and asset files regardless of the game's working directory. Call `get_runtime_directory()` for a wide-string path that preserves full Unicode fidelity, or `get_runtime_directory_utf8()` for a UTF-8 encoding of the same path. Resolution and conversion run once and are cached, but each call returns an owning copy of the cached path (a string copy that may allocate), and both fall back gracefully if module detection fails.
 
 Header: [`filesystem.hpp`](include/DetourModKit/filesystem.hpp)
 </details>

--- a/include/DetourModKit/detail/drift_manifest.hpp
+++ b/include/DetourModKit/detail/drift_manifest.hpp
@@ -52,8 +52,8 @@ namespace DetourModKit
          * @brief Serializes a drift report to a durable, line-oriented manifest.
          * @details Emits a versioned header line followed by one tab-separated line per entry (name, nominal_offset,
          *          healed_offset, delta, ok, error). The error is written as a stable token, not the human-readable
-         *          @ref Error::message() text, so the manifest round-trips. Names are assumed free of tab and
-         *          newline (MSVC mangled type names are).
+         *          @ref Error::message() text. Record delimiters and backslashes in a name use C-style escapes so every
+         *          name round-trips exactly through @ref parse_drift_report.
          * @param entries The drift entries to serialize (e.g. from @ref heal_report).
          * @return The manifest text.
          */
@@ -61,8 +61,8 @@ namespace DetourModKit
 
         /**
          * @brief Parses a drift manifest produced by @ref serialize_drift_report.
-         * @details Tolerates blank lines and trailing carriage returns (CRLF input). Fails closed on a missing header
-         *          or any malformed record line.
+         * @details Tolerates blank lines and CRLF input. Decodes the name field's C-style escapes. Fails closed on a
+         *          missing header or any malformed record line, including a truncated or unknown name escape.
          * @param text The manifest text.
          * @return The parsed records, or an Error carrying ErrorCode::MissingHeader (no header line) or
          *         ErrorCode::MalformedLine (a bad record line).

--- a/include/DetourModKit/filesystem.hpp
+++ b/include/DetourModKit/filesystem.hpp
@@ -17,10 +17,12 @@ namespace DetourModKit
 
         /**
          * @brief Gets the directory containing the currently executing module (DLL/EXE).
-         * @details Uses Windows Wide APIs (GetModuleHandleExW, GetModuleFileNameW) to determine the full path of the
-         *          current module and extracts its parent directory using std::filesystem. The result is cached after
-         *          the first successful resolution, making subsequent calls zero-cost. Falls back to the current
-         *          working directory if module path detection fails for any reason.
+         * @details Resolution (GetModuleHandleExW, GetModuleFileNameW, parent-path extraction) runs once and the
+         *          resolved path is cached, but every call returns an owning copy of that cached string, so each call
+         *          still pays a string copy and may allocate (a typical path exceeds the small-string buffer). Not
+         *          allocation-free and therefore not callback-safe; capture the result once at setup instead of
+         *          calling from a hot or allocation-restricted path. Falls back to the current working directory if
+         *          module path detection fails for any reason.
          * @return std::wstring The absolute directory path of the current module as a wide string, preserving full
          *         Unicode fidelity for paths with non-ASCII characters (e.g. CJK/Cyrillic usernames). Returns L"." on
          *         total failure.
@@ -29,10 +31,10 @@ namespace DetourModKit
 
         /**
          * @brief UTF-8 sibling of get_runtime_directory().
-         * @details Converts the cached wide-string module directory to UTF-8 via WideCharToMultiByte(CP_UTF8). The
-         *          conversion result is cached separately so repeated calls are allocation-free. Returns "." if the
-         *          wide-string resolution failed or if the
-         *          UTF-8 conversion itself fails (best-effort fallback).
+         * @details The WideCharToMultiByte(CP_UTF8) conversion runs once and its result is cached separately, but as
+         *          with the wide getter every call returns an owning copy of the cached string and may allocate; it
+         *          is not allocation-free or callback-safe. Returns "." if the wide-string resolution failed or if
+         *          the UTF-8 conversion itself fails (best-effort fallback).
          * @return std::string Absolute module directory encoded in UTF-8.
          */
         [[nodiscard]] std::string get_runtime_directory_utf8();

--- a/include/DetourModKit/format.hpp
+++ b/include/DetourModKit/format.hpp
@@ -72,6 +72,21 @@ namespace DetourModKit
         }
 
         /**
+         * @brief Formats a signed long as an unsigned hexadecimal string.
+         * @details Exact match for the 32-bit Win32 LONG family (HRESULT, LONG, LSTATUS, NTSTATUS). Negative values
+         *          print the unsigned two's-complement bit pattern like the int overload.
+         * @param value The long value to format.
+         * @param width Minimum width of the hex part (0 for no padding).
+         * @return std::string Formatted hex string (e.g., "0x80004005").
+         */
+        [[nodiscard]] inline std::string format_hex(long value, int width = 0)
+        {
+            if (width > 0)
+                return std::format("0x{:0{}X}", static_cast<unsigned long>(value), width);
+            return std::format("0x{:X}", static_cast<unsigned long>(value));
+        }
+
+        /**
          * @brief Formats any unsigned integer as a hexadecimal string.
          * @details Constrained to std::unsigned_integral so a size_t / unsigned / uint64_t argument binds here exactly
          *          instead of being ambiguous between the int and ptrdiff_t overloads. The full value is preserved
@@ -91,14 +106,10 @@ namespace DetourModKit
 
         /**
          * @brief Formats a ptrdiff_t as a signed hexadecimal string.
-         * @details The signed 64-bit path. When this overload carried no width parameter, a call that supplied one --
-         *          e.g. `format_hex(some_ptrdiff_t, 8)` -- could not bind here (it took a single argument) and instead
-         *          selected the `int` overload, which narrows the 64-bit value to 32 bits before formatting. That
-         *          silently truncated any pointer difference outside the int range (a large positive offset dropped its
-         *          high half; a negative one printed as a bogus unsigned int). Carrying the same width parameter as the
-         *          other overloads keeps a signed hex value whole when a caller pads it. The pad count applies to the
-         *          hex digits only; the leading '-' and the "0x" prefix sit outside the padded field, matching the int
-         *          and unsigned-integral overloads.
+         * @details The signed 64-bit path (LONG_PTR / SSIZE_T / long long on LLP64), and the one signed overload that
+         *          prints a leading '-' with the magnitude rather than the two's-complement bit pattern -- a pointer
+         *          difference is a distance, not a register image. The pad count applies to the hex digits only; the
+         *          '-' and the "0x" prefix sit outside the padded field, matching the other overloads.
          * @param value The value to format.
          * @param width Minimum width of the hex part (0 for no padding).
          * @return std::string Formatted hex string (e.g., "0xFF" or "-0x10").

--- a/src/drift_manifest.cpp
+++ b/src/drift_manifest.cpp
@@ -69,6 +69,79 @@ namespace DetourModKit
                 return false;
             }
 
+            /**
+             * @brief Appends a name without exposing record delimiters to the manifest grammar.
+             * @param out The manifest buffer to append to.
+             * @param name The unescaped name.
+             */
+            void append_escaped_name(std::string &out, std::string_view name)
+            {
+                for (const char c : name)
+                {
+                    switch (c)
+                    {
+                    case '\t':
+                        out.append("\\t");
+                        break;
+                    case '\n':
+                        out.append("\\n");
+                        break;
+                    case '\r':
+                        out.append("\\r");
+                        break;
+                    case '\\':
+                        out.append("\\\\");
+                        break;
+                    default:
+                        out.push_back(c);
+                        break;
+                    }
+                }
+            }
+
+            /**
+             * @brief Decodes an escaped name field.
+             * @param field The encoded field.
+             * @param out Receives the decoded name.
+             * @return False for a truncated or unknown escape.
+             */
+            [[nodiscard]] bool unescape_name(std::string_view field, std::string &out)
+            {
+                out.clear();
+                out.reserve(field.size());
+                for (std::size_t i = 0; i < field.size(); ++i)
+                {
+                    const char c = field[i];
+                    if (c != '\\')
+                    {
+                        out.push_back(c);
+                        continue;
+                    }
+                    if (++i >= field.size())
+                    {
+                        return false;
+                    }
+                    switch (field[i])
+                    {
+                    case 't':
+                        out.push_back('\t');
+                        break;
+                    case 'n':
+                        out.push_back('\n');
+                        break;
+                    case 'r':
+                        out.push_back('\r');
+                        break;
+                    case '\\':
+                        out.push_back('\\');
+                        break;
+                    default:
+                        return false;
+                    }
+                }
+                return true;
+            }
+
             // Parses a decimal (possibly negative) offset that must span the whole field.
             [[nodiscard]] bool parse_offset(std::string_view field, std::ptrdiff_t &out) noexcept
             {
@@ -97,7 +170,7 @@ namespace DetourModKit
             out.push_back('\n');
             for (const DriftEntry &entry : entries)
             {
-                out.append(entry.name.data(), entry.name.size());
+                append_escaped_name(out, entry.name);
                 out.push_back(FIELD_SEP);
                 out.append(std::to_string(entry.nominal_offset));
                 out.push_back(FIELD_SEP);
@@ -175,7 +248,10 @@ namespace DetourModKit
                 }
 
                 DriftRecord record;
-                record.name = std::string(fields[0]);
+                if (!unescape_name(fields[0], record.name))
+                {
+                    return manifest_error(ErrorCode::MalformedLine);
+                }
                 if (!parse_offset(fields[1], record.nominal_offset) || !parse_offset(fields[2], record.healed_offset) ||
                     !parse_offset(fields[3], record.delta))
                 {

--- a/src/internal/module_name.hpp
+++ b/src/internal/module_name.hpp
@@ -1,0 +1,90 @@
+#ifndef DETOURMODKIT_INTERNAL_MODULE_NAME_HPP
+#define DETOURMODKIT_INTERNAL_MODULE_NAME_HPP
+
+/**
+ * @file module_name.hpp
+ * @brief Shared bounded UTF-8 -> UTF-16 widening for module-name lookups.
+ */
+
+#include <windows.h>
+
+#include <climits>
+#include <cstddef>
+#include <new>
+#include <string>
+#include <string_view>
+
+namespace DetourModKit
+{
+    namespace detail
+    {
+        /**
+         * @brief Reports whether a module-name byte count fits the Win32 conversion API.
+         * @param length The byte count to test.
+         * @return True when @p length can be represented by the converter's signed count.
+         */
+        [[nodiscard]] constexpr bool module_name_length_fits_win32(std::size_t length) noexcept
+        {
+            return length <= static_cast<std::size_t>(INT_MAX);
+        }
+
+        /**
+         * @brief Widens a pointer/count UTF-8 module name after validating its Win32 length.
+         * @details The length check precedes construction of a view and every access through @p data. Embedded NUL and
+         *          malformed UTF-8 are rejected because GetModuleHandleW would otherwise observe a different name.
+         * @param data The first name byte; may be null only when @p length is zero or oversized.
+         * @param length The number of name bytes.
+         * @return The UTF-16 name, or an empty string when validation, conversion, or allocation fails.
+         * @pre When @p length is nonzero and at most INT_MAX, @p data addresses @p length readable bytes.
+         */
+        [[nodiscard]] inline std::wstring widen_module_name_bytes(const char *data, std::size_t length) noexcept
+        {
+            if (length == 0 || !module_name_length_fits_win32(length) || data == nullptr)
+            {
+                return std::wstring{};
+            }
+
+            const std::string_view name{data, length};
+            if (name.find('\0') != std::string_view::npos)
+            {
+                return std::wstring{};
+            }
+
+            const int input_length = static_cast<int>(length);
+            const int wide_length =
+                ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, data, input_length, nullptr, 0);
+            if (wide_length <= 0)
+            {
+                return std::wstring{};
+            }
+            try
+            {
+                std::wstring wide_name(static_cast<std::size_t>(wide_length), L'\0');
+                const int converted = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, data, input_length,
+                                                            wide_name.data(), wide_length);
+                if (converted != wide_length)
+                {
+                    return std::wstring{};
+                }
+                return wide_name;
+            }
+            catch (const std::bad_alloc &)
+            {
+                return std::wstring{};
+            }
+        }
+
+        /**
+         * @brief Widens a UTF-8 module name to the UTF-16 the Win32 module APIs expect.
+         * @details Reads exactly @c name.size() bytes, so a non-NUL-terminated view is safe.
+         * @param name The bounded UTF-8 module name.
+         * @return The UTF-16 name, or an empty string when validation, conversion, or allocation fails.
+         */
+        [[nodiscard]] inline std::wstring widen_module_name(std::string_view name) noexcept
+        {
+            return widen_module_name_bytes(name.data(), name.size());
+        }
+    } // namespace detail
+} // namespace DetourModKit
+
+#endif // DETOURMODKIT_INTERNAL_MODULE_NAME_HPP

--- a/src/memory_module.cpp
+++ b/src/memory_module.cpp
@@ -12,6 +12,7 @@
 #include "DetourModKit/memory.hpp"
 #include "internal/lifecycle_context.hpp"
 #include "internal/memory_representation_win32.hpp"
+#include "internal/module_name.hpp"
 #include "internal/srw_shared_mutex.hpp"
 
 #include <windows.h>
@@ -188,41 +189,6 @@ namespace DetourModKit
 
     namespace memory
     {
-        namespace
-        {
-            /**
-             * @brief Widens a UTF-8 module name to the UTF-16 the Win32 module APIs expect.
-             * @return The widened name, or an empty string when the name is empty or the conversion measurement fails.
-             */
-            [[nodiscard]] std::wstring widen_module_name(std::string_view name) noexcept
-            {
-                if (name.empty())
-                {
-                    return std::wstring{};
-                }
-                const int wide_length =
-                    ::MultiByteToWideChar(CP_UTF8, 0, name.data(), static_cast<int>(name.size()), nullptr, 0);
-                if (wide_length <= 0)
-                {
-                    return std::wstring{};
-                }
-                // The wstring allocation can throw bad_alloc, but this helper is noexcept and feeds noexcept module
-                // queries. Fail soft to an empty name -- every caller reads that as "no such module" -- rather than let
-                // a bad_alloc escape and terminate the host under the exact memory pressure the query must survive.
-                try
-                {
-                    std::wstring wide_name(static_cast<std::size_t>(wide_length), L'\0');
-                    ::MultiByteToWideChar(CP_UTF8, 0, name.data(), static_cast<int>(name.size()), wide_name.data(),
-                                          wide_length);
-                    return wide_name;
-                }
-                catch (const std::bad_alloc &)
-                {
-                    return std::wstring{};
-                }
-            }
-        } // namespace
-
         Region module_of(Address address) noexcept
         {
             if (!address)
@@ -240,7 +206,7 @@ namespace DetourModKit
 
         bool is_module_loaded(std::string_view basename, bool case_insensitive) noexcept
         {
-            const std::wstring wide_name = widen_module_name(basename);
+            const std::wstring wide_name = detail::widen_module_name(basename);
             if (wide_name.empty())
             {
                 return false;

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -1,12 +1,12 @@
 #include "DetourModKit/region.hpp"
 
 #include "internal/memory_guarded.hpp"
+#include "internal/module_name.hpp"
 
 #include <windows.h>
 
 #include <cstddef>
 #include <cstdint>
-#include <new>
 #include <string>
 
 namespace DetourModKit
@@ -38,39 +38,17 @@ namespace DetourModKit
 
     Region Region::module_named(std::string_view name) noexcept
     {
-        if (name.empty())
+        // Invalid names and conversion failures take the same fail-closed path as an unloaded module.
+        const std::wstring wide_name = detail::widen_module_name(name);
+        if (wide_name.empty())
         {
             return Region{};
         }
 
-        // Widen the UTF-8 module name to the UTF-16 the Win32 W API expects. A zero/failed measurement (malformed
-        // UTF-8) or an unloaded module both fall through to an empty Region, so a bad name never throws or scans.
-        const int wide_length =
-            ::MultiByteToWideChar(CP_UTF8, 0, name.data(), static_cast<int>(name.size()), nullptr, 0);
-        if (wide_length <= 0)
-        {
-            return Region{};
-        }
-
-        // The wstring allocation can throw bad_alloc, but module_named is noexcept. Fail soft to an empty Region -- the
-        // same fail-closed outcome as an unloaded module -- rather than let a bad_alloc escape and terminate the host.
-        HMODULE module_handle = nullptr;
-        try
-        {
-            std::wstring wide_name(static_cast<std::size_t>(wide_length), L'\0');
-            ::MultiByteToWideChar(CP_UTF8, 0, name.data(), static_cast<int>(name.size()), wide_name.data(),
-                                  wide_length);
-            // GetModuleHandleW does not add a reference, so the returned handle is only valid while the module stays
-            // loaded. That is the correct contract here: a Region is a transient scan scope, not an ownership claim.
-            module_handle = ::GetModuleHandleW(wide_name.c_str());
-        }
-        catch (const std::bad_alloc &)
-        {
-            return Region{};
-        }
-
+        // GetModuleHandleW does not add a reference, so the returned handle is only valid while the module stays
+        // loaded. That is the correct contract here: a Region is a transient scan scope, not an ownership claim.
         // The resolved span is cached per module handle (detail::cached_module_image_region).
-        return detail::cached_module_image_region(Address{module_handle});
+        return detail::cached_module_image_region(Address{::GetModuleHandleW(wide_name.c_str())});
     }
 
     Region Region::whole_process() noexcept

--- a/tests/test_drift_manifest.cpp
+++ b/tests/test_drift_manifest.cpp
@@ -108,6 +108,40 @@ TEST(DriftManifestTest, ParseRejectsNonNumericOffset)
     EXPECT_EQ(parsed.error().code, ErrorCode::MalformedLine);
 }
 
+// Names may contain the manifest's record delimiters, so framing characters and the escape character must round-trip.
+TEST(DriftManifestTest, ControlCharacterNamesRoundTripExactly)
+{
+    DriftEntry entries[3];
+    entries[0].name = "tab\there\nand\rmore";
+    entries[0].nominal_offset = 8;
+    entries[1].name = "trailing_cr\r"; // a raw trailing CR would be eaten by the parser's CRLF tolerance
+    entries[1].nominal_offset = 16;
+    entries[2].name = "back\\slash\\"; // the escape character itself must round-trip
+    entries[2].nominal_offset = 24;
+
+    const auto parsed = rtti::parse_drift_report(rtti::serialize_drift_report(entries));
+    ASSERT_TRUE(parsed.has_value());
+    ASSERT_EQ(parsed->size(), 3u);
+    EXPECT_EQ((*parsed)[0].name, "tab\there\nand\rmore");
+    EXPECT_EQ((*parsed)[1].name, "trailing_cr\r");
+    EXPECT_EQ((*parsed)[2].name, "back\\slash\\");
+}
+
+// A truncated escape (lone backslash at field end) or an unknown escape letter is a malformed line, not a silently
+// altered name.
+TEST(DriftManifestTest, ParseRejectsTruncatedOrUnknownNameEscape)
+{
+    const std::string header = "# DetourModKit drift manifest v1\n";
+
+    const auto truncated = rtti::parse_drift_report(header + "bad\\\t1\t2\t3\t1\tOk\n");
+    ASSERT_FALSE(truncated.has_value());
+    EXPECT_EQ(truncated.error().code, ErrorCode::MalformedLine);
+
+    const auto unknown = rtti::parse_drift_report(header + "bad\\x\t1\t2\t3\t1\tOk\n");
+    ASSERT_FALSE(unknown.has_value());
+    EXPECT_EQ(unknown.error().code, ErrorCode::MalformedLine);
+}
+
 TEST(DriftManifestTest, ParseToleratesBlankLinesAndCrlf)
 {
     const std::string text = "# DetourModKit drift manifest v1\r\n\r\nfoo\t1\t2\t1\t1\tBadDescriptor\r\n\r\n";

--- a/tests/test_filesystem.cpp
+++ b/tests/test_filesystem.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 #include <chrono>
 #include <filesystem>
+#include <string>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
 #include "DetourModKit/filesystem.hpp"
@@ -95,8 +97,9 @@ TEST(FilesystemTest, GetRuntimeDirectory_CachedResult)
     const auto elapsed = std::chrono::steady_clock::now() - start;
     const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
 
-    // 10000 cached calls should complete well under 1 second.
-    EXPECT_LT(elapsed_ms, 1000) << "Cached get_runtime_directory should be near-zero cost per call";
+    // 10000 cached calls should complete well under 1 second. This bounds wall time only: each call still copies the
+    // cached string (see FilesystemContractTest.OwningResultCopyCostIsDocumented for the ownership contract).
+    EXPECT_LT(elapsed_ms, 1000) << "Cached resolution should keep repeat calls fast";
 }
 
 TEST(FilesystemUtf8, ReturnsNonEmpty)
@@ -110,4 +113,15 @@ TEST(FilesystemUtf8, Cached)
     const std::string a = filesystem::get_runtime_directory_utf8();
     const std::string b = filesystem::get_runtime_directory_utf8();
     EXPECT_EQ(a, b);
+}
+
+// The ownership contract is pinned at compile time: by-value string returns cannot alias the cached path, so a caller
+// may mutate its copy freely. Cross-call value equality is covered by FilesystemTest.GetRuntimeDirectory_Consistent and
+// FilesystemUtf8.Cached; a runtime aliasing probe would be inert against these return types.
+TEST(FilesystemContractTest, OwningResultCopyCostIsDocumented)
+{
+    static_assert(std::is_same_v<decltype(filesystem::get_runtime_directory()), std::wstring>,
+                  "get_runtime_directory returns an owning std::wstring, not a reference or view");
+    static_assert(std::is_same_v<decltype(filesystem::get_runtime_directory_utf8()), std::string>,
+                  "get_runtime_directory_utf8 returns an owning std::string, not a reference or view");
 }

--- a/tests/test_format.cpp
+++ b/tests/test_format.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+#include <windows.h>
+
 #include <climits>
 #include <cstddef>
 #include <cstdint>
@@ -259,4 +261,40 @@ TEST(FormatTest, FormatHex_PtrdiffWidthNegativeAboveInt)
     // int overload would have widened a truncated 32-bit value to a bogus unsigned representation.
     ptrdiff_t value = -static_cast<ptrdiff_t>(0x0000000100000000LL);
     EXPECT_EQ(format::format_hex(value, 4), "-0x100000000");
+}
+
+TEST(FormatTest, SignedLongUsesExactLlp64Bits)
+{
+    // Negatives use the unsigned 32-bit representation shared by the int and Win32 LONG contracts.
+    static_assert(sizeof(long) == 4, "Windows LLP64: long is 32-bit on both supported toolchains");
+    EXPECT_EQ(format::format_hex(-1L), "0xFFFFFFFF");
+    EXPECT_EQ(format::format_hex(0x10L), "0x10");
+    EXPECT_EQ(format::format_hex(-1L, 8), "0xFFFFFFFF");
+    EXPECT_EQ(format::format_hex(LONG_MIN), "0x80000000");
+    EXPECT_EQ(format::format_hex(0L, 4), "0x0000");
+    // HRESULT formatting preserves the complete status-code bit pattern.
+    EXPECT_EQ(format::format_hex(E_FAIL), "0x80004005");
+}
+
+TEST(FormatCompileTest, Win32SignedIntegerTypedefsResolveUnambiguously)
+{
+    // Each supported Win32 and language integer type must select one overload on both toolchains.
+    const HRESULT hr = E_FAIL;                        // long: exact long overload
+    const LONG win_long = -1;                         // long
+    const LSTATUS status = ERROR_FILE_NOT_FOUND;      // LONG
+    const DWORD dword = 0xDEADBEEFu;                  // unsigned long: unsigned-integral template
+    const SIZE_T size = static_cast<SIZE_T>(1) << 40; // unsigned __int64: unsigned-integral template
+    const LONG_PTR long_ptr = -0x10;                  // __int64 == ptrdiff_t: signed-magnitude overload
+    EXPECT_EQ(format::format_hex(hr), "0x80004005");
+    EXPECT_EQ(format::format_hex(win_long), "0xFFFFFFFF");
+    EXPECT_EQ(format::format_hex(status), "0x2");
+    EXPECT_EQ(format::format_hex(dword), "0xDEADBEEF");
+    EXPECT_EQ(format::format_hex(size), "0x10000000000");
+    EXPECT_EQ(format::format_hex(long_ptr), "-0x10");
+
+    EXPECT_EQ(format::format_hex(-1), "0xFFFFFFFF");                          // int
+    EXPECT_EQ(format::format_hex(0xFFFFFFFFUL), "0xFFFFFFFF");                // unsigned long
+    EXPECT_EQ(format::format_hex(static_cast<long long>(-1)), "-0x1");        // long long (== ptrdiff_t on LLP64)
+    EXPECT_EQ(format::format_hex(static_cast<std::size_t>(16)), "0x10");      // size_t
+    EXPECT_EQ(format::format_hex(static_cast<std::ptrdiff_t>(-16)), "-0x10"); // ptrdiff_t
 }

--- a/tests/test_memory.cpp
+++ b/tests/test_memory.cpp
@@ -7,6 +7,7 @@
 #include "internal/lifecycle_context.hpp"
 #include "internal/memory_fault.hpp"
 #include "internal/memory_guarded.hpp"
+#include "internal/module_name.hpp"
 
 // Deterministic thread-local out-of-memory injection for the ProtectGuard allocation-failure test.
 #include "test_alloc_probe.hpp"
@@ -3931,6 +3932,44 @@ TEST_F(MemoryTest, IsModuleLoaded_AllocFailureFailsSoftNoTerminate)
     }
     // The widen allocation failed, so the query fails closed to false instead of terminating the noexcept host path.
     EXPECT_FALSE(under_oom);
+}
+
+// MultiByteToWideChar uses a signed byte count; 0xFFFFFFFF would become its NUL-terminated sentinel if narrowed.
+TEST_F(MemoryTest, ModuleNameLengthSeamRejectsOverIntMax)
+{
+    static_assert(DetourModKit::detail::module_name_length_fits_win32(static_cast<std::size_t>(INT_MAX)),
+                  "INT_MAX is the largest byte count the Win32 converter accepts");
+    static_assert(!DetourModKit::detail::module_name_length_fits_win32(static_cast<std::size_t>(INT_MAX) + 1U),
+                  "INT_MAX + 1 must fail the length seam");
+
+    // The raw pointer/count seam rejects before constructing a view or accessing the deliberately small buffer.
+    static constexpr char SMALL_NAME[] = "kernel32.dll";
+    EXPECT_TRUE(DetourModKit::detail::widen_module_name_bytes(SMALL_NAME, 0xFFFFFFFFu).empty());
+}
+
+// An ordinary non-NUL-terminated view stays bounded: only the view's bytes are read, so a name carved from a larger
+// buffer with no NUL at the view's end widens to exactly the viewed characters.
+TEST_F(MemoryTest, ModuleNameWidenIsBoundedToTheView)
+{
+    static constexpr char PADDED_NAME[] = "kernel32.dllTRAILING_GARBAGE";
+    const std::string_view bounded{PADDED_NAME, 12}; // "kernel32.dll", no NUL at the view boundary
+    EXPECT_EQ(DetourModKit::detail::widen_module_name(bounded), L"kernel32.dll");
+    EXPECT_TRUE(memory::is_module_loaded(bounded));
+    EXPECT_NE(Region::module_named(bounded).size, 0u);
+    // The unbounded spelling would have seen the trailing garbage and matched nothing.
+    EXPECT_FALSE(memory::is_module_loaded(std::string_view{PADDED_NAME, sizeof(PADDED_NAME) - 1}));
+}
+
+TEST_F(MemoryTest, ModuleNameWidenRejectsNamesWin32WouldTruncateOrReplace)
+{
+    static constexpr char EMBEDDED_NUL[] = "kernel32.dll\0ignored";
+    EXPECT_TRUE(
+        DetourModKit::detail::widen_module_name(std::string_view{EMBEDDED_NUL, sizeof(EMBEDDED_NUL) - 1}).empty());
+    EXPECT_FALSE(memory::is_module_loaded(std::string_view{EMBEDDED_NUL, sizeof(EMBEDDED_NUL) - 1}));
+    EXPECT_EQ(Region::module_named(std::string_view{EMBEDDED_NUL, sizeof(EMBEDDED_NUL) - 1}).size, 0u);
+
+    static constexpr char INVALID_UTF8[] = {'k', static_cast<char>(0xFF), 'x'};
+    EXPECT_TRUE(DetourModKit::detail::widen_module_name(std::string_view{INVALID_UTF8, sizeof(INVALID_UTF8)}).empty());
 }
 
 // write_bytes' slow path across a protection seam restores EACH region to its own prior protection: a patch straddling


### PR DESCRIPTION
## Summary

Closes the remaining narrow utility and ownership contracts (PR-25).

- Routes both module-name widen sites (`region.cpp`, `memory_module.cpp`) through one shared bounded seam in `src/internal/module_name.hpp` that rejects over-INT_MAX, embedded-NUL, and malformed UTF-8 names before any Win32 call.
- Escapes record delimiters and backslashes in persisted drift manifest names on write and fails closed on truncated or unknown escapes on read, so every name round-trips exactly.
- Adds an exact `format_hex(long)` overload for the Win32 LONG family (HRESULT, LONG, LSTATUS) with negatives matching the int contract; the full Win32 signed typedef matrix resolves unambiguously.
- Corrects the filesystem docs: resolution and conversion are cached, but each call returns an owning copy that may allocate; the ownership contract is pinned by static_assert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hexadecimal formatting support for `long` values, including optional zero-padding and consistent Windows-compatible output.
  - Drift report names now safely preserve tabs, line breaks, carriage returns, and backslashes during serialization.

- **Bug Fixes**
  - Drift report parsing now rejects truncated or unknown escape sequences.
  - Improved handling of invalid UTF-8, embedded null characters, and oversized module names.
  - Clarified that runtime directory results are owning copies and may allocate.

- **Documentation**
  - Updated formatting, filesystem, and drift report behavior descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->