### PR TITLE
feat(scan): fail-closed invalid enum rejection at direct scan boundaries

### DIFF
--- a/include/DetourModKit/scan.hpp
+++ b/include/DetourModKit/scan.hpp
@@ -403,7 +403,9 @@ namespace DetourModKit::scan
      *          reported as @ref ErrorCode::IncompleteScan whatever the phase found, because a sweep that never read
      *          part of the image can neither call the literal absent nor call it unique. StringAmbiguous and
      *          AmbiguousReference are reserved for a second copy or a second reference actually observed. Text that
-     *          cannot be encoded as asked returns @ref ErrorCode::MalformedQueryText.
+     *          cannot be encoded as asked returns @ref ErrorCode::MalformedQueryText. An out-of-range
+     *          @ref StringRefQuery::encoding or @ref StringRefQuery::return_mode returns @ref ErrorCode::InvalidArg
+     *          before either phase starts.
      * @note @p query.text's own storage is excluded from phase 1 whenever it lies inside @p scope, so passing a pointer
      *       into the scanned image locates the image's OTHER copy instead of reporting the query as its own answer. The
      *       consequence to know: if the caller's buffer is the only copy in scope (a literal the linker pooled with the
@@ -763,8 +765,9 @@ namespace DetourModKit::scan
      *          resolve; if the selected site loses executable protection before decoding, or its decoded instruction
      *          crosses into a non-executable page, it returns DecodeFailed. A site that no longer decodes
      *          (DecodeFailed), whose operand is the wrong kind (UnexpectedShape), or whose operand index is out of
-     *          range (OperandOutOfRange) also returns a typed error rather than a guess. A RIP-relative memory operand
-     *          is resolved to its absolute target.
+     *          range (OperandOutOfRange) also returns a typed error rather than a guess. An out-of-range
+     *          @ref CodeConstant::kind returns @ref ErrorCode::InvalidArg before site resolution. A RIP-relative memory
+     *          operand is resolved to its absolute target.
      * @note Not noexcept: resolving the site allocates. Setup/control-plane only.
      */
     [[nodiscard]] Result<std::int64_t> read_code_constant(const CodeConstant &code_constant,
@@ -1005,9 +1008,11 @@ namespace DetourModKit::scan
      * @param ladder The candidate ladder to order.
      * @param out Destination for the permutation; receives up to min(ladder.size(), out.size()) indices.
      * @return The number of indices written.
-     * @details Pure index math, no allocation: it emits an ordering, never touches the candidates. AsDeclared is the
-     *          identity permutation. UniqueFirst is a stable three-pass partition (unique-only text tiers, then
-     *          anchored byte patterns, then the rest), declared order preserved within each group.
+     * @details Pure index math, no allocation. UniqueFirst is a stable three-pass partition (unique-only text tiers,
+     *          then anchored byte patterns, then the rest), declared order preserved within each group. Every other
+     *          value, including an out-of-range one, yields the identity permutation, so a mis-declared order can never
+     *          select the UniqueFirst promotion; the fallible @ref resolve boundary rejects it with
+     *          @ref ErrorCode::InvalidArg.
      * @note Callback-safe: pure index math, noexcept, no allocation.
      */
     [[nodiscard]] std::size_t order_candidates(CandidateOrder order, std::span<const Candidate> ladder,
@@ -1031,8 +1036,10 @@ namespace DetourModKit::scan
      *          @ref ErrorCode::IncompleteScan from its own readable sweep) does not preempt recovery, but is reported
      *          in place of the generic miss when nothing resolves. An unconfined Pages::Readable scope that declares
      *          no @ref ScanRequest::exclusions refuses the whole request with @ref ErrorCode::NotAuthoritative before
-     *          any candidate is graded. May allocate, so it is NOT noexcept; the only throwing path is allocation
-     *          failure.
+     *          any candidate is graded. An out-of-range @ref ScanRequest::pages, @ref ScanRequest::order,
+     *          @ref ScanRequest::fallback_policy, or StringXref candidate encoding/return mode fails closed with
+     *          @ref ErrorCode::InvalidArg rather than selecting a permissive default. May allocate, so it is NOT
+     *          noexcept; the only throwing path is allocation failure.
      * @note Setup/control-plane only: a cascade resolve walks the image and is a startup-time operation.
      */
     [[nodiscard]] Result<Hit> resolve(const ScanRequest &request);
@@ -1073,7 +1080,8 @@ namespace DetourModKit::scan
      *          means the whole scope was traversed and the pattern is not in it. @ref ErrorCode::IncompleteScan means a
      *          region faulted mid-scan (a concurrent decommit or reprotect) and was skipped, so the pattern may live in
      *          bytes that were never read. @ref ErrorCode::BudgetExceeded means a bounded-jump pattern spent its
-     *          backtracking budget before the traversal was exhaustive. Neither truncation is reported as a miss.
+     *          backtracking budget before the traversal was exhaustive. Neither truncation is reported as a miss. An
+     *          out-of-range @p pages value returns @ref ErrorCode::InvalidArg before the sweep starts.
      *
      *          @ref ErrorCode::NotAuthoritative is returned for a @ref Pages::Readable scan whose scope is not confined
      *          to one mapped image or one reserved allocation and that declared no exclusions. Such a scope includes

--- a/src/anchor.cpp
+++ b/src/anchor.cpp
@@ -78,30 +78,42 @@ namespace DetourModKit
             }
 
             // Fail-closed range checks for the anchor's per-kind safety enums. A caller can build an Anchor with an
-            // out-of-range enum (static_cast<Enum>(0xFF) into a designated-initializer table); left unchecked it would
-            // fall through the scan backends' two-way tests to a permissive default -- byte-verbatim encoding, the
-            // displacement operand, the reference-instruction return, the tolerance vote. Each kind validates the enum
-            // it consumes and fails closed instead, so an invalid enum can never silently select a resolution mode.
+            // out-of-range enum (static_cast<Enum>(0xFF) into a designated-initializer table). Each kind validates the
+            // enums it consumes and fails closed at this boundary: the anchor contract reports AnchorStatus::Failed
+            // rather than relaying the scan backends' own InvalidArg rejection, declared_domain must classify the same
+            // declarations without resolving anything, and QuorumMatch is consumed only by the local quorum vote, so an
+            // invalid enum can never silently select a resolution mode.
             [[nodiscard]] constexpr bool valid_operand_kind(scan::OperandKind kind) noexcept
             {
-                return static_cast<std::uint8_t>(kind) <=
-                       static_cast<std::uint8_t>(scan::OperandKind::MemoryDisplacement);
+                return kind == scan::OperandKind::Immediate || kind == scan::OperandKind::MemoryDisplacement;
             }
 
             [[nodiscard]] constexpr bool valid_string_encoding(scan::StringEncoding encoding) noexcept
             {
-                return static_cast<std::uint8_t>(encoding) <= static_cast<std::uint8_t>(scan::StringEncoding::Utf16le);
+                return encoding == scan::StringEncoding::Utf8 || encoding == scan::StringEncoding::Utf16le;
             }
 
             [[nodiscard]] constexpr bool valid_xref_return(scan::XrefReturn mode) noexcept
             {
-                return static_cast<std::uint8_t>(mode) <=
-                       static_cast<std::uint8_t>(scan::XrefReturn::StringPointerSlot);
+                switch (mode)
+                {
+                case scan::XrefReturn::ReferencingInstruction:
+                case scan::XrefReturn::EnclosingFunction:
+                case scan::XrefReturn::StringPointerSlot:
+                    return true;
+                }
+                return false;
             }
 
             [[nodiscard]] constexpr bool valid_quorum_match(QuorumMatch match) noexcept
             {
-                return static_cast<std::uint8_t>(match) <= static_cast<std::uint8_t>(QuorumMatch::WithinTolerance);
+                return match == QuorumMatch::ExactValue || match == QuorumMatch::WithinTolerance;
+            }
+
+            // CodeOperand consumes the order locally; RipGlobal delegates validation to scan::resolve.
+            [[nodiscard]] constexpr bool valid_candidate_order(scan::CandidateOrder order) noexcept
+            {
+                return order == scan::CandidateOrder::AsDeclared || order == scan::CandidateOrder::UniqueFirst;
             }
 
             // The canonical independence-evidence atoms, defined below with the other fingerprint machinery. Declared
@@ -697,7 +709,7 @@ namespace DetourModKit
             }
             case AnchorKind::CodeOperand:
             {
-                if (!valid_operand_kind(anchor.operand_kind))
+                if (!valid_operand_kind(anchor.operand_kind) || !valid_candidate_order(profile.candidate_order))
                 {
                     result.status = AnchorStatus::Failed;
                     break;

--- a/src/internal/scan_shared.hpp
+++ b/src/internal/scan_shared.hpp
@@ -134,6 +134,25 @@ namespace DetourModKit
             return engine_pattern_from(pattern, anchor);
         }
 
+        // Exact-membership validity checks for the string-xref facet enums, shared by the direct find_string_xref
+        // boundary and resolve()'s whole-ladder prepass so both fail closed on the same vocabulary.
+        [[nodiscard]] inline constexpr bool valid_string_encoding(scan::StringEncoding encoding) noexcept
+        {
+            return encoding == scan::StringEncoding::Utf8 || encoding == scan::StringEncoding::Utf16le;
+        }
+
+        [[nodiscard]] inline constexpr bool valid_xref_return(scan::XrefReturn mode) noexcept
+        {
+            switch (mode)
+            {
+            case scan::XrefReturn::ReferencingInstruction:
+            case scan::XrefReturn::EnclosingFunction:
+            case scan::XrefReturn::StringPointerSlot:
+                return true;
+            }
+            return false;
+        }
+
         /**
          * @brief Resolves a string xref while honouring an exclusion set the caller already assembled.
          * @param query String literal and reference-selection facets.

--- a/src/scan_candidates.cpp
+++ b/src/scan_candidates.cpp
@@ -20,7 +20,9 @@ namespace DetourModKit
                                      std::span<std::size_t> out) noexcept
         {
             const std::size_t count = std::min(ladder.size(), out.size());
-            if (order == CandidateOrder::AsDeclared)
+            // This noexcept helper cannot report InvalidArg, so an unknown value preserves declaration order and never
+            // selects the UniqueFirst promotion.
+            if (order != CandidateOrder::UniqueFirst)
             {
                 for (std::size_t i = 0; i < count; ++i)
                 {

--- a/src/scan_code_constant.cpp
+++ b/src/scan_code_constant.cpp
@@ -46,6 +46,11 @@ namespace DetourModKit
 
         Result<std::int64_t> read_code_constant(const CodeConstant &code_constant, Region scope)
         {
+            if (code_constant.kind != OperandKind::Immediate && code_constant.kind != OperandKind::MemoryDisplacement)
+            {
+                return std::unexpected(Error{ErrorCode::InvalidArg, "scan::read_code_constant"});
+            }
+
             // Resolve the instruction site through the candidate ladder and propagate its typed failure verbatim
             // (EmptyCandidates, NoMatch, InvalidRange, ...). The resolved address must name an executable instruction
             // site; require_executable_result rejects an unsuitable rung and lets resolve() try a later ladder

--- a/src/scan_resolution.cpp
+++ b/src/scan_resolution.cpp
@@ -54,6 +54,30 @@ namespace DetourModKit
                 return !request.require_executable_result || detail::is_executable_address(address.raw());
             }
 
+            [[nodiscard]] constexpr bool valid_candidate_order(CandidateOrder order) noexcept
+            {
+                return order == CandidateOrder::AsDeclared || order == CandidateOrder::UniqueFirst;
+            }
+
+            [[nodiscard]] constexpr bool valid_fallback_policy(FallbackPolicy policy) noexcept
+            {
+                switch (policy)
+                {
+                case FallbackPolicy::Off:
+                case FallbackPolicy::WarnOnly:
+                case FallbackPolicy::RequireIdentity:
+                    return true;
+                }
+                return false;
+            }
+
+            [[nodiscard]] bool valid_candidate_enums(const Candidate &candidate) noexcept
+            {
+                const StringXref *xref = candidate.as_string_xref();
+                return xref == nullptr ||
+                       (detail::valid_string_encoding(xref->encoding) && detail::valid_xref_return(xref->return_mode));
+            }
+
             // Resolve a byte-tier candidate's match to its final address: a Direct walk-back, or a RipRelative disp32
             // read. Both screen the result through the plausible-userspace floor (in the shared helpers), so a faulted
             // read or a crafted displacement is a miss, never a hit at a near-null or kernel-range address.
@@ -149,13 +173,24 @@ namespace DetourModKit
 
         Result<Hit> resolve(const ScanRequest &request)
         {
-            if (request.ladder.empty())
-            {
-                return std::unexpected(Error{ErrorCode::EmptyCandidates, "scan::resolve"});
-            }
             if (request.pages != Pages::Readable && request.pages != Pages::Executable)
             {
                 return std::unexpected(Error{ErrorCode::InvalidArg, "scan::resolve"});
+            }
+            if (!valid_candidate_order(request.order) || !valid_fallback_policy(request.fallback_policy))
+            {
+                return std::unexpected(Error{ErrorCode::InvalidArg, "scan::resolve"});
+            }
+            for (const Candidate &candidate : request.ladder)
+            {
+                if (!valid_candidate_enums(candidate))
+                {
+                    return std::unexpected(Error{ErrorCode::InvalidArg, "scan::resolve"});
+                }
+            }
+            if (request.ladder.empty())
+            {
+                return std::unexpected(Error{ErrorCode::EmptyCandidates, "scan::resolve"});
             }
             const detail::ModuleSpan range = detail::module_span(request.scope);
             if (!range.valid())

--- a/src/scan_string_xref.cpp
+++ b/src/scan_string_xref.cpp
@@ -1189,6 +1189,10 @@ namespace DetourModKit
                                                 const detail::ScanExclusions *provided_exclusions,
                                                 std::span<const Region> declared_exclusions)
             {
+                if (!detail::valid_string_encoding(query.encoding) || !detail::valid_xref_return(query.return_mode))
+                {
+                    return std::unexpected(Error{ErrorCode::InvalidArg, "scan::find_string_xref"});
+                }
                 if (query.text.empty())
                 {
                     return std::unexpected(Error{ErrorCode::EmptyQuery, "scan::find_string_xref"});

--- a/tests/test_anchor.cpp
+++ b/tests/test_anchor.cpp
@@ -2255,9 +2255,11 @@ TEST(PolicyDomainTest, InvalidEnumsFailClosedEverywhere)
     EXPECT_EQ(an::resolve(bad_kind, page.range()).status, an::AnchorStatus::Failed);
     EXPECT_EQ(an::declared_domain(bad_kind), an::ResultDomain::Unknown);
 
-    // CodeOperand: the site must carry a MEMORY operand so the test discriminates the guard. With the guard removed an
-    // invalid kind falls through to the MemoryDisplacement branch and would RESOLVE the displacement; an immediate-only
-    // site would instead fail closed for an unrelated operand-shape mismatch and prove nothing about the guard.
+    // CodeOperand: the resolve EXPECT pins the layered fail-closed chain rather than the anchor-local validator alone.
+    // With the anchor guard removed the invalid kind reaches scan::read_code_constant, whose own boundary rejection
+    // maps back to the same Failed (ResolvedAnchor carries no error code), so the anchor-local validator itself is
+    // discriminated by the declared_domain EXPECT, which classifies the declaration without resolving. The memory
+    // operand keeps the positive control meaningful and feeds the candidate-order EXPECTs below.
     page.put(0x100, {0x8A, 0x45, 0xFF}); // mov al, byte [rbp-0x01]
     const sc::Candidate disp_site[] = {sc::Candidate::direct("disp8", aob("8A 45 FF"))};
     an::Anchor code_control{};
@@ -2313,6 +2315,22 @@ TEST(PolicyDomainTest, InvalidEnumsFailClosedEverywhere)
     bad_match.quorum_match = static_cast<an::QuorumMatch>(0xFF);
     EXPECT_EQ(an::resolve(bad_match, imm_page.range()).status, an::AnchorStatus::Failed);
     EXPECT_EQ(an::declared_domain(bad_match), an::ResultDomain::Unknown);
+
+    // Candidate order: two distinct guards. RipGlobal forwards the profile order into ScanRequest::order, so its
+    // EXPECT pins scan::resolve's boundary check; CodeOperand orders its ladder locally before read_code_constant
+    // (which has no order parameter), so its EXPECT pins the anchor-local check.
+    const sc::Candidate rip_site[] = {sc::Candidate::direct("byte", aob("8A 45 FF"))};
+    an::Anchor rip_control{};
+    rip_control.kind = an::AnchorKind::RipGlobal;
+    rip_control.site = rip_site;
+    an::ScanProfile bad_order_profile{};
+    bad_order_profile.candidate_order = static_cast<sc::CandidateOrder>(0xFF);
+    ASSERT_EQ(an::resolve_with_profile(rip_control, an::ScanProfile{}, page.range()).status,
+              an::AnchorStatus::Resolved);
+    EXPECT_EQ(an::resolve_with_profile(rip_control, bad_order_profile, page.range()).status, an::AnchorStatus::Failed);
+    ASSERT_EQ(an::resolve_with_profile(code_control, an::ScanProfile{}, page.range()).status,
+              an::AnchorStatus::Resolved);
+    EXPECT_EQ(an::resolve_with_profile(code_control, bad_order_profile, page.range()).status, an::AnchorStatus::Failed);
 }
 
 // declared_domain maps each kind to the ResultDomain a consumer binding must accept.

--- a/tests/test_code_constant.cpp
+++ b/tests/test_code_constant.cpp
@@ -181,6 +181,36 @@ TEST(CodeConstantTest, ReadsMemoryDisplacement)
     EXPECT_EQ(*value, 0x218);
 }
 
+TEST(CodeConstantTest, InvalidOperandKindReturnsInvalidArg)
+{
+    CodeRegion region;
+    ASSERT_TRUE(region.ok());
+    region.put(0x100, {0x8A, 0x45, 0xFF}); // mov al, byte [rbp-0x01]
+
+    const scan::Candidate candidates[] = {scan::Candidate::direct("disp8", aob("8A 45 FF"))};
+    scan::CodeConstant code_constant{};
+    code_constant.site = candidates;
+    code_constant.kind = scan::OperandKind::MemoryDisplacement;
+    code_constant.operand_index = 1;
+    code_constant.byte_width = 1;
+
+    const auto control = scan::read_code_constant(code_constant, region.range());
+    ASSERT_TRUE(control.has_value());
+    EXPECT_EQ(*control, -1);
+
+    code_constant.kind = static_cast<scan::OperandKind>(0xFF);
+    const auto invalid = scan::read_code_constant(code_constant, region.range());
+    ASSERT_FALSE(invalid.has_value());
+    EXPECT_EQ(invalid.error().code, ErrorCode::InvalidArg);
+
+    // The guard precedes site resolution: an absent site cannot downgrade the invalid kind to a routine NoMatch miss.
+    const scan::Candidate absent[] = {scan::Candidate::direct("absent", aob("11 22 33 44 55 66 77 88"))};
+    code_constant.site = absent;
+    const auto absent_invalid = scan::read_code_constant(code_constant, region.range());
+    ASSERT_FALSE(absent_invalid.has_value());
+    EXPECT_EQ(absent_invalid.error().code, ErrorCode::InvalidArg);
+}
+
 TEST(CodeConstantTest, ReadsNegativeDisp8WithNarrowing)
 {
     CodeRegion region;

--- a/tests/test_scan_resolve.cpp
+++ b/tests/test_scan_resolve.cpp
@@ -549,6 +549,75 @@ TEST(ScanResolve, CandidateOrderChangesTheWinner)
     EXPECT_EQ(unique_first->address.raw(), buffer.address_of(0x100));
 }
 
+TEST(ScanResolve, InvalidEnumValuesCannotNormalizePermissively)
+{
+    ReadableBuffer buffer(0x400);
+    buffer.put(0x100, {0xDE, 0xAD, 0xBE, 0xEF});
+    const std::array<Candidate, 1> ladder = {Candidate::direct("marker", scan::Pattern::literal("DE AD BE EF"))};
+
+    const auto valid = scan::resolve(scan::ScanRequest{.ladder = ladder, .scope = buffer.region()});
+    ASSERT_TRUE(valid.has_value());
+    EXPECT_EQ(valid->address.raw(), buffer.address_of(0x100));
+
+    const auto bad_order = scan::resolve(scan::ScanRequest{
+        .ladder = ladder, .scope = buffer.region(), .order = static_cast<scan::CandidateOrder>(0xFF)});
+    ASSERT_FALSE(bad_order.has_value());
+    EXPECT_EQ(bad_order.error().code, ErrorCode::InvalidArg);
+
+    const auto bad_fallback = scan::resolve(scan::ScanRequest{
+        .ladder = ladder, .scope = buffer.region(), .fallback_policy = static_cast<scan::FallbackPolicy>(0xFF)});
+    ASSERT_FALSE(bad_fallback.has_value());
+    EXPECT_EQ(bad_fallback.error().code, ErrorCode::InvalidArg);
+
+    scan::StringRefQuery invalid_xref{.text = "literal"};
+    invalid_xref.encoding = static_cast<scan::StringEncoding>(0xFF);
+    const std::array<Candidate, 2> bad_encoding_ladder = {
+        Candidate::direct("fallback", scan::Pattern::literal("DE AD BE EF")),
+        Candidate::string_xref("invalid-encoding", invalid_xref),
+    };
+    const auto bad_encoding = scan::resolve(scan::ScanRequest{.ladder = bad_encoding_ladder, .scope = buffer.region()});
+    ASSERT_FALSE(bad_encoding.has_value());
+    EXPECT_EQ(bad_encoding.error().code, ErrorCode::InvalidArg);
+
+    invalid_xref.encoding = scan::StringEncoding::Utf8;
+    invalid_xref.return_mode = static_cast<scan::XrefReturn>(0xFF);
+    const std::array<Candidate, 2> bad_return_ladder = {
+        Candidate::direct("fallback", scan::Pattern::literal("DE AD BE EF")),
+        Candidate::string_xref("invalid-return", invalid_xref),
+    };
+    const auto bad_return = scan::resolve(scan::ScanRequest{.ladder = bad_return_ladder, .scope = buffer.region()});
+    ASSERT_FALSE(bad_return.has_value());
+    EXPECT_EQ(bad_return.error().code, ErrorCode::InvalidArg);
+
+    // A malformed request outranks an empty one: the policy-enum checks run before the EmptyCandidates verdict, so an
+    // empty ladder cannot downgrade an invalid enum to a routine missing-candidates miss.
+    const auto empty_invalid = scan::resolve(
+        scan::ScanRequest{.ladder = {}, .scope = buffer.region(), .order = static_cast<scan::CandidateOrder>(0xFF)});
+    ASSERT_FALSE(empty_invalid.has_value());
+    EXPECT_EQ(empty_invalid.error().code, ErrorCode::InvalidArg);
+
+    const std::array<scan::ScanRequest, 2> requests = {
+        scan::ScanRequest{.ladder = ladder, .scope = buffer.region()},
+        scan::ScanRequest{.ladder = ladder, .scope = buffer.region(), .order = static_cast<scan::CandidateOrder>(0xFF)},
+    };
+    const auto batch = scan::resolve_batch(requests);
+    ASSERT_TRUE(batch.has_value());
+    ASSERT_EQ(batch->size(), 2U);
+    EXPECT_TRUE((*batch)[0].has_value());
+    ASSERT_FALSE((*batch)[1].has_value());
+    EXPECT_EQ((*batch)[1].error().code, ErrorCode::InvalidArg);
+
+    const std::array<Candidate, 2> mixed = {
+        Candidate::direct("byte", scan::Pattern::literal("DE AD BE EF")),
+        Candidate::string_xref("xref", "literal"),
+    };
+    std::array<std::size_t, 2> out{};
+    const std::size_t count = scan::order_candidates(static_cast<scan::CandidateOrder>(0xFF), mixed, out);
+    ASSERT_EQ(count, 2U);
+    EXPECT_EQ(out[0], 0U);
+    EXPECT_EQ(out[1], 1U);
+}
+
 TEST(ScanResolve, OrNullAndAddressOrFlatten)
 {
     const Result<scan::Hit> ok = scan::Hit{Address{0x1234}, "n"};

--- a/tests/test_string_xref.cpp
+++ b/tests/test_string_xref.cpp
@@ -558,6 +558,47 @@ TEST(StringXrefTest, ResolvesUniqueLeaReference)
     EXPECT_EQ(result->raw(), img.addr(0x10));
 }
 
+TEST(StringXrefTest, InvalidEnumsReturnInvalidArg)
+{
+    SyntheticImage img;
+    if (!img.ok())
+    {
+        GTEST_SKIP() << "could not allocate a synthetic image page";
+    }
+    const char str[] = "InvalidEnumAnchor";
+    img.write(0x100, str, sizeof(str));
+    img.plant_rip_load(0x10, 0x100, LEA);
+
+    scan::StringRefQuery query = utf8_query("InvalidEnumAnchor");
+    const auto control = scan::find_string_xref(query, img.range());
+    ASSERT_TRUE(control.has_value());
+    EXPECT_EQ(control->raw(), img.addr(0x10));
+
+    query.encoding = static_cast<scan::StringEncoding>(0xFF);
+    const auto invalid_encoding = scan::find_string_xref(query, img.range());
+    ASSERT_FALSE(invalid_encoding.has_value());
+    EXPECT_EQ(invalid_encoding.error().code, ErrorCode::InvalidArg);
+
+    query.encoding = scan::StringEncoding::Utf8;
+    query.return_mode = static_cast<scan::XrefReturn>(0xFF);
+    const auto invalid_return = scan::find_string_xref(query, img.range());
+    ASSERT_FALSE(invalid_return.has_value());
+    EXPECT_EQ(invalid_return.error().code, ErrorCode::InvalidArg);
+
+    // The guard precedes both phases: a literal absent from scope cannot downgrade an invalid enum to StringNotFound.
+    scan::StringRefQuery absent_query = utf8_query("AbsentInvalidEnumAnchor");
+    absent_query.encoding = static_cast<scan::StringEncoding>(0xFF);
+    const auto absent_encoding = scan::find_string_xref(absent_query, img.range());
+    ASSERT_FALSE(absent_encoding.has_value());
+    EXPECT_EQ(absent_encoding.error().code, ErrorCode::InvalidArg);
+
+    absent_query.encoding = scan::StringEncoding::Utf8;
+    absent_query.return_mode = static_cast<scan::XrefReturn>(0xFF);
+    const auto absent_return = scan::find_string_xref(absent_query, img.range());
+    ASSERT_FALSE(absent_return.has_value());
+    EXPECT_EQ(absent_return.error().code, ErrorCode::InvalidArg);
+}
+
 TEST(StringXrefTest, BorrowedQueryStorageInsideScopeIsExcluded)
 {
     SyntheticImage img;


### PR DESCRIPTION
## Summary

Closes the FN-41 scan-boundary leg (P1-02 item 6): invalid underlying values of scan safety enums now fail closed with `InvalidArg` at every direct public scan entry instead of selecting a permissive default.

- `scan::resolve` (and `resolve_batch` through it) rejects an out-of-range `CandidateOrder` or `FallbackPolicy` and pre-validates every StringXref rung's encoding and return mode across the whole ladder before grading any candidate; a malformed request outranks an empty one.
- `scan::read_code_constant` rejects an out-of-range `OperandKind` before site resolution.
- `scan::find_string_xref` rejects an out-of-range encoding or return mode on both entry points before either phase starts.
- `scan::order_candidates` maps every unknown order to the identity permutation so the noexcept helper can never silently promote; the anchor `CodeOperand` path fails closed on an invalid `ScanProfile::candidate_order`.
- Validity helpers use exact enumerator membership, shared in `internal/scan_shared.hpp` for the scan TUs; the anchor keeps its own boundary validators and reports `Failed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of scan, anchor, string-reference, and code-constant inputs.
  * Invalid or unsupported option values now fail safely with a clear invalid-argument error.
  * Prevented malformed requests from being processed or producing misleading results.
  * Clarified behavior when candidate ordering, fallback policies, and scan ranges are invalid.

* **Documentation**
  * Expanded API documentation describing validation and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->