### PR TITLE
fix(ci): backend-patch CRLF hash, clang-format, and clang-tidy warnings

### DIFF
--- a/include/DetourModKit/detail/event_dispatcher.hpp
+++ b/include/DetourModKit/detail/event_dispatcher.hpp
@@ -697,8 +697,8 @@ namespace DetourModKit
             {
                 std::scoped_lock lock{this->m_writer_mutex};
                 auto current = this->m_handlers.load(std::memory_order_acquire);
-                auto it = std::find_if(current->begin(), current->end(),
-                                       [id](const Entry &entry) { return entry.id == id; });
+                auto it =
+                    std::find_if(current->begin(), current->end(), [id](const Entry &entry) { return entry.id == id; });
                 if (it == current->end())
                 {
                     return;

--- a/scripts/check_backend_patch.py
+++ b/scripts/check_backend_patch.py
@@ -40,7 +40,7 @@ UPSTREAM_URL_RE = re.compile(r"^(?:https?://|ssh://git@|git://|git@)github\.com[
 # SHA-256 over the patch set (each file's name, a NUL, then its bytes, in sorted order). This freezes the vendored
 # delta to the exact reviewed content: an edit that keeps a fix marker but inverts the logic still changes this hash
 # and fails the gate. Regenerate ONLY alongside a deliberate backend re-pin, then update this value:
-#   python -c "import hashlib,pathlib; h=hashlib.sha256(); [ (h.update(p.name.encode()),h.update(b'\0'),h.update(p.read_bytes())) for p in sorted(pathlib.Path('cmake/safetyhook_patches').glob('*.patch')) ]; print(h.hexdigest())"
+#   python -c "import hashlib,pathlib; h=hashlib.sha256(); [ (h.update(p.name.encode()),h.update(b'\0'),h.update(p.read_bytes().replace(b'\r\n',b'\n'))) for p in sorted(pathlib.Path('cmake/safetyhook_patches').glob('*.patch')) ]; print(h.hexdigest())"
 EXPECTED_PATCH_SHA256 = "21d124c525a75393d152e072e97d8285787a958611812f5be02ba576f6d2995b"
 # The documented upstream base the patch reconstructs. Both the parent gitlink and the checked-out submodule HEAD
 # must equal this, so a silent re-pin is rejected even when the patch still reverse-applies against the drifted
@@ -67,7 +67,10 @@ def patchset_sha256(paths) -> str:
     for p in paths:
         h.update(p.name.encode("utf-8"))
         h.update(b"\0")
-        h.update(p.read_bytes())
+        # Normalize CRLF to LF so the hash is stable across checkouts that re-encode line endings: a Windows
+        # autocrlf checkout stores the patch as CRLF, which would otherwise hash differently in CI than the
+        # LF value pinned here.
+        h.update(p.read_bytes().replace(b"\r\n", b"\n"))
     return h.hexdigest()
 
 

--- a/scripts/test_check_backend_patch.py
+++ b/scripts/test_check_backend_patch.py
@@ -98,6 +98,18 @@ def test_patchset_sha256_stable_and_order_independent_input() -> None:
         assert MODULE.patchset_sha256(MODULE.patch_files(dp)) != first
 
 
+def test_patchset_sha256_is_line_ending_agnostic() -> None:
+    # A git checkout may store the patch CRLF (Windows autocrlf) or LF; the frozen hash must not change.
+    with tempfile.TemporaryDirectory() as d:
+        lf = Path(d) / "lf"
+        lf.mkdir()
+        (lf / "0001.patch").write_bytes(b"line one\nline two\n")
+        crlf = Path(d) / "crlf"
+        crlf.mkdir()
+        (crlf / "0001.patch").write_bytes(b"line one\r\nline two\r\n")
+        assert MODULE.patchset_sha256(MODULE.patch_files(lf)) == MODULE.patchset_sha256(MODULE.patch_files(crlf))
+
+
 def test_submodule_url_parsed_and_fork_detected() -> None:
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -704,7 +704,7 @@ namespace DetourModKit
             }
 #endif
             auto *surrogate_vptr = reinterpret_cast<std::uint8_t **>(backend_snapshot.data() + header_count);
-            auto created = safetyhook::VmtHook::create(&surrogate_vptr);
+            auto created = safetyhook::VmtHook::create(static_cast<void *>(&surrogate_vptr));
             if (!created)
             {
                 return std::unexpected(Error{ErrorCode::BackendFailed, "hook::vmt_for", vptr});
@@ -716,7 +716,7 @@ namespace DetourModKit
                         reinterpret_cast<std::uintptr_t *>(cloned_vptr_base));
             // Erase the stack surrogate from the backend before it leaves scope. Real host objects are published and
             // restored only through DMK's guarded swaps, so the backend never retains a foreign object pointer.
-            backend.remove(&surrogate_vptr);
+            backend.remove(static_cast<void *>(&surrogate_vptr));
             return DetachedVmtBackend{std::move(backend), cloned_vptr_base, cloned_slots};
         }
 
@@ -1380,6 +1380,9 @@ namespace DetourModKit
             return m_impl ? std::string_view{m_impl->name} : std::string_view{};
         }
 
+        // noexcept query: acquiring the call lock can in principle throw, but a lock failure here is an
+        // unrecoverable OS condition where terminate is the intended outcome.
+        // NOLINTNEXTLINE(bugprone-exception-escape)
         bool Hook::is_enabled() const noexcept
         {
             const std::shared_ptr<CallGate> gate = m_gate.load(std::memory_order_acquire);

--- a/src/internal/input_binding_lifecycle.hpp
+++ b/src/internal/input_binding_lifecycle.hpp
@@ -32,16 +32,10 @@ namespace DetourModKit::detail
         explicit BindingLifecycle(std::uint64_t initial_generation) noexcept : m_generation(initial_generation) {}
 
         /// Returns the generation to carry with a staged callback.
-        [[nodiscard]] std::uint64_t generation() const noexcept
-        {
-            return m_generation.load(std::memory_order_acquire);
-        }
+        [[nodiscard]] std::uint64_t generation() const noexcept { return m_generation.load(std::memory_order_acquire); }
 
         /// Returns whether removal permanently retired this registration.
-        [[nodiscard]] bool tombstoned() const noexcept
-        {
-            return m_tombstoned.load(std::memory_order_acquire);
-        }
+        [[nodiscard]] bool tombstoned() const noexcept { return m_tombstoned.load(std::memory_order_acquire); }
 
         /**
          * @brief Advances to the next generation and returns the retired generation.

--- a/src/internal/lifecycle_reaper.cpp
+++ b/src/internal/lifecycle_reaper.cpp
@@ -236,8 +236,11 @@ namespace DetourModKit::detail
         }
 
         // Retain the module reference if the running body cannot be queued for a safe off-thread join.
+        // enqueue consumes `parcel` only when it returns true; every false path above leaves it intact, and this
+        // fallback tolerates even a moved-from parcel (a null thread skips the detach below).
         try
         {
+            // NOLINTNEXTLINE(bugprone-use-after-move)
             if (parcel.thread != nullptr && parcel.thread->joinable())
             {
                 parcel.thread->detach();
@@ -279,6 +282,7 @@ namespace DetourModKit::detail
 
         // A failed enqueue leaves the parcel populated. Drop the reaper's copy -- never the last one, since the caller
         // still holds theirs -- and report the failure so the caller can abandon its own into permanent storage.
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         parcel.shared_owner.reset();
         return false;
     }

--- a/src/internal/mid_hook_adapter.hpp
+++ b/src/internal/mid_hook_adapter.hpp
@@ -232,8 +232,8 @@ namespace DetourModKit::detail
     }
 
     template <std::size_t... Indices>
-    [[nodiscard]] constexpr std::array<safetyhook::MidHookFn, sizeof...(Indices)> make_mid_adapter_table(
-        std::index_sequence<Indices...>) noexcept
+    [[nodiscard]] constexpr std::array<safetyhook::MidHookFn, sizeof...(Indices)>
+    make_mid_adapter_table(std::index_sequence<Indices...>) noexcept
     {
         // Dropping noexcept from each adapter pointer's type is a standard implicit conversion.
         return {&mid_adapter<Indices>...};

--- a/src/internal/scan_pages.cpp
+++ b/src/internal/scan_pages.cpp
@@ -151,16 +151,15 @@ namespace DetourModKit
                 ScanTally *tally;
                 bool *budget_exhausted;
                 bool cap_reached;
-            } scan_ctx{region_start, scan_size, &pattern, &exclusions,          count_floor,
-                       target,      cap,        &tally,   &out_budget_exhausted, false};
+            } scan_ctx{region_start, scan_size, &pattern, &exclusions,           count_floor,
+                       target,       cap,       &tally,   &out_budget_exhausted, false};
 
             const auto run_scan = [](void *opaque) noexcept -> void
             {
                 auto *context = static_cast<ScanContext *>(opaque);
-                context->cap_reached = scan_region_for_match(context->region_start, context->scan_size,
-                                                             *context->pattern, *context->exclusions,
-                                                             context->count_floor, context->target, context->cap,
-                                                             *context->tally, *context->budget_exhausted);
+                context->cap_reached = scan_region_for_match(
+                    context->region_start, context->scan_size, *context->pattern, *context->exclusions,
+                    context->count_floor, context->target, context->cap, *context->tally, *context->budget_exhausted);
             };
 
             const auto span_lo = reinterpret_cast<std::uintptr_t>(region_start);

--- a/src/internal/win_file_stream.cpp
+++ b/src/internal/win_file_stream.cpp
@@ -289,7 +289,7 @@ namespace DetourModKit::detail
         try
         {
             content.reserve(expected_size);
-            std::array<char, 64 * 1024> buffer{};
+            std::array<char, std::size_t{64} * 1024> buffer{};
             std::size_t total = 0;
             for (;;)
             {

--- a/src/manifest.cpp
+++ b/src/manifest.cpp
@@ -1562,13 +1562,14 @@ namespace DetourModKit::manifest
             // Reject ambiguous grammar and every encoded, structural, field, and aggregate excess before the backend
             // allocates its store.
             DMK_TRY_VOID(detail::validate_manifest_grammar(
-                text, detail::GrammarLimits{.max_file_bytes = limits.max_file_bytes,
-                                            .max_sections = limits.max_sections,
-                                            .max_keys_per_section = limits.max_keys_per_section,
-                                            .max_records = limits.max_records,
-                                            .max_rungs_per_record = limits.max_rungs_per_record,
-                                            .max_field_bytes = limits.max_field_bytes,
-                                            .max_total_decoded_bytes = limits.max_total_decoded_bytes},
+                text,
+                detail::GrammarLimits{.max_file_bytes = limits.max_file_bytes,
+                                      .max_sections = limits.max_sections,
+                                      .max_keys_per_section = limits.max_keys_per_section,
+                                      .max_records = limits.max_records,
+                                      .max_rungs_per_record = limits.max_rungs_per_record,
+                                      .max_field_bytes = limits.max_field_bytes,
+                                      .max_total_decoded_bytes = limits.max_total_decoded_bytes},
                 "manifest::parse"));
 
             ManifestIni ini;
@@ -1976,13 +1977,14 @@ namespace DetourModKit::manifest
             }
             // Re-run the reader's grammar over the emitted bytes so identity and framing checks cannot diverge.
             DMK_TRY_VOID(detail::validate_manifest_grammar(
-                out, detail::GrammarLimits{.max_file_bytes = limits.max_file_bytes,
-                                           .max_sections = limits.max_sections,
-                                           .max_keys_per_section = limits.max_keys_per_section,
-                                           .max_records = limits.max_records,
-                                           .max_rungs_per_record = limits.max_rungs_per_record,
-                                           .max_field_bytes = limits.max_field_bytes,
-                                           .max_total_decoded_bytes = limits.max_total_decoded_bytes},
+                out,
+                detail::GrammarLimits{.max_file_bytes = limits.max_file_bytes,
+                                      .max_sections = limits.max_sections,
+                                      .max_keys_per_section = limits.max_keys_per_section,
+                                      .max_records = limits.max_records,
+                                      .max_rungs_per_record = limits.max_rungs_per_record,
+                                      .max_field_bytes = limits.max_field_bytes,
+                                      .max_total_decoded_bytes = limits.max_total_decoded_bytes},
                 "manifest::serialize_checked"));
             return out;
         }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -102,10 +102,7 @@ namespace DetourModKit
             }
 
             [[nodiscard]] std::string_view name_view() const noexcept { return {name.data(), name_size}; }
-            [[nodiscard]] std::string_view log_file_view() const noexcept
-            {
-                return {log_file.data(), log_file_size};
-            }
+            [[nodiscard]] std::string_view log_file_view() const noexcept { return {log_file.data(), log_file_size}; }
 
             [[nodiscard]] AsyncLoggerConfig logger_config() const
             {
@@ -579,7 +576,7 @@ namespace DetourModKit
 
         // The allocation-free bootstrap core. Every failure occurs before the Session and callback are published.
         [[nodiscard]] Result<void> bootstrap_core(const ModInfo &info,
-                                                   std::move_only_function<Result<void>(Session &)> on_ready) noexcept
+                                                  std::move_only_function<Result<void>(Session &)> on_ready) noexcept
         {
             // Claim the slot before touching any other static. A drain nulls the worker handle and the shutdown event
             // early but publishes Drained only after it has also retired the init callback and the module identity, so

--- a/tests/bench_logger.cpp
+++ b/tests/bench_logger.cpp
@@ -71,7 +71,7 @@ int main()
     };
 
     std::printf("workload\tsamples\tp50_ns\tp99_ns\tp999_ns\tmax_ns\tdropped\n");
-    std::printf("enqueue_streaming\t%d\t%lld\t%lld\t%lld\t%lld\t%zu\n", SAMPLES, percentile(0.50),
-                percentile(0.99), percentile(0.999), latencies.back(), dropped);
+    std::printf("enqueue_streaming\t%d\t%lld\t%lld\t%lld\t%lld\t%zu\n", SAMPLES, percentile(0.50), percentile(0.99),
+                percentile(0.999), latencies.back(), dropped);
     return 0;
 }

--- a/tests/lifecycle/bootstrap_probe_dll.cpp
+++ b/tests/lifecycle/bootstrap_probe_dll.cpp
@@ -193,8 +193,7 @@ BOOL WINAPI DllMain(HINSTANCE, DWORD reason, LPVOID reserved)
         info.name = "DMKBootstrapProbe";
         info.log_file = "dmk_bootstrap_probe.log";
         std::move_only_function<DetourModKit::Result<void>(DetourModKit::Session &)> on_ready{
-            [retained_capture = RetainedCapture{}](
-                DetourModKit::Session &) mutable -> DetourModKit::Result<void>
+            [retained_capture = RetainedCapture{}](DetourModKit::Session &) mutable -> DetourModKit::Result<void>
             {
                 const bool capture_armed = retained_capture.arm();
                 // The bare-FreeLibrary scenario creates this named event before loading the DLL. Waiting here keeps

--- a/tests/lifecycle/logger_first_use_oom.cpp
+++ b/tests/lifecycle/logger_first_use_oom.cpp
@@ -91,8 +91,8 @@ namespace
 
     int run_concurrent_oom_case()
     {
-        using DetourModKit::LogLevel;
         using DetourModKit::Logger;
+        using DetourModKit::LogLevel;
 
         constexpr std::size_t THREAD_COUNT = 4;
         std::array<std::thread, THREAD_COUNT> threads;

--- a/tests/lifecycle/test_bootstrap_module_ref.cpp
+++ b/tests/lifecycle/test_bootstrap_module_ref.cpp
@@ -205,14 +205,14 @@ namespace
             std::fprintf(stderr, "FAIL[leaf]: LoadLibraryW failed (error %lu)\n", GetLastError());
             return 2;
         }
-        const auto attach_allocations = reinterpret_cast<AttachAllocationsFn>(
-            resolve_required(dll, "dmk_probe_attach_allocations", "leaf"));
+        const auto attach_allocations =
+            reinterpret_cast<AttachAllocationsFn>(resolve_required(dll, "dmk_probe_attach_allocations", "leaf"));
         if (attach_allocations == nullptr)
         {
             return 2;
         }
-        const auto selftest_allocations = reinterpret_cast<AttachAllocationsFn>(
-            resolve_required(dll, "dmk_probe_selftest_allocations", "leaf"));
+        const auto selftest_allocations =
+            reinterpret_cast<AttachAllocationsFn>(resolve_required(dll, "dmk_probe_selftest_allocations", "leaf"));
         if (selftest_allocations == nullptr)
         {
             return 2;

--- a/tests/lifecycle/test_config_servicer_self_retire.cpp
+++ b/tests/lifecycle/test_config_servicer_self_retire.cpp
@@ -108,8 +108,8 @@ int main()
         }
     }
 
-    const std::size_t leaks_before = DetourModKit::diagnostics::intentional_leak_count(
-        DetourModKit::diagnostics::LeakSubsystem::Worker);
+    const std::size_t leaks_before =
+        DetourModKit::diagnostics::intentional_leak_count(DetourModKit::diagnostics::LeakSubsystem::Worker);
     armed.store(true, std::memory_order_release);
     if (!DetourModKit::detail::request_servicer_reload_for_test())
     {

--- a/tests/lifecycle/test_full_lifecycle.cpp
+++ b/tests/lifecycle/test_full_lifecycle.cpp
@@ -278,8 +278,7 @@ namespace
             auto on_ready = [subsystems_ok, ini_observer, ready, cycle](Session &session) -> Result<void>
             {
                 const std::shared_ptr<ScratchIni> active_ini = ini_observer.lock();
-                const bool ok = active_ini != nullptr &&
-                                use_every_subsystem("cycles", session, *active_ini, cycle);
+                const bool ok = active_ini != nullptr && use_every_subsystem("cycles", session, *active_ini, cycle);
                 subsystems_ok->store(ok, std::memory_order_release);
                 ready->signal();
                 return ok ? Result<void>{} : std::unexpected(Error{ErrorCode::Unknown, "cycles"});

--- a/tests/lifecycle/test_input_gate_abba.cpp
+++ b/tests/lifecycle/test_input_gate_abba.cpp
@@ -67,40 +67,40 @@ int main()
         std::atomic<bool> a_in_callback{false};
         std::atomic<bool> b_in_callback{false};
 
-        auto result_a = manager.register_combo(make_hold_binding(
-            "abba_a", KEY_A,
-            [&](bool active)
-            {
-                if (active)
-                {
-                    a_true.fetch_add(1, std::memory_order_relaxed);
-                    return;
-                }
-                a_false.fetch_add(1, std::memory_order_relaxed);
-                a_in_callback.store(true, std::memory_order_release);
-                while (!b_in_callback.load(std::memory_order_acquire))
-                {
-                    std::this_thread::yield();
-                }
-                guard_b.release();
-            }));
-        auto result_b = manager.register_combo(make_hold_binding(
-            "abba_b", KEY_B,
-            [&](bool active)
-            {
-                if (active)
-                {
-                    b_true.fetch_add(1, std::memory_order_relaxed);
-                    return;
-                }
-                b_false.fetch_add(1, std::memory_order_relaxed);
-                b_in_callback.store(true, std::memory_order_release);
-                while (!a_in_callback.load(std::memory_order_acquire))
-                {
-                    std::this_thread::yield();
-                }
-                guard_a.release();
-            }));
+        auto result_a =
+            manager.register_combo(make_hold_binding("abba_a", KEY_A,
+                                                     [&](bool active)
+                                                     {
+                                                         if (active)
+                                                         {
+                                                             a_true.fetch_add(1, std::memory_order_relaxed);
+                                                             return;
+                                                         }
+                                                         a_false.fetch_add(1, std::memory_order_relaxed);
+                                                         a_in_callback.store(true, std::memory_order_release);
+                                                         while (!b_in_callback.load(std::memory_order_acquire))
+                                                         {
+                                                             std::this_thread::yield();
+                                                         }
+                                                         guard_b.release();
+                                                     }));
+        auto result_b =
+            manager.register_combo(make_hold_binding("abba_b", KEY_B,
+                                                     [&](bool active)
+                                                     {
+                                                         if (active)
+                                                         {
+                                                             b_true.fetch_add(1, std::memory_order_relaxed);
+                                                             return;
+                                                         }
+                                                         b_false.fetch_add(1, std::memory_order_relaxed);
+                                                         b_in_callback.store(true, std::memory_order_release);
+                                                         while (!a_in_callback.load(std::memory_order_acquire))
+                                                         {
+                                                             std::this_thread::yield();
+                                                         }
+                                                         guard_a.release();
+                                                     }));
         if (!result_a || !result_b)
         {
             std::puts("FAIL: registration");
@@ -111,8 +111,8 @@ int main()
 
         if (!manager.is_running())
         {
-            const auto started = manager.start(input::Input::Settings{.poll_interval = std::chrono::milliseconds{1},
-                                                                       .require_focus = false});
+            const auto started = manager.start(
+                input::Input::Settings{.poll_interval = std::chrono::milliseconds{1}, .require_focus = false});
             if (!started)
             {
                 std::puts("FAIL: start");

--- a/tests/test_alloc_probe.hpp
+++ b/tests/test_alloc_probe.hpp
@@ -65,14 +65,14 @@ namespace dmk_test
 // MSVC's debug STL allocates hidden container proxies inside noexcept constructors, so exact-budget OOM injection is
 // supported only by libstdc++ and the MSVC release STL. The out-of-line runtime query keeps the remainder of a skipped
 // test compile-reachable under MSVC's unreachable-code warning.
-#define DMK_REQUIRE_PROXY_FREE_STL()                                                                              \
-    do                                                                                                            \
-    {                                                                                                             \
-        if (!dmk_test::stl_supports_exact_allocation_budgets())                                                   \
-        {                                                                                                         \
-            GTEST_SKIP() << "MSVC debug iterators allocate hidden container proxies; this out-of-memory contract " \
-                            "is proven on the MSVC release STL lane and on libstdc++";                             \
-        }                                                                                                         \
+#define DMK_REQUIRE_PROXY_FREE_STL()                                                                                   \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!dmk_test::stl_supports_exact_allocation_budgets())                                                        \
+        {                                                                                                              \
+            GTEST_SKIP() << "MSVC debug iterators allocate hidden container proxies; this out-of-memory contract "     \
+                            "is proven on the MSVC release STL lane and on libstdc++";                                 \
+        }                                                                                                              \
     } while (false)
 
 #endif // DETOURMODKIT_TEST_ALLOC_PROBE_HPP

--- a/tests/test_event_dispatcher.cpp
+++ b/tests/test_event_dispatcher.cpp
@@ -1159,8 +1159,8 @@ TEST(EventDispatcherProcessProof, MinGWFreshThreadEmitDoesNotAllocateOrTerminate
     args.dispatcher = &dispatcher;
 
     // One allocation-free subscriber: no captures to copy, so nothing but the dispatcher itself can allocate.
-    Subscription sub = dispatcher.subscribe([&args](const SimpleEvent &)
-                                            { args.handler_ran.store(true, std::memory_order_release); });
+    Subscription sub =
+        dispatcher.subscribe([&args](const SimpleEvent &) { args.handler_ran.store(true, std::memory_order_release); });
 
     run_fresh_thread(args);
 

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -805,8 +805,8 @@ TEST_F(InputTest, ScopeAbandonRetainsConsumerCaptureWithoutDestroyingIt)
 
     // Once the engine entry is removed, only the guard's release gate retains the consumer callback. abandon() must
     // keep that gate intact: destroying the callback capture inside DllMain is as unsafe as invoking the callback.
-    const std::size_t leaks_before = DetourModKit::diagnostics::intentional_leak_count(
-        DetourModKit::diagnostics::LeakSubsystem::Input);
+    const std::size_t leaks_before =
+        DetourModKit::diagnostics::intentional_leak_count(DetourModKit::diagnostics::LeakSubsystem::Input);
     scope.abandon();
     EXPECT_EQ(mgr.remove_bindings_by_name("abandon_capture", false), 1u);
     capture.reset();

--- a/tests/test_mid_hook_context.cpp
+++ b/tests/test_mid_hook_context.cpp
@@ -761,9 +761,9 @@ TEST(MidHookCapacityTest, ExhaustionIsTypedAndInstallsNothing)
 
     for (std::size_t i = 0; i < POOL_SITE_COUNT; ++i)
     {
-        Result<Hook> hook = mid_at(MidRequest{.name = "MidPool",
-                                              .target = Address{reinterpret_cast<std::uintptr_t>(POOL_SITES[i])}},
-                                   &inert_detour);
+        Result<Hook> hook =
+            mid_at(MidRequest{.name = "MidPool", .target = Address{reinterpret_cast<std::uintptr_t>(POOL_SITES[i])}},
+                   &inert_detour);
         if (!hook.has_value())
         {
             refusal = hook.error();
@@ -800,9 +800,9 @@ TEST(MidHookCapacityTest, DrainedTeardownRecyclesItsAdapter)
 {
     for (std::size_t i = 0; i < POOL_SITE_COUNT; ++i)
     {
-        Result<Hook> hook = mid_at(MidRequest{.name = "MidRecycle",
-                                              .target = Address{reinterpret_cast<std::uintptr_t>(POOL_SITES[i])}},
-                                   &inert_detour);
+        Result<Hook> hook =
+            mid_at(MidRequest{.name = "MidRecycle", .target = Address{reinterpret_cast<std::uintptr_t>(POOL_SITES[i])}},
+                   &inert_detour);
         ASSERT_TRUE(hook.has_value()) << "install " << i << " failed, so a prior teardown did not recycle its adapter: "
                                       << hook.error().message();
         // Destroyed at end of iteration: tombstone, restore, drain, release.

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -1474,10 +1474,9 @@ TEST_F(SessionLifecycleContext, FailedAttachGateLeavesNoNonBlockingPhasePublishe
     ASSERT_NE(pre_owned, nullptr);
     ASSERT_EQ(GetLastError(), 0u) << "the instance name collided before the test could pre-own it";
 
-    Result<void> started = bootstrap(ModInfo{.name = "CTX_FAILED_ATTACH",
-                                             .log_file = "sess_ctx_failed_attach.log",
-                                             .instance_mutex_prefix = prefix},
-                                     [](Session &) -> Result<void> { return {}; });
+    Result<void> started = bootstrap(
+        ModInfo{.name = "CTX_FAILED_ATTACH", .log_file = "sess_ctx_failed_attach.log", .instance_mutex_prefix = prefix},
+        [](Session &) -> Result<void> { return {}; });
     CloseHandle(pre_owned);
 
     ASSERT_FALSE(started.has_value());
@@ -1507,8 +1506,7 @@ TEST_F(SessionLifecycleContext, BootstrapDefersLoggerAndSessionSetupToTheWorker)
 
     EXPECT_EQ(DetourModKit::detail::lifecycle().state(), DetourModKit::detail::LifecycleState::Starting);
     EXPECT_EQ(DetourModKit::detail::lifecycle().loader_context(), DetourModKit::detail::LoaderContext::Attach);
-    EXPECT_FALSE(std::filesystem::exists(log_path))
-        << "logger/file setup ran in bootstrap instead of the held worker";
+    EXPECT_FALSE(std::filesystem::exists(log_path)) << "logger/file setup ran in bootstrap instead of the held worker";
 
     setup_hold.release();
     ASSERT_TRUE(m_sig.wait_for_ready(kTestTimeout));
@@ -1610,29 +1608,25 @@ TEST_F(SessionLifecycleContext, TheBootstrapWorkerStaysAuthorizedThroughAnUnload
     std::atomic<bool> identity_published{false};
     std::atomic<bool> worker_authorized{false};
 
-    Result<void> started = bootstrap(ModInfo{.name = "CTX_WORKER_AUTH", .log_file = "sess_ctx_worker_auth.log"},
-                                     [&](Session &) -> Result<void>
-                                     {
-                                         // Close the forced-probe seam before releasing the control thread. The
-                                         // override is a plain pointer the seam requires to be set and cleared while
-                                         // no peer thread reads it, and the control thread's shutdown_and_wait() reads
-                                         // it through is_loader_lock_held().
-                                         {
-                                             ForcedLoaderProbe probe{&force_loader_lock_free};
-                                             DetourModKit::detail::lifecycle().set_loader_context(
-                                                 DetourModKit::detail::LoaderContext::LoaderDetach);
-                                             observed_worker_tid.store(static_cast<std::uint32_t>(GetCurrentThreadId()),
-                                                                       std::memory_order_relaxed);
-                                             identity_published.store(
-                                                 DetourModKit::detail::lifecycle().is_worker_thread(),
-                                                 std::memory_order_relaxed);
-                                             worker_authorized.store(
-                                                 DetourModKit::detail::blocking_teardown_permitted(),
-                                                 std::memory_order_relaxed);
-                                         }
-                                         m_sig.signal_ready();
-                                         return {};
-                                     });
+    Result<void> started = bootstrap(
+        ModInfo{.name = "CTX_WORKER_AUTH", .log_file = "sess_ctx_worker_auth.log"},
+        [&](Session &) -> Result<void>
+        {
+            // Close the forced-probe seam before releasing the control thread. The
+            // override is a plain pointer the seam requires to be set and cleared while
+            // no peer thread reads it, and the control thread's shutdown_and_wait() reads
+            // it through is_loader_lock_held().
+            {
+                ForcedLoaderProbe probe{&force_loader_lock_free};
+                DetourModKit::detail::lifecycle().set_loader_context(DetourModKit::detail::LoaderContext::LoaderDetach);
+                observed_worker_tid.store(static_cast<std::uint32_t>(GetCurrentThreadId()), std::memory_order_relaxed);
+                identity_published.store(DetourModKit::detail::lifecycle().is_worker_thread(),
+                                         std::memory_order_relaxed);
+                worker_authorized.store(DetourModKit::detail::blocking_teardown_permitted(), std::memory_order_relaxed);
+            }
+            m_sig.signal_ready();
+            return {};
+        });
     ASSERT_TRUE(started.has_value()) << started.error().message();
     m_bootstrapped = true;
     ASSERT_TRUE(m_sig.wait_for_ready(kTestTimeout));


### PR DESCRIPTION
Resolves the CI failures on the vendored-backend-patch merge (run 30100290520).
