### PR TITLE
fix(input): allocation-free XInput retain-on-timeout on MSVC

### DIFF
--- a/src/internal/input_intercept.cpp
+++ b/src/internal/input_intercept.cpp
@@ -115,10 +115,10 @@ namespace DetourModKit::detail
         HMODULE s_xinput_self_ref{nullptr};
         HMODULE s_xinput_target_ref{nullptr};
 
-        // Reserved storage for hooks a timed-out uninstall must keep mapped rather than destroy. Reserved instead of
-        // heap-allocated at teardown because the failure it covers is precisely the one where an allocation cannot be
-        // made. Never destroyed, and claimed at most once: the claim latches s_xinput_permanent_detour, after which
-        // uninstall() takes the disarm path and install_xinput() never builds new hook objects.
+        // Reserved storage for hooks a timed-out uninstall must keep mapped rather than destroy. Constructing an
+        // InlineHook move target creates a vector container proxy under MSVC's debug STL, so the cell is initialized
+        // before the detour goes live. Timed-out teardown then move-assigns the hooks, reusing the cell's existing
+        // container proxies and mutexes. Never destroyed; populated at most once when the hooks become permanent.
         struct PermanentXInputHooks
         {
             safetyhook::InlineHook primary;
@@ -127,9 +127,38 @@ namespace DetourModKit::detail
             HMODULE target_ref;
         };
         alignas(PermanentXInputHooks) unsigned char s_xinput_permanent_cell[sizeof(PermanentXInputHooks)];
+        bool s_xinput_permanent_cell_ready{false};
 #if defined(DMK_ENABLE_TEST_SEAMS)
         PermanentXInputHooks *s_xinput_permanent_hooks{nullptr};
 #endif
+
+        /**
+         * @brief Returns the reserved cell as a live object.
+         * @return Pointer to the object constructed by ensure_permanent_cell().
+         * @note Requires s_intercept_mutex and a prior successful ensure_permanent_cell().
+         */
+        [[nodiscard]] PermanentXInputHooks *permanent_cell() noexcept
+        {
+            return std::launder(reinterpret_cast<PermanentXInputHooks *>(s_xinput_permanent_cell));
+        }
+
+        /**
+         * @brief Constructs the reserved cell before an XInput detour is published.
+         * @note Requires s_intercept_mutex. MSVC debug-container proxy setup may allocate, so this runs before the
+         *       allocation-free teardown boundary.
+         */
+        void ensure_permanent_cell() noexcept
+        {
+            if (s_xinput_permanent_cell_ready)
+            {
+                return;
+            }
+            ::new (static_cast<void *>(s_xinput_permanent_cell)) PermanentXInputHooks{};
+            s_xinput_permanent_cell_ready = true;
+#if defined(DMK_ENABLE_TEST_SEAMS)
+            s_xinput_permanent_hooks = permanent_cell();
+#endif
+        }
 
         std::atomic<int> s_bound_user_index{0};
         std::atomic<uint16_t> s_suppress_mask{0};
@@ -799,6 +828,10 @@ namespace DetourModKit::detail
             return false;
         }
 
+        // Construct the reserved permanent cell while allocation is permitted. A timed-out teardown can then transfer
+        // the live hooks without move-constructing InlineHook's debug-container proxies.
+        ensure_permanent_cell();
+
         auto allocator = safetyhook::Allocator::global();
         // Create the hook disabled so the trampoline exists before the prologue is
         // patched: publish the original (trampoline) pointer first, then enable.
@@ -1117,8 +1150,8 @@ namespace DetourModKit::detail
         // additionally relocates a thread caught mid-prologue during removal, so this drain shrinks the window rather
         // than being the sole guarantee. Use a short wall-clock bound instead of a yield count: a hot game thread can
         // keep entering the detour after the trampoline pointers are retired, and teardown must still make progress.
-        constexpr uint64_t XINPUT_QUIESCE_TIMEOUT_MS = 10;
-        const uint64_t quiesce_deadline_ms = GetTickCount64() + XINPUT_QUIESCE_TIMEOUT_MS;
+        constexpr uint64_t xinput_quiesce_timeout_ms = 10;
+        const uint64_t quiesce_deadline_ms = GetTickCount64() + xinput_quiesce_timeout_ms;
         while (s_xinput_inflight.load(std::memory_order_seq_cst) != 0 && GetTickCount64() < quiesce_deadline_ms)
         {
             std::this_thread::yield();
@@ -1133,12 +1166,13 @@ namespace DetourModKit::detail
             // still running through. Move them into the reserved cell instead, so their trampolines stay mapped for
             // the rest of the process. Every resource this path needs -- the storage and both module keepalives -- was
             // secured at install time, so it cannot fail here and has no fallback that frees a live trampoline.
-            auto *const permanent = ::new (static_cast<void *>(s_xinput_permanent_cell)) PermanentXInputHooks{
-                std::move(s_xinput_hook), std::move(s_xinput_ex_hook), std::exchange(s_xinput_self_ref, nullptr),
-                std::exchange(s_xinput_target_ref, nullptr)};
-#if defined(DMK_ENABLE_TEST_SEAMS)
-            s_xinput_permanent_hooks = permanent;
-#endif
+            // Move-assign into the cell built at install time. InlineHook's move-assignment reuses the destination's
+            // existing vector proxy and mutex while transferring the allocated original-bytes buffer.
+            PermanentXInputHooks *const permanent = permanent_cell();
+            permanent->primary = std::move(s_xinput_hook);
+            permanent->ex = std::move(s_xinput_ex_hook);
+            permanent->self_ref = std::exchange(s_xinput_self_ref, nullptr);
+            permanent->target_ref = std::exchange(s_xinput_target_ref, nullptr);
 
             // Republish the trampoline pointers so the now-permanent detours forward through the original again.
             // Between the retire stores above and this point -- the 10 ms drain -- the detours are live but read a
@@ -1155,10 +1189,11 @@ namespace DetourModKit::detail
             // The install-time keepalives moved into the same never-destroyed owner as the hooks, so the permanent
             // detour code and the patched module remain mapped together.
             DetourModKit::diagnostics::record_intentional_leak(DetourModKit::diagnostics::LeakSubsystem::Input);
-            (void)log().try_log(LogLevel::Warning,
-                                "XInput interception: {} game thread(s) still inside a detour after a {} ms "
-                                "quiesce; retained the hook trampolines instead of freeing them to stay memory-safe.",
-                                still_inflight, XINPUT_QUIESCE_TIMEOUT_MS);
+            // Avoid formatting on the OOM-critical path and contain every sink failure at this noexcept boundary.
+            (void)log().log_noexcept(LogLevel::Warning,
+                                     "XInput interception: a game thread was still inside a detour at the quiesce "
+                                     "deadline; retained the hook trampolines instead of freeing them to stay "
+                                     "memory-safe.");
             s_xinput_enable_warned.store(false, std::memory_order_relaxed);
             s_xinput_ex_enable_warned.store(false, std::memory_order_relaxed);
             release_owner();

--- a/tests/lifecycle/xinput_detour_rundown.cpp
+++ b/tests/lifecycle/xinput_detour_rundown.cpp
@@ -3,6 +3,8 @@
 
 #include "internal/input_intercept.hpp"
 
+#include "DetourModKit/logger.hpp"
+
 #include <windows.h>
 #include <Xinput.h>
 
@@ -13,22 +15,26 @@
 #include <string_view>
 #include <thread>
 
+#if defined(_MSC_VER)
+#include <crtdbg.h>
+#endif
+
 namespace
 {
-    // When set, every plain (non-aligned) operator new throws. Armed only around uninstall() so the retain-on-timeout
-    // path is proven to need no plain heap allocation.
-    std::atomic<bool> g_poison{false};
+    // Thread id whose plain (non-aligned) operator new must throw, or 0 when disarmed. Armed only around uninstall() on
+    // that thread so unrelated worker allocations do not weaken the caller-thread teardown contract.
+    std::atomic<DWORD> s_poison_thread_id{0};
 } // namespace
 
 void *operator new(std::size_t size)
 {
-    if (g_poison.load(std::memory_order_acquire))
+    if (s_poison_thread_id.load(std::memory_order_acquire) == GetCurrentThreadId())
     {
         throw std::bad_alloc{};
     }
-    if (void *p = std::malloc(size != 0 ? size : 1))
+    if (void *allocation = std::malloc(size != 0 ? size : 1))
     {
-        return p;
+        return allocation;
     }
     throw std::bad_alloc{};
 }
@@ -74,13 +80,13 @@ namespace
     constexpr int SKIP_EXIT_CODE = 77;
 
     // The parked caller signals arrival here and waits for release, so the drain has a genuinely in-flight detour.
-    std::atomic<bool> g_parked{false};
-    std::atomic<bool> g_release{false};
+    std::atomic<bool> s_parked{false};
+    std::atomic<bool> s_release{false};
 
     void park_in_detour() noexcept
     {
-        g_parked.store(true, std::memory_order_release);
-        while (!g_release.load(std::memory_order_acquire))
+        s_parked.store(true, std::memory_order_release);
+        while (!s_release.load(std::memory_order_acquire))
         {
             std::this_thread::yield();
         }
@@ -143,7 +149,7 @@ namespace
                 XINPUT_STATE state{};
                 (void)get_state(0, &state);
             });
-        while (!g_parked.load(std::memory_order_acquire))
+        while (!s_parked.load(std::memory_order_acquire))
         {
             std::this_thread::yield();
         }
@@ -151,14 +157,21 @@ namespace
         // republished trampoline can be exercised below.
         set_xinput_detour_body_seam(nullptr);
 
-        g_poison.store(true, std::memory_order_release);
-        uninstall();
-        g_poison.store(false, std::memory_order_release);
+        // Keep the process-default logger's one-time setup outside the allocation-poison window so this proof isolates
+        // uninstall's retain path.
+        (void)DetourModKit::log();
 
-        // Release and join before any verdict below: the parked caller only ever waits on g_release, so returning
+        // Poison only this thread's plain allocations across uninstall(): the retain-on-timeout path retains the hooks,
+        // trampolines, and keepalives using resources secured at install time, so it takes no plain heap allocation of
+        // its own. Allocations on unrelated threads stay outside this caller-thread contract.
+        s_poison_thread_id.store(GetCurrentThreadId(), std::memory_order_release);
+        uninstall();
+        s_poison_thread_id.store(0, std::memory_order_release);
+
+        // Release and join before any verdict below: the parked caller only ever waits on s_release, so returning
         // while it is still joinable would destroy a running std::thread and terminate the process, replacing every
         // diagnostic exit code after this point with an abort.
-        g_release.store(true, std::memory_order_release);
+        s_release.store(true, std::memory_order_release);
         parked.join();
 
         if (xinput_installed())
@@ -225,8 +238,8 @@ namespace
             return 7;
         }
 
-        constexpr int ROUNDS = 4;
-        for (int round = 0; round < ROUNDS; ++round)
+        constexpr int rounds = 4;
+        for (int round = 0; round < rounds; ++round)
         {
             if (!install_xinput(0))
             {
@@ -263,6 +276,17 @@ int main(int argc, char **argv)
         std::fprintf(stderr, "usage: xinput_detour_rundown <timeout|reference-balance>\n");
         return 1;
     }
+
+#if defined(_MSC_VER)
+    // A raw proof runs headless: nothing dismisses a modal CRT dialog. Route asserts/errors to stderr and make abort()
+    // exit with a status instead of blocking on a message box, so a failure is a fast diagnostic exit, not a hang.
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    SetErrorMode(SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS);
+#endif
 
     const std::string_view selected_case{argv[1]};
     if (selected_case == "timeout")


### PR DESCRIPTION
## Summary

The XInput retain-on-timeout teardown could allocate on MSVC. Moving the live SafetyHook hooks into the reserved cell by move-construction allocated MSVC Debug's vector container proxy, which terminated the `noexcept` teardown under the proof's allocation poison and made `Lifecycle.XInputTimeoutRetainsTrampolinesWithoutAllocating` hang behind a modal abort dialog on headless CI.

The reserved cell is now constructed at install time (while allocation is permitted) and the teardown move-assigns the live hooks into it, reusing the cell's existing container proxies and mutex so the retain path allocates nothing. The retain diagnostic uses the pre-rendered `log_noexcept` tier, and the proof scopes its allocation poison to the teardown thread and suppresses MSVC's modal CRT dialogs so a raw proof never blocks CI.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability when uninstalling while input hooks are still active.
  * Ensured timeout handling can complete safely without introducing additional allocation or logging failures.
  * Preserved hook and module state consistently during delayed teardown.

* **Tests**
  * Strengthened lifecycle coverage for timeout scenarios and allocation isolation.
  * Improved test failure handling so failures report cleanly instead of blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->