### PR TITLE
fix: keep test seams out of shipping archives and build all lifecycle proofs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -479,7 +479,7 @@ jobs:
           --target
           fault_tests dmk_timeout_probe fast_fail_probe hook_static_order logger_first_use_oom
           hook_instance_scope input_gate_abba config_servicer_self_retire input_self_shutdown
-          input_first_use_oom xinput_detour_rundown profiler_late_uaf profiler_first_use_oom
+          input_first_use_oom xinput_detour_rundown xinput_forwarding_guard profiler_late_uaf profiler_first_use_oom
           diagnostics_late_emitter bootstrap_module_ref full_lifecycle
           --parallel 4
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,14 @@ jobs:
           python scripts/check_install_prefix.py "${{ github.workspace }}/install_package/mingw"
         shell: bash
 
+      - name: Assert No Test Seams (MinGW)
+        run: |
+          # A tests-OFF (shipping) archive must export no test seam: an unguarded *_for_test / g_*_override /
+          # g_*_probe symbol leaks a private entry point or mutable hook the export-equality gate cannot see.
+          archive=$(ls "${{ github.workspace }}"/install_package/mingw/lib*/libDetourModKit.a)
+          python scripts/check_no_test_seams.py "$archive"
+        shell: bash
+
       - name: Smoke Test Installed Package (MinGW)
         run: |
           cmake -S tests/package_smoke -B build/package-smoke-mingw -G Ninja \
@@ -366,6 +374,13 @@ jobs:
 
       - name: Assert Install-Prefix Hygiene (MSVC)
         run: python scripts/check_install_prefix.py "${{ github.workspace }}/install_package/msvc"
+        shell: bash
+
+      - name: Assert No Test Seams (MSVC)
+        run: |
+          # A tests-OFF (shipping) archive must export no test seam; dumpbin comes from the MSVC dev environment.
+          archive=$(ls "${{ github.workspace }}"/install_package/msvc/lib*/libDetourModKit.lib)
+          python scripts/check_no_test_seams.py "$archive"
         shell: bash
 
       - name: Smoke Test Installed Package (MSVC)

--- a/scripts/check_no_test_seams.py
+++ b/scripts/check_no_test_seams.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Shipping-archive test-seam hygiene gate.
+
+A test-only seam in a `src/` TU (a `*_for_test` helper, a `g_*_override` injection pointer, a `g_*_probe`
+point) is permitted ONLY when its definition and every reference are gated behind DMK_ENABLE_TEST_SEAMS, so
+a tests-OFF (DMK_BUILD_TESTS=OFF) build compiles none of it. An unguarded seam silently exports a mutable
+hook or a private entry point into every shipped archive; the export-equality gate cannot see it, because a
+tests-ON tree legitimately carries seams.
+
+This gate scans a shipped (tests-OFF) static archive and fails if any defined external symbol names a test
+seam. It reads `.a` archives with `nm` and `.lib` archives with `dumpbin` (falling back to `llvm-nm` for
+either); a pre-captured symbol dump can be passed with --symbols-file so the policy is toolchain-agnostic
+and unit-testable. Exit status is 1 with the offending symbols printed when a seam leaks, else 0.
+"""
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+# A shipped archive must contain none of these. `_for_test` is the naming convention for test-only entry
+# points; `g_*_override` / `g_*_probe` are the injection-pointer and probe seams. Anchored to the `g_` global
+# prefix so ordinary internal helpers such as `resolve_candidate_by_probe` are not false positives.
+SEAM_PATTERNS = (
+    re.compile(r"_for_test\b"),
+    re.compile(r"\bg_[A-Za-z0-9_]*_override\b"),
+    re.compile(r"\bg_[A-Za-z0-9_]*_probe\b"),
+)
+
+
+def find_seam_symbols(symbol_names):
+    """Returns the sorted, de-duplicated subset of @p symbol_names that names a test seam."""
+    hits = set()
+    for name in symbol_names:
+        if any(pattern.search(name) for pattern in SEAM_PATTERNS):
+            hits.add(name.strip())
+    return sorted(hits)
+
+
+def _run(tool_args):
+    return subprocess.run(tool_args, capture_output=True, text=True, check=False)
+
+
+def defined_symbols_from_nm(archive, nm_tool):
+    """Defined external symbols of @p archive via nm, demangled. Raises on tool failure."""
+    result = _run([nm_tool, "-C", "--defined-only", "--extern-only", str(archive)])
+    if result.returncode != 0:
+        raise RuntimeError(f"{nm_tool} failed on {archive}: {result.stderr.strip()}")
+    names = []
+    for line in result.stdout.splitlines():
+        # `<addr> <type> <name>`; with --defined-only --extern-only every remaining line is a defined global.
+        parts = line.split(" ", 2)
+        if len(parts) == 3:
+            names.append(parts[2])
+    return names
+
+
+def defined_symbols_from_dumpbin(archive):
+    """Defined external symbols of a .lib via dumpbin /SYMBOLS. Undecorated names carry the seam token."""
+    result = _run(["dumpbin", "/SYMBOLS", str(archive)])
+    if result.returncode != 0:
+        raise RuntimeError(f"dumpbin failed on {archive}: {result.stderr.strip()}")
+    names = []
+    for line in result.stdout.splitlines():
+        if "External" not in line or "UNDEF" in line:
+            continue
+        # `... External     | ?seed_wheel_notches_for_test@detail@... (public: ...)`; the decorated name
+        # after `|` still contains the literal seam token, which is all the patterns need to match.
+        marker = line.find("|")
+        if marker != -1:
+            names.append(line[marker + 1:].strip())
+    return names
+
+
+def archive_symbols(archive):
+    suffix = archive.suffix.lower()
+    if suffix == ".a":
+        for tool in ("nm", "llvm-nm"):
+            if shutil.which(tool):
+                return defined_symbols_from_nm(archive, tool)
+        raise RuntimeError("no nm/llvm-nm on PATH to read a .a archive")
+    if suffix == ".lib":
+        if shutil.which("dumpbin"):
+            return defined_symbols_from_dumpbin(archive)
+        if shutil.which("llvm-nm"):
+            return defined_symbols_from_nm(archive, "llvm-nm")
+        raise RuntimeError("no dumpbin/llvm-nm on PATH to read a .lib archive")
+    raise RuntimeError(f"unsupported archive type: {archive}")
+
+
+def main(argv):
+    args = argv[1:]
+    symbols_file = None
+    positional = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--symbols-file":
+            symbols_file = args[i + 1]
+            i += 2
+        else:
+            positional.append(args[i])
+            i += 1
+
+    if symbols_file is not None:
+        names = Path(symbols_file).read_text(encoding="utf-8", errors="replace").splitlines()
+    elif len(positional) == 1:
+        archive = Path(positional[0]).resolve()
+        if not archive.is_file():
+            print(f"test-seam gate FAILED: archive '{archive}' does not exist")
+            return 1
+        try:
+            names = archive_symbols(archive)
+        except RuntimeError as error:
+            print(f"test-seam gate could not read the archive: {error}")
+            return 2
+    else:
+        print("usage: check_no_test_seams.py <shipped-archive.a|.lib> | --symbols-file <dump>")
+        return 2
+
+    seams = find_seam_symbols(names)
+    if seams:
+        print("Test-seam hygiene gate FAILED: the shipped (tests-OFF) archive exports test seams:\n")
+        for seam in seams:
+            print("  " + seam)
+        print(f"\n{len(seams)} leaked seam(s): gate each behind #if defined(DMK_ENABLE_TEST_SEAMS).")
+        return 1
+    print("Test-seam hygiene gate passed: the shipped archive exports no test seam.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/test_check_no_test_seams.py
+++ b/scripts/test_check_no_test_seams.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Self-test for check_no_test_seams.py: the gate must flag every seam-naming shape and pass clean archives.
+
+Covers the policy core (find_seam_symbols) for the *_for_test convention, g_*_override / g_*_probe injection
+globals, the MSVC-decorated form of a seam, and the resolve_candidate_by_probe non-seam that must NOT trip
+the g_*_probe anchor; plus the end-to-end --symbols-file path for both a leaking and a clean dump.
+"""
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+from contextlib import redirect_stdout
+
+_SCRIPT = pathlib.Path(__file__).with_name("check_no_test_seams.py")
+_spec = importlib.util.spec_from_file_location("check_no_test_seams", _SCRIPT)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+
+def _expect(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def _run_symbols_file(lines):
+    with tempfile.TemporaryDirectory() as tmp:
+        dump = pathlib.Path(tmp) / "syms.txt"
+        dump.write_text("\n".join(lines), encoding="utf-8")
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = _module.main(["check_no_test_seams.py", "--symbols-file", str(dump)])
+        return code, out.getvalue()
+
+
+def _test_policy_core():
+    seams = _module.find_seam_symbols([
+        "DetourModKit::detail::seed_wheel_notches_for_test(std::array<int, 4ull> const&)",
+        "DetourModKit::detail::request_servicer_reload_for_test()",
+        "g_rtti_resolve_clock_override",
+        "g_mid_adapter_precommit_probe",
+        "?bootstrap_shutdown_event_for_test@detail@DetourModKit@@YAPEAX_test@@XZ",  # MSVC-decorated
+    ])
+    _expect(len(seams) == 5, f"expected all 5 seams flagged, got {seams}")
+
+    clean = _module.find_seam_symbols([
+        "DetourModKit::detail::take_wheel_counts()",
+        "DetourModKit::detail::publish_wheel_consume(unsigned char)",
+        "DetourModKit::scan::(anonymous namespace)::resolve_candidate_by_probe(...)",  # not a g_* probe
+        "DetourModKit::hook::install(...)",
+    ])
+    _expect(clean == [], f"non-seam symbols must not trip the gate, got {clean}")
+
+
+def _test_symbols_file():
+    code, out = _run_symbols_file([
+        "0000000000000000 T DetourModKit::detail::seed_wheel_notches_for_test(std::array<int, 4ull> const&)",
+        "0000000000000000 T DetourModKit::hook::install(void*)",
+    ])
+    _expect(code == 1, "a dump containing a seam must exit 1")
+    _expect("seed_wheel_notches_for_test" in out, "the offending seam must be printed")
+
+    code, out = _run_symbols_file([
+        "0000000000000000 T DetourModKit::detail::take_wheel_counts()",
+        "0000000000000000 T DetourModKit::detail::publish_wheel_consume(unsigned char)",
+    ])
+    _expect(code == 0, "a clean dump must exit 0")
+    _expect("passed" in out, "a clean dump must report a pass")
+
+
+def main():
+    failures = []
+    for test in (_test_policy_core, _test_symbols_file):
+        try:
+            test()
+        except AssertionError as error:
+            failures.append(f"{test.__name__}: {error}")
+    if failures:
+        print("check_no_test_seams self-test FAILED:")
+        for failure in failures:
+            print("  " + failure)
+        return 1
+    print("check_no_test_seams self-test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/internal/input_intercept.cpp
+++ b/src/internal/input_intercept.cpp
@@ -1036,6 +1036,7 @@ namespace DetourModKit::detail
         return out;
     }
 
+#if defined(DMK_ENABLE_TEST_SEAMS)
     void seed_wheel_notches_for_test(const std::array<int, 4> &notches) noexcept
     {
         for (size_t dir = 0; dir < s_wheel_count.size(); ++dir)
@@ -1054,6 +1055,7 @@ namespace DetourModKit::detail
             s_wheel_count[dir].store(n, std::memory_order_relaxed);
         }
     }
+#endif
 
     void publish_wheel_consume(uint8_t direction_mask) noexcept
     {

--- a/src/internal/input_intercept.hpp
+++ b/src/internal/input_intercept.hpp
@@ -314,15 +314,17 @@ namespace DetourModKit::detail
      */
     [[nodiscard]] std::array<int, 4> take_wheel_counts() noexcept;
 
+#if defined(DMK_ENABLE_TEST_SEAMS)
     /**
      * @brief Test-only: stages a wheel-notch backlog as if the WndProc detour had latched @p notches.
      * @details The detour increments the counters only from a real WM_MOUSEWHEEL / WM_MOUSEHWHEEL, which the unit suite
      *          cannot deliver without a live window. This seam lets a white-box test stand up the exact stale-backlog
      *          state that the poll loop's drain and recompute's no-wheel -> wheel discard exist to handle, so those
      *          paths are exercised deterministically. Each slot saturates at MAX_WHEEL_NOTCHES, matching the detour's
-     *          write site. Not part of the shipping surface (this header is never installed).
+     *          write site. Compiled out of shipping archives.
      */
     void seed_wheel_notches_for_test(const std::array<int, 4> &notches) noexcept;
+#endif
 
     /**
      * @brief Publishes the set of wheel directions the WndProc detour should swallow this cycle.


### PR DESCRIPTION
## Summary

- A test-only seam (`seed_wheel_notches_for_test`) was leaking into shipping (`DMK_BUILD_TESTS=OFF`) archives because it sat outside the `DMK_ENABLE_TEST_SEAMS` guard. It is now gated, and a new `scripts/check_no_test_seams.py` (with self-test, wired into `release.yml` for both the MinGW and MSVC shipping prefixes) fails the release if any test seam reaches a shipped archive.
- Separately, the `pr-check` GTest-route jobs were missing `xinput_forwarding_guard` from their proof-target build, so the two FN-48 forwarding proofs failed as "could not find executable"; that target is now built alongside the rest.


